### PR TITLE
chore: Disable CocoaPods caching in GitHub Actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -445,18 +445,6 @@ jobs:
           ruby-version: "3.2"
           bundler-cache: true
 
-      - name: Cache CocoaPods
-        id: cache-pods
-        uses: actions/cache@v4
-        with:
-          path: |
-            ios/Pods
-            ~/Library/Caches/CocoaPods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}-${{ hashFiles('ios/Podfile') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}-
-            ${{ runner.os }}-pods-
-
       - name: Cache Xcode DerivedData
         uses: actions/cache@v4
         with:
@@ -469,12 +457,8 @@ jobs:
       - name: Install CocoaPods dependencies
         run: |
           cd ios
-          if [ ! -d "Pods" ] || [ -f "Podfile.lock" ] && [ "Podfile.lock" -nt "Pods/Manifest.lock" ] || [ "${{ steps.cache-pods.outputs.cache-hit }}" != "true" ]; then
-            pod install
-            echo "✅ Pod install complete"
-          else
-            echo "✅ Pods are up to date (cache hit), skipping installation"
-          fi
+          pod install
+          echo "✅ Pod install complete"
 
       - name: Import signing certificate
         env:

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -512,18 +512,6 @@ jobs:
           ruby-version: "3.2"
           bundler-cache: true
 
-      - name: Cache CocoaPods
-        id: cache-pods
-        uses: actions/cache@v4
-        with:
-          path: |
-            ios/Pods
-            ~/Library/Caches/CocoaPods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}-${{ hashFiles('ios/Podfile') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}-
-            ${{ runner.os }}-pods-
-
       - name: Cache Xcode DerivedData
         uses: actions/cache@v4
         with:
@@ -536,12 +524,8 @@ jobs:
       - name: Install CocoaPods dependencies
         run: |
           cd ios
-          if [ ! -d "Pods" ] || [ "Podfile.lock" ] && [ "Podfile.lock" -nt "Pods/Manifest.lock" ] || [ "${{ steps.cache-pods.outputs.cache-hit }}" != "true" ]; then
-            pod install
-            echo "✅ Pod install complete"
-          else
-            echo "✅ Pods are up to date (cache hit), skipping installation"
-          fi
+          pod install
+          echo "✅ Pod install complete"
 
       - name: Import signing certificate
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -436,18 +436,6 @@ jobs:
             exit 1
           fi
 
-      - name: Cache CocoaPods
-        id: cache-pods
-        uses: actions/cache@v4
-        with:
-          path: |
-            ios/Pods
-            ~/Library/Caches/CocoaPods
-          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}-${{ hashFiles('ios/Podfile') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}-
-            ${{ runner.os }}-pods-
-
       - name: Cache Xcode DerivedData
         uses: actions/cache@v4
         with:
@@ -460,13 +448,8 @@ jobs:
       - name: Install CocoaPods
         run: |
           cd ios
-          # Only install if Pods directory doesn't exist or is outdated
-          if [ ! -d "Pods" ] || [ "Podfile.lock" -nt "Pods/Manifest.lock" ] || [ "${{ steps.cache-pods.outputs.cache-hit }}" != "true" ]; then
-            pod install
-            echo "✅ Pod install complete"
-          else
-            echo "✅ Pods are up to date (cache hit), skipping installation"
-          fi
+          pod install
+          echo "✅ Pod install complete"
 
       - name: Build iOS
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
     secrets: inherit
 
   unit-tests:
-    name: Unit Tests
+    name: Code Analysis and Tests
     runs-on: ubuntu-20.04-16core2
     needs: [determine-frb-rev, setup-rust-tools-android]
     steps:


### PR DESCRIPTION
Remove CocoaPods cache steps and update pod install to always run. Ensures consistent dependency resolution at the cost of longer build times.