### PR TITLE
remove x86_64-apple-ios from rustup targets. No iOs device is using Intel CPUs anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ source $HOME/.cargo/env
 
 # Add iOS targets for cross-compilation
 rustup target add aarch64-apple-ios
-rustup target add x86_64-apple-ios
 rustup target add aarch64-apple-ios-sim
 ```
 


### PR DESCRIPTION
…ntel CPUs