### PR TITLE
Add private key and demo account import options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,39 @@ SENTRY_DSN=
 GITHUB_TOKEN=
 
 # =============================================================================
+# DEMO ACCOUNTS
+# =============================================================================
+# JSON object containing demo accounts with full metadata for development/testing
+# Each account includes: secret_key_hex, public_key_hex, public_key_hash_bech32m, amount, tier
+# When importing, the app validates that keys derived from secret_key_hex match the provided values
+# Amount is in base units (1 UT = 1,000,000 base units)
+# Tier determines UI display: "foundation" (👑), "whale" (🐋), "fish" (🐟)
+# Format: {"accounts":[{...account1...},{...account2...},...]}
+# Leave as empty accounts array to disable demo accounts feature
+# Default: {"accounts":[]} (empty - no demo accounts)
+#
+# Example with 2 accounts (minify for actual use):
+# {
+#   "accounts": [
+#     {
+#       "secret_key_hex": "0000000000000000000000000000000000000000000000000000000000000001",
+#       "public_key_hex": "0000000000000000000000000000000000000000000000000000000000000000",
+#       "public_key_hash_bech32m": "un1qfwwqxgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpc2yxp",
+#       "amount": 4000000000000,
+#       "tier": "foundation"
+#     },
+#     {
+#       "secret_key_hex": "0000000000000000000000000000000000000000000000000000000000000002",
+#       "public_key_hex": "0000000000000000000000000000000000000000000000000000000000000001",
+#       "public_key_hash_bech32m": "un1qfwwqxgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9p93cd",
+#       "amount": 200000000000,
+#       "tier": "whale"
+#     }
+#   ]
+# }
+DEMO_ACCOUNTS_JSON={"accounts":[]}
+
+# =============================================================================
 # FEATURE FLAGS
 # =============================================================================
 # Enable result-based providers (true/false)

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -107,6 +107,7 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.PROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.PROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.PROD_METRICS_INTERVAL }}
+          DEMO_ACCOUNT_PRIVATE_KEYS=${{ secrets.PROD_DEMO_ACCOUNT_PRIVATE_KEYS }}
           EOF
           else
             cat > .env << EOF
