### PR TITLE
Improve app orientation and node status display

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:screenOrientation="portrait">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -50,5 +50,15 @@
         <string>be.tramckrijte.workmanager.slot_monitoring_task</string>
         <string>com.usernode.app.slotmonitoring</string>
     </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    </array>
 </dict>
 </plist>

--- a/lib/features/node/data/repositories/node_repository_impl.dart
+++ b/lib/features/node/data/repositories/node_repository_impl.dart
@@ -70,6 +70,8 @@ class NodeRepositoryImpl implements NodeRepository {
         networkBestHeight: networkBest?.height,
         epoch: display?.epoch,
         globalSlot: display?.globalSlot,
+        currentEpoch: s.node.curEpoch,
+        currentGlobalSlot: s.node.curGlobalSlot,
         bestTipHash: bestTipHash,
       ));
     } catch (e) {

--- a/lib/features/node/domain/entities/node_status.dart
+++ b/lib/features/node/domain/entities/node_status.dart
@@ -7,6 +7,8 @@ class NodeStatus {
   final int? networkBestHeight;
   final int? epoch;
   final int? globalSlot;
+  final int? currentEpoch;
+  final int? currentGlobalSlot;
   final String? bestTipHash;
   final String? peerId;
 
@@ -17,6 +19,8 @@ class NodeStatus {
     required this.networkBestHeight,
     required this.epoch,
     required this.globalSlot,
+    required this.currentEpoch,
+    required this.currentGlobalSlot,
     required this.bestTipHash,
     this.peerId,
   });

--- a/lib/features/node/presentation/controllers/node_raw_status_provider.dart
+++ b/lib/features/node/presentation/controllers/node_raw_status_provider.dart
@@ -42,6 +42,9 @@ class NodeRawStatusView {
   int? get epoch => (networkBest ?? localBest)?.epoch;
   int? get globalSlot => (networkBest ?? localBest)?.globalSlot;
 
+  /// Current epoch from backend (node's clock-based epoch)
+  int? get currentEpoch => node.curEpoch;
+
   /// Current global slot from backend (node's clock-based slot)
   int? get currentGlobalSlot => node.curGlobalSlot;
 

--- a/lib/features/node/presentation/controllers/node_status_provider.dart
+++ b/lib/features/node/presentation/controllers/node_status_provider.dart
@@ -22,6 +22,8 @@ final nodeStatusProvider = Provider<AsyncValue<NodeStatus?>>((ref) {
         networkBestHeight: raw.networkBestHeight,
         epoch: raw.epoch,
         globalSlot: raw.globalSlot,
+        currentEpoch: raw.currentEpoch,
+        currentGlobalSlot: raw.currentGlobalSlot,
         bestTipHash: raw.bestTipHash,
         peerId: peerId,
       ));

--- a/lib/features/node/presentation/screens/node_status_screen.dart
+++ b/lib/features/node/presentation/screens/node_status_screen.dart
@@ -240,7 +240,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
     final shortened = _shortenMid(peerId);
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      padding: const EdgeInsets.all(0),
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(8),
@@ -249,37 +249,37 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
         children: [
           Icon(
             Icons.fingerprint,
-            size: 18,
+            size: 16,
             color: colorScheme.primary,
           ),
           const SizedBox(width: 8),
           Text(
-            'Node ID: ',
-            style: theme.textTheme.bodyMedium?.copyWith(
+            'Peer ID: ',
+            style: theme.textTheme.bodySmall?.copyWith(
               color: colorScheme.onSurfaceVariant,
             ),
           ),
           Expanded(
             child: Text(
               shortened,
-              style: theme.textTheme.bodyMedium?.copyWith(
+              style: theme.textTheme.bodySmall?.copyWith(
                 fontFamily: 'monospace',
                 color: colorScheme.onSurface,
               ),
             ),
           ),
           IconButton(
-            icon: const Icon(Icons.copy, size: 18),
+            icon: const Icon(Icons.copy, size: 16),
             onPressed: () {
               Clipboard.setData(ClipboardData(text: peerId));
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(
-                  content: Text('Node ID copied to clipboard'),
+                  content: Text('Peer ID copied to clipboard'),
                   duration: Duration(seconds: 2),
                 ),
               );
             },
-            tooltip: 'Copy full Node ID',
+            tooltip: 'Copy full Peer ID',
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(),
           ),
@@ -364,6 +364,12 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
       children: [
         _buildSectionHeader(context, 'Overview'),
         const SizedBox(height: 12),
+
+        // Peer ID row
+        if (statusFromProvider?.peerId != null) ...[
+          _buildNodeIdRow(context, statusFromProvider!.peerId!),
+          const SizedBox(height: 12),
+        ],
 
         // Status line
         Row(
@@ -475,21 +481,16 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
               child: _buildCompactInfoCard(
                 context,
                 icon: Icons.access_time,
-                label: 'Epoch',
-                value: '${statusFromProvider?.epoch ?? _bestTipEpoch ?? 'N/A'}',
-                subtitle: 'Slot ${statusFromProvider?.globalSlot ?? _bestTipGlobalSlot ?? 'N/A'}',
+                label: 'Cur. Epoch',
+                value: '${statusFromProvider?.currentEpoch ?? 'N/A'}',
+                subtitle:
+                    'Cur. Slot ${statusFromProvider?.currentGlobalSlot ?? 'N/A'}',
                 color: colorScheme.primary,
                 colorScheme: colorScheme,
               ),
             ),
           ],
         ),
-
-        // Node ID (peer ID) row
-        if (statusFromProvider?.peerId != null) ...[
-          const SizedBox(height: 12),
-          _buildNodeIdRow(context, statusFromProvider!.peerId!),
-        ],
 
         // Horizontal divider before Produced blocks and Won slots
         Padding(
@@ -525,16 +526,29 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
             return Row(
               children: [
                 Expanded(
-                  child: _buildCompactInfoCard(
+                  child: _buildMultiLineInfoCard(
                     context,
-                    icon: Icons.check_circle_outline,
-                    label: 'Produced',
-                    value:
-                        '', // Value shown only in subtitle to avoid repetition
-                    subtitle: produced == 1 ? '1 block' : '$produced blocks',
-                    color: colorScheme.tertiary, // Match Peers icon color
+                    icon: Icons.analytics,
+                    label: 'VRF',
+                    lines: () {
+                      // Display VRF status directly from provider
+                      final vrfStatus = vrfEvaluator?.currentEpochVrfEvaluationStatus;
+                      final statusText = switch (vrfStatus) {
+                        RpcStatusVrfEvaluationStatus.pending => 'Pending',
+                        RpcStatusVrfEvaluationStatus.evaluating => 'Evaluating',
+                        RpcStatusVrfEvaluationStatus.completed => 'Completed',
+                        _ => 'N/A',
+                      };
+
+                      return [
+                        'Status: $statusText',
+                        'Total: ${NumberFormat('#,###').format(totalSlotsPerEpoch)}',
+                        'Evaluated: ${NumberFormat('#,###').format(evaluatedSlots)}',
+                        'Won: ${NumberFormat('#,###').format(wonSlots)}',
+                      ];
+                    }(),
+                    color: colorScheme.tertiary,
                     colorScheme: colorScheme,
-                    onTap: () => context.push('/main/node/produced-blocks'),
                     useGradient: false,
                   ),
                 ),
@@ -543,11 +557,11 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
                   child: _buildMultiLineInfoCard(
                     context,
                     icon: Icons.emoji_events,
-                    label: 'Slots',
+                    label: 'Slots/Blocks',
                     lines: [
                       'Total: ${NumberFormat('#,###').format(totalSlotsPerEpoch)}',
-                      'Evaluated: ${NumberFormat('#,###').format(evaluatedSlots)}',
                       'Won: ${NumberFormat('#,###').format(wonSlots)}',
+                      'Produced: ${NumberFormat('#,###').format(produced)}',
                     ],
                     color: const Color(0xFFF9A825),
                     colorScheme: colorScheme,
@@ -584,18 +598,18 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
 
                   final height = displayBestTip.height;
                   final hash = displayBestTip.hash.toString();
-                  final producer = displayBestTip.producerPubkey;
+                  final epoch = raw?.epoch ?? _bestTipEpoch;
+                  final slot = raw?.globalSlot ?? _bestTipGlobalSlot;
 
                   final formattedHeight =
                       'Height ${NumberFormat('#,###').format(height)}';
+                  final epochText = 'Epoch ${epoch ?? 'N/A'}';
+                  final slotText = 'Slot ${slot ?? 'N/A'}';
                   final truncatedHash = hash.length > 16
                       ? '${hash.substring(0, 8)}...${hash.substring(hash.length - 8)}'
                       : hash;
-                  final truncatedProducer = producer.length > 16
-                      ? '${producer.substring(0, 6)}...${producer.substring(producer.length - 4)}'
-                      : producer;
 
-                  return [formattedHeight, truncatedHash, truncatedProducer];
+                  return [formattedHeight, epochText, slotText, truncatedHash];
                 }(),
                 color: colorScheme.tertiary,
                 colorScheme: colorScheme,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
@@ -21,6 +22,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Lock orientation to portrait mode
+  await SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
+  ]);
 
   final log = LoggingService();
   await SentryUtil.bootstrap(() async {


### PR DESCRIPTION
- Lock app to portrait orientation on Android and iOS
- Reorganize node status screen: move Peer ID to top
- Update epoch/slot labels to "Current Epoch/Slot" with accurate values
- Modify Best Tip card to show Height/Epoch/Slot/Hash
- Replace Produced blocks card with VRF evaluation metrics
- Combine Slots and Blocks data into unified Slots/Blocks card
- Simplify VRF status to display provider values directly