@@ -122,6 +123,7 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.NONPROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.NONPROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.NONPROD_METRICS_INTERVAL }}
+          DEMO_ACCOUNT_PRIVATE_KEYS=${{ secrets.NONPROD_DEMO_ACCOUNT_PRIVATE_KEYS }}
           EOF
           fi
           echo "✅ Created .env file with ${{ steps.env_config.outputs.env_type }} secrets"

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class AppConfig {
   final String environment;
   final bool verboseLogging;
@@ -51,4 +53,48 @@ class AppConfig {
       Duration(seconds: blockProductionWakeBeforeSlotSeconds);
   static Duration get epochMonitorBaseInterval =>
       Duration(seconds: epochMonitorBaseIntervalSeconds);
+
+  // Demo accounts configuration (JSON object with account metadata)
+  static const String _demoAccountsJson =
+      String.fromEnvironment('DEMO_ACCOUNTS_JSON', defaultValue: '{"accounts":[]}');
+
+  static List<DemoAccount> get demoAccounts {
+    try {
+      final decoded = jsonDecode(_demoAccountsJson);
+      if (decoded is Map && decoded['accounts'] is List) {
+        final accounts = decoded['accounts'] as List;
+        return accounts.map((acc) => DemoAccount.fromJson(acc as Map<String, dynamic>)).toList();
+      }
+      return [];
+    } catch (e) {
+      return [];
+    }
+  }
+}
+
+/// Demo account model with metadata
+class DemoAccount {
+  final String secretKeyHex;
+  final String publicKeyHex;
+  final String publicKeyHashBech32m;
+  final int amount;
+  final String tier;
+
+  DemoAccount({
+    required this.secretKeyHex,
+    required this.publicKeyHex,
+    required this.publicKeyHashBech32m,
+    required this.amount,
+    required this.tier,
+  });
+
+  factory DemoAccount.fromJson(Map<String, dynamic> json) {
+    return DemoAccount(
+      secretKeyHex: json['secret_key_hex'] as String,
+      publicKeyHex: json['public_key_hex'] as String,
+      publicKeyHashBech32m: json['public_key_hash_bech32m'] as String,
+      amount: json['amount'] as int,
+      tier: json['tier'] as String,
+    );
+  }
 }

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -6,6 +6,8 @@ import 'package:crypto_mobile_app/features/splash/presentation/screens/splash_sc
 import 'package:crypto_mobile_app/features/onboarding/presentation/screens/account_mode_selection_screen.dart';
 import 'package:crypto_mobile_app/features/onboarding/presentation/screens/create_new_account_screen.dart';
 import 'package:crypto_mobile_app/features/onboarding/presentation/screens/import_seed_phrase_screen.dart';
+import 'package:crypto_mobile_app/features/onboarding/presentation/screens/import_private_key_screen.dart';
+import 'package:crypto_mobile_app/features/onboarding/presentation/screens/use_demo_accounts_screen.dart';
 import 'package:crypto_mobile_app/features/onboarding/presentation/screens/identity_verification_screen.dart';
 import 'package:crypto_mobile_app/core/main_app.dart';
 import 'package:crypto_mobile_app/features/home/presentation/screens/home_screen.dart';
@@ -92,6 +94,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/import-seed-phrase',
         builder: (context, state) => const ImportSeedPhraseScreen(),
+      ),
+      GoRoute(
+        path: '/import-private-key',
+        builder: (context, state) => const ImportPrivateKeyScreen(),
+      ),
+      GoRoute(
+        path: '/use-demo-accounts',
+        builder: (context, state) => const UseDemoAccountsScreen(),
       ),
       GoRoute(
         path: '/identity-verification',
@@ -234,6 +244,8 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         if (currentLocation == AppRoutes.onboarding ||
             currentLocation == '/create-new-account' ||
             currentLocation == '/import-seed-phrase' ||
+            currentLocation == '/import-private-key' ||
+            currentLocation == '/use-demo-accounts' ||
             currentLocation == '/identity-verification') {
           LoggingService.instance
               .debug('Allowing onboarding route', tag: 'ROUTER');
@@ -251,7 +263,9 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       // Allow identity verification and account setup during onboarding flow
       if (currentLocation == '/identity-verification' ||
           currentLocation == '/create-new-account' ||
-          currentLocation == '/import-seed-phrase') {
+          currentLocation == '/import-seed-phrase' ||
+          currentLocation == '/import-private-key' ||
+          currentLocation == '/use-demo-accounts') {
         LoggingService.instance
             .debug('Allowing onboarding flow route', tag: 'ROUTER');
         return null;

--- a/lib/features/node/data/repositories/rust_backend_service.dart
+++ b/lib/features/node/data/repositories/rust_backend_service.dart
@@ -16,6 +16,7 @@ import 'package:crypto_mobile_app/src/rust/node.dart';
 import 'package:crypto_mobile_app/src/rust/node/builder.dart';
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
 import 'package:crypto_mobile_app/core/models/backend_rpc_response.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 /// A small façade around flutter_rust_bridge generated APIs.
 /// Centralizes initialization and access to the Rust node / RPC.
@@ -69,11 +70,25 @@ class RustBackendService {
 
   /// Build and start the Rust node, then expose an RPC client.
   /// Safe to call multiple times; subsequent calls are no-ops.
-  Future<void> startNode({int? httpPort}) async {
+  Future<void> startNode({int? httpPort, String? privateKeyHex}) async {
     if (!_initialized) {
       await init();
     }
     if (_nodeRunning) return;
+
+    // Validate private key is provided
+    if (privateKeyHex == null || privateKeyHex.isEmpty) {
+      LoggingService.instance.error(
+        'Cannot start node: private key not provided',
+        tag: 'RUST'
+      );
+      await SentryUtil.captureMessage(
+        'Node start failed: missing private key',
+        level: SentryLevel.error,
+      );
+      throw ArgumentError('Private key required to start node');
+    }
+
     LoggingService.instance.trace(
         'Starting node${httpPort != null ? ' on $httpPort' : ''}',
         tag: 'RUST');
@@ -88,9 +103,12 @@ class RustBackendService {
       builder.httpServer(port: httpPort);
     }
 
-    builder.blockProducerHex(
-        skHex:
-            "f065204f7232abb3adc4621e2d92d401c91a0f3ad77905426efb8fcbc44ce29c");
+    // SECURITY: Do NOT log the actual key value, only its length
+    LoggingService.instance.trace(
+      'Configuring block producer with user private key (length: ${privateKeyHex.length})',
+      tag: 'RUST'
+    );
+    builder.blockProducerHex(skHex: privateKeyHex);
     builder.mempoolAutoinsertInterval(secs: BigInt.from(1));
 
     _node = builder.build();
@@ -107,6 +125,8 @@ class RustBackendService {
     // Run the node in a background thread.
     _node!.runForeverInNewThread();
     _nodeRunning = true;
+
+    LoggingService.instance.info('Node started with user account block producer', tag: 'RUST');
   }
 
   Future<void> stopNode() async {
@@ -137,8 +157,41 @@ class RustBackendService {
           category: 'backend', message: 'no accounts; skipping start');
       return false;
     }
-    LoggingService.instance
-        .debug('Account exists - proceeding with node start', tag: 'RUST');
+
+    // Retrieve active account
+    LoggingService.instance.debug('Retrieving active account...', tag: 'RUST');
+    final account = await repo.getActive();
+
+    if (account == null) {
+      LoggingService.instance.error('Failed to retrieve active account', tag: 'RUST');
+      await SentryUtil.captureMessage(
+        'Node start failed: no active account found',
+        level: SentryLevel.warning,
+      );
+      return false;
+    }
+
+    LoggingService.instance.debug('Active account: ${account.id} (${account.name})', tag: 'RUST');
+
+    // Get private key for active account
+    LoggingService.instance.trace('Retrieving private key for account ${account.id}...', tag: 'RUST');
+    final privateKey = await repo.getPrivateKey(account.id);
+
+    if (privateKey == null || privateKey.isEmpty) {
+      LoggingService.instance.error(
+        'Cannot start node: private key unavailable for account ${account.id}',
+        tag: 'RUST'
+      );
+      await SentryUtil.captureMessage(
+        'Node start failed: private key unavailable',
+        level: SentryLevel.error,
+      );
+      return false;
+    }
+
+    // SECURITY: Only log key length, not value
+    LoggingService.instance.trace('Private key retrieved (length: ${privateKey.length})', tag: 'RUST');
+
     if (!_initialized) {
       await init();
     }
@@ -146,10 +199,23 @@ class RustBackendService {
       LoggingService.instance.trace('Node already running', tag: 'RUST');
       return true;
     }
-    await startNode();
-    LoggingService.instance.trace('startForActiveAccount done', tag: 'RUST');
-    await SentryUtil.captureMessage('Backend started for active account');
-    return true;
+
+    // Start node with user's private key
+    try {
+      await startNode(privateKeyHex: privateKey);
+      LoggingService.instance.trace('startForActiveAccount done', tag: 'RUST');
+      await SentryUtil.captureMessage('Backend started for active account ${account.id}');
+      return true;
+    } catch (e, st) {
+      LoggingService.instance.error(
+        'Failed to start node with account ${account.id}',
+        tag: 'RUST',
+        error: e,
+        stackTrace: st
+      );
+      await SentryUtil.captureError(e, st, tag: 'startNode');
+      return false;
+    }
   }
 
   /// Restart node using current active account context.

--- a/lib/features/onboarding/presentation/screens/account_mode_selection_screen.dart
+++ b/lib/features/onboarding/presentation/screens/account_mode_selection_screen.dart
@@ -33,7 +33,7 @@ class _AccountModeSelectionScreenState
 
       // Navigate using GoRouter with mnemonic as URL parameter
       final encodedMnemonic = Uri.encodeComponent(mnemonic);
-      context.go('/create-new-account?mnemonic=$encodedMnemonic');
+      context.push('/create-new-account?mnemonic=$encodedMnemonic');
     } catch (e) {
       if (!mounted) return;
       setState(() => _generatingMnemonic = false);
@@ -44,7 +44,15 @@ class _AccountModeSelectionScreenState
   }
 
   void _navigateToImportSeed() {
-    context.go('/import-seed-phrase');
+    context.push('/import-seed-phrase');
+  }
+
+  void _navigateToImportPrivateKey() {
+    context.push('/import-private-key');
+  }
+
+  void _navigateToDemoAccounts() {
+    context.push('/use-demo-accounts');
   }
 
   @override
@@ -100,6 +108,22 @@ class _AccountModeSelectionScreenState
                   subtitle:
                       'Restore your wallet using your existing 12-word recovery phrase.',
                   onTap: _navigateToImportSeed,
+                ),
+                const SizedBox(height: 12),
+                _ModeCard(
+                  icon: Icons.vpn_key,
+                  title: 'Import from Private Key',
+                  subtitle:
+                      'Import your account using a hex-encoded private key.',
+                  onTap: _navigateToImportPrivateKey,
+                ),
+                const SizedBox(height: 12),
+                _ModeCard(
+                  icon: Icons.science_outlined,
+                  title: 'Use Demo Account',
+                  subtitle:
+                      'Quickly set up a pre-configured account for testing purposes.',
+                  onTap: _navigateToDemoAccounts,
                 ),
               ],
             ),

--- a/lib/features/onboarding/presentation/screens/import_private_key_screen.dart
+++ b/lib/features/onboarding/presentation/screens/import_private_key_screen.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:crypto_mobile_app/core/widgets/app_bar.dart';
+import 'package:crypto_mobile_app/features/wallet/data/repositories/accounts_repository.dart';
+import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/src/rust/account.dart';
+import 'package:crypto_mobile_app/features/node/data/repositories/rust_backend_service.dart';
+
+class ImportPrivateKeyScreen extends ConsumerStatefulWidget {
+  const ImportPrivateKeyScreen({super.key});
+
+  @override
+  ConsumerState<ImportPrivateKeyScreen> createState() =>
+      _ImportPrivateKeyScreenState();
+}
+
+class _ImportPrivateKeyScreenState
+    extends ConsumerState<ImportPrivateKeyScreen> {
+  final _keyCtrl = TextEditingController();
+  String? _keyError;
+  bool _keyValid = false;
+  bool _processing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _keyCtrl.addListener(_validateKey);
+  }
+
+  @override
+  void dispose() {
+    _keyCtrl.removeListener(_validateKey);
+    _keyCtrl.dispose();
+    super.dispose();
+  }
+
+  void _validateKey() {
+    final key = _normalizeHex(_keyCtrl.text);
+    bool valid = false;
+    String? error;
+
+    if (key.isNotEmpty) {
+      // Check hex format and length (64 chars = 32 bytes, or 66 with 0x prefix)
+      final hexPattern = RegExp(r'^(0x)?[0-9a-fA-F]{64}$');
+      if (!hexPattern.hasMatch(key)) {
+        error =
+            'Invalid format: Must be 64 hex characters (with optional 0x prefix)';
+      } else {
+        // Validate by attempting to derive account from private key using Rust backend
+        try {
+          accountFromPrivateKey(privateKeyHex: key);
+          valid = true;
+        } catch (e) {
+          error = 'Invalid private key';
+        }
+      }
+    }
+
+    setState(() {
+      _keyValid = valid;
+      _keyError = error;
+    });
+  }
+
+  String _normalizeHex(String input) {
+    return input.trim();
+  }
+
+  Future<void> _pasteFromClipboard() async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    if (data?.text != null) {
+      _keyCtrl.text = data!.text!;
+    }
+  }
+
+  Future<void> _importAccount() async {
+    if (!_keyValid || _processing) return;
+
+    setState(() => _processing = true);
+
+    try {
+      final repo = await AccountsRepository.create();
+      final result = await repo.importFromPrivateKey(
+        name: 'Imported Account',
+        privateKeyHex: _normalizeHex(_keyCtrl.text),
+      );
+
+      if (!mounted) return;
+
+      // Check if import succeeded
+      if (result == null) {
+        setState(() => _processing = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+              content: Text('Failed to import account: Invalid private key')),
+        );
+        return;
+      }
+
+      LoggingService.instance.debug('Import successful, starting backend',
+          tag: 'IMPORT_PRIVATE_KEY');
+
+      // Start backend for new account
+      try {
+        await RustBackendService.instance.startForActiveAccount();
+        LoggingService.instance
+            .debug('Backend started successfully', tag: 'IMPORT_PRIVATE_KEY');
+      } catch (e) {
+        LoggingService.instance.error('Failed to start backend',
+            tag: 'IMPORT_PRIVATE_KEY', error: e);
+      }
+
+      // Navigate to identity verification screen
+      if (!mounted) return;
+      context.go('/identity-verification?accountId=${result.id}');
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _processing = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to import account: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: const AppAppBar(
+        title: 'Import from Private Key',
+        showNodeStatus: false,
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Enter your private key (hex format) to import your account.',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.warning_amber_rounded,
+                          size: 16,
+                          color: theme.colorScheme.error,
+                        ),
+                        const SizedBox(width: 4),
+                        Expanded(
+                          child: Text(
+                            'Never share your private key with anyone!',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.error,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _keyCtrl,
+                decoration: InputDecoration(
+                  labelText: 'Private Key (Hex)',
+                  hintText: '0x... or 64 hex characters',
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.vpn_key),
+                  suffixIcon: IconButton(
+                    icon: const Icon(Icons.paste),
+                    onPressed: _pasteFromClipboard,
+                    tooltip: 'Paste',
+                  ),
+                  errorText: _keyError,
+                ),
+                textInputAction: TextInputAction.done,
+                autofocus: true,
+                obscureText: true,
+                enableSuggestions: false,
+                autocorrect: false,
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed:
+                      (_keyValid && !_processing) ? _importAccount : null,
+                  child: _processing
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Import Account'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/screens/use_demo_accounts_screen.dart
+++ b/lib/features/onboarding/presentation/screens/use_demo_accounts_screen.dart
@@ -1,0 +1,388 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:crypto_mobile_app/core/widgets/app_bar.dart';
+import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/features/wallet/data/repositories/accounts_repository.dart';
+import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/src/rust/account.dart';
+import 'package:crypto_mobile_app/features/node/data/repositories/rust_backend_service.dart';
+
+class UseDemoAccountsScreen extends ConsumerStatefulWidget {
+  const UseDemoAccountsScreen({super.key});
+
+  @override
+  ConsumerState<UseDemoAccountsScreen> createState() =>
+      _UseDemoAccountsScreenState();
+}
+
+class _UseDemoAccountsScreenState extends ConsumerState<UseDemoAccountsScreen> {
+  List<DemoAccountPreview> _demoAccounts = [];
+  bool _loading = true;
+  bool _importing = false;
+  int? _importingIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDemoAccounts();
+  }
+
+  Future<void> _loadDemoAccounts() async {
+    setState(() => _loading = true);
+
+    try {
+      final demoAccounts = AppConfig.demoAccounts;
+      final previews = <DemoAccountPreview>[];
+
+      for (int i = 0; i < demoAccounts.length; i++) {
+        final account = demoAccounts[i];
+        previews.add(DemoAccountPreview(
+          index: i + 1,
+          privateKey: account.secretKeyHex,
+          expectedPublicKey: account.publicKeyHex,
+          expectedBech32Address: account.publicKeyHashBech32m,
+          amount: account.amount,
+          tier: account.tier,
+        ));
+      }
+
+      setState(() {
+        _demoAccounts = previews;
+        _loading = false;
+      });
+    } catch (e) {
+      LoggingService.instance.error(
+        'Failed to load demo accounts',
+        tag: 'DEMO_ACCOUNTS',
+        error: e,
+      );
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _importDemoAccount(DemoAccountPreview account) async {
+    if (_importing) return;
+
+    setState(() {
+      _importing = true;
+      _importingIndex = account.index;
+    });
+
+    try {
+      // Derive keys from private key
+      final accountExport = accountFromPrivateKey(
+        privateKeyHex: account.privateKey,
+      );
+
+      // Validate that generated keys match expected keys
+      if (accountExport.publicKeyHex != account.expectedPublicKey) {
+        if (!mounted) return;
+        setState(() {
+          _importing = false;
+          _importingIndex = null;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Key validation failed: Public key mismatch for ${account.tier} account',
+            ),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+        LoggingService.instance.error(
+          'Public key mismatch: expected ${account.expectedPublicKey}, got ${accountExport.publicKeyHex}',
+          tag: 'DEMO_ACCOUNTS',
+        );
+        return;
+      }
+
+      if (accountExport.publicKeyHashBech32M != account.expectedBech32Address) {
+        if (!mounted) return;
+        setState(() {
+          _importing = false;
+          _importingIndex = null;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Key validation failed: Address mismatch for ${account.tier} account',
+            ),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+        LoggingService.instance.error(
+          'Address mismatch: expected ${account.expectedBech32Address}, got ${accountExport.publicKeyHashBech32M}',
+          tag: 'DEMO_ACCOUNTS',
+        );
+        return;
+      }
+
+      LoggingService.instance.debug(
+        'Demo account keys validated successfully',
+        tag: 'DEMO_ACCOUNTS',
+      );
+
+      // Import the validated account
+      final repo = await AccountsRepository.create();
+      final result = await repo.importFromPrivateKey(
+        name: 'Demo ${account.tier.toUpperCase()} ${account.index}',
+        privateKeyHex: account.privateKey,
+        isDemo: true,
+      );
+
+      if (!mounted) return;
+
+      if (result == null) {
+        setState(() {
+          _importing = false;
+          _importingIndex = null;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Failed to import demo account'),
+          ),
+        );
+        return;
+      }
+
+      LoggingService.instance.debug(
+        'Demo account imported successfully',
+        tag: 'DEMO_ACCOUNTS',
+      );
+
+      // Start backend for new account
+      try {
+        await RustBackendService.instance.startForActiveAccount();
+      } catch (e) {
+        LoggingService.instance.error(
+          'Failed to start backend',
+          tag: 'DEMO_ACCOUNTS',
+          error: e,
+        );
+      }
+
+      // Navigate to identity verification screen
+      if (!mounted) return;
+      context.go('/identity-verification?accountId=${result.id}');
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _importing = false;
+        _importingIndex = null;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to import demo account: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: const AppAppBar(
+        title: 'Use Demo Account',
+        showNodeStatus: false,
+      ),
+      body: SafeArea(
+        child: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : _demoAccounts.isEmpty
+                ? Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.info_outline,
+                            size: 64,
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            'No Demo Accounts Available',
+                            style: theme.textTheme.titleLarge,
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'Demo accounts are not configured in this build.',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                : Column(
+                    children: [
+                      Container(
+                        width: double.infinity,
+                        margin: const EdgeInsets.all(16),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Select a demo account to import for testing purposes.',
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Row(
+                              children: [
+                                Icon(
+                                  Icons.science_outlined,
+                                  size: 16,
+                                  color: theme.colorScheme.primary,
+                                ),
+                                const SizedBox(width: 4),
+                                Expanded(
+                                  child: Text(
+                                    'Demo accounts are for development/testing only',
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: theme.colorScheme.primary,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                      Expanded(
+                        child: ListView.builder(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          itemCount: _demoAccounts.length,
+                          itemBuilder: (context, index) {
+                            final account = _demoAccounts[index];
+                            final isImporting =
+                                _importingIndex == account.index;
+
+                            return Card(
+                              margin: const EdgeInsets.only(bottom: 12),
+                              child: ListTile(
+                                contentPadding: const EdgeInsets.all(16),
+                                leading: CircleAvatar(
+                                  backgroundColor:
+                                      theme.colorScheme.primaryContainer,
+                                  child: Text(
+                                    '${account.index}',
+                                    style: TextStyle(
+                                      color:
+                                          theme.colorScheme.onPrimaryContainer,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                                title: Row(
+                                  children: [
+                                    Text(
+                                      account.tierDisplay,
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 8,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: theme.colorScheme.primaryContainer,
+                                        borderRadius: BorderRadius.circular(4),
+                                      ),
+                                      child: Text(
+                                        account.formattedBalance,
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: theme
+                                              .colorScheme.onPrimaryContainer,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                trailing: isImporting
+                                    ? const SizedBox(
+                                        width: 24,
+                                        height: 24,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                        ),
+                                      )
+                                    : FilledButton(
+                                        onPressed: _importing
+                                            ? null
+                                            : () => _importDemoAccount(account),
+                                        child: const Text('Use'),
+                                      ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+      ),
+    );
+  }
+}
+
+class DemoAccountPreview {
+  final int index;
+  final String privateKey;
+  final String expectedPublicKey;
+  final String expectedBech32Address;
+  final int amount;
+  final String tier;
+
+  DemoAccountPreview({
+    required this.index,
+    required this.privateKey,
+    required this.expectedPublicKey,
+    required this.expectedBech32Address,
+    required this.amount,
+    required this.tier,
+  });
+
+  String get formattedBalance {
+    // Convert from base units to millions (divide by 1,000,000)
+    final millions = amount / 1000000;
+    if (millions >= 1000) {
+      // Convert millions to billions
+      final billions = millions / 1000;
+      return '${billions.toStringAsFixed(0)}B TKN';
+    } else {
+      return '${millions.toStringAsFixed(0)}M TKN';
+    }
+  }
+
+  String get tierEmoji {
+    switch (tier.toLowerCase()) {
+      case 'foundation':
+        return '👑';
+      case 'whale':
+        return '🐋';
+      case 'fish':
+        return '🐟';
+      default:
+        return '📦';
+    }
+  }
+
+  String get tierDisplay => '$tierEmoji ${tier.toUpperCase()}';
+}

--- a/lib/features/wallet/data/models/account.dart
+++ b/lib/features/wallet/data/models/account.dart
@@ -11,6 +11,7 @@ class AccountMeta {
   final bool backupConfirmed;
   final bool identityVerified;
   final DateTime? identityVerifiedAt;
+  final bool isDemo;
 
   const AccountMeta({
     required this.id,
@@ -23,6 +24,7 @@ class AccountMeta {
     required this.backupConfirmed,
     this.identityVerified = false,
     this.identityVerifiedAt,
+    this.isDemo = false,
   });
 
   AccountMeta copyWith({
@@ -30,6 +32,7 @@ class AccountMeta {
     bool? backupConfirmed,
     bool? identityVerified,
     DateTime? identityVerifiedAt,
+    bool? isDemo,
   }) =>
       AccountMeta(
         id: id,
@@ -42,6 +45,7 @@ class AccountMeta {
         backupConfirmed: backupConfirmed ?? this.backupConfirmed,
         identityVerified: identityVerified ?? this.identityVerified,
         identityVerifiedAt: identityVerifiedAt ?? this.identityVerifiedAt,
+        isDemo: isDemo ?? this.isDemo,
       );
 
   Map<String, dynamic> toJson() => {
@@ -55,6 +59,7 @@ class AccountMeta {
         'backupConfirmed': backupConfirmed,
         'identityVerified': identityVerified,
         'identityVerifiedAt': identityVerifiedAt?.toIso8601String(),
+        'isDemo': isDemo,
       };
 
   static AccountMeta fromJson(Map<String, dynamic> json) => AccountMeta(
@@ -70,6 +75,7 @@ class AccountMeta {
         identityVerifiedAt: json['identityVerifiedAt'] != null
             ? DateTime.parse(json['identityVerifiedAt'] as String)
             : null,
+        isDemo: (json['isDemo'] as bool? ?? false),
       );
 
   @override

--- a/lib/features/wallet/data/repositories/accounts_repository.dart
+++ b/lib/features/wallet/data/repositories/accounts_repository.dart
@@ -218,11 +218,62 @@ class AccountsRepository {
     }
   }
 
+  /// Import an account from a hex-encoded private key.
+  Future<AccountMeta?> importFromPrivateKey({
+    required String name,
+    required String privateKeyHex,
+    bool isDemo = false,
+  }) async {
+    LoggingService.instance.trace(
+        'importFromPrivateKey - start (name: $name, isDemo: $isDemo)',
+        tag: 'ACCOUNTS_REPO');
+
+    try {
+      // Use Rust backend to derive public key and address from private key
+      final accountExport = accountFromPrivateKey(
+        privateKeyHex: privateKeyHex.trim(),
+      );
+
+      // Extract keys from AccountExport
+      final privateKey = accountExport.secretKeyHex;
+      final publicKey = accountExport.publicKeyHex;
+      final address = accountExport.publicKeyHashHex;
+
+      LoggingService.instance.trace('Private key length: ${privateKey.length}',
+          tag: 'ACCOUNTS_REPO');
+      LoggingService.instance.trace('Public key length: ${publicKey.length}',
+          tag: 'ACCOUNTS_REPO');
+      LoggingService.instance.trace('Address: $address', tag: 'ACCOUNTS_REPO');
+
+      final result = await _persistNew(
+        name: name,
+        address: address,
+        publicKey: publicKey,
+        privateKey: privateKey,
+        derivationPath: 'imported', // Mark as imported rather than HD path
+        isDemo: isDemo,
+      );
+      LoggingService.instance.trace(
+          'importFromPrivateKey - success (account id: ${result.id})',
+          tag: 'ACCOUNTS_REPO');
+      return result;
+    } catch (e, stackTrace) {
+      LoggingService.instance.error(
+          'importFromPrivateKey - FAILED with exception',
+          tag: 'ACCOUNTS_REPO',
+          error: e,
+          stackTrace: stackTrace);
+      return null;
+    }
+  }
+
   Future<AccountMeta> _persistNew({
     required String name,
     required String address,
     required String publicKey,
     required String privateKey,
+    String? derivationPath,
+    bool isDemo = false,
   }) async {
     LoggingService.instance.trace(
         '_persistNew - start (name: $name, address: $address)',
@@ -239,11 +290,12 @@ class AccountsRepository {
       id: id,
       name: name,
       createdAt: DateTime.now(),
-      derivationPath: '$_kPathPrefix$index',
+      derivationPath: derivationPath ?? '$_kPathPrefix$index',
       hdIndex: index,
       address: address,
       publicKey: publicKey,
       backupConfirmed: true, // Imported accounts assumed backed up by user
+      isDemo: isDemo,
     );
 
     LoggingService.instance


### PR DESCRIPTION
- Add new account import methods: private key (hex) and demo accounts
- Update block producer to use wallet private key instead of hardcoded key
- Add demo accounts configuration with JSON structure and validation
- Update demo accounts UI to show only tier and token amounts
- Add isDemo field to AccountMeta model
- Update GitHub workflow to inject demo accounts from secrets