### PR TITLE
chore: Disable Xcode DerivedData caching in GitHub Actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -445,15 +445,6 @@ jobs:
           ruby-version: "3.2"
           bundler-cache: true
 
-      - name: Cache Xcode DerivedData
-        uses: actions/cache@v4
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-xcode-${{ hashFiles('ios/**/*.{swift,m,h}', 'ios/Podfile.lock') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-xcode-${{ hashFiles('ios/**/*.{swift,m,h}', 'ios/Podfile.lock') }}-
-            ${{ runner.os }}-xcode-
-
       - name: Install CocoaPods dependencies
         run: |
           cd ios

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -512,15 +512,6 @@ jobs:
           ruby-version: "3.2"
           bundler-cache: true
 
-      - name: Cache Xcode DerivedData
-        uses: actions/cache@v4
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-xcode-${{ hashFiles('ios/**/*.{swift,m,h}', 'ios/Podfile.lock') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-xcode-${{ hashFiles('ios/**/*.{swift,m,h}', 'ios/Podfile.lock') }}-
-            ${{ runner.os }}-xcode-
-
       - name: Install CocoaPods dependencies
         run: |
           cd ios

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -436,15 +436,6 @@ jobs:
             exit 1
           fi
 
-      - name: Cache Xcode DerivedData
-        uses: actions/cache@v4
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData
-          key: ${{ runner.os }}-xcode-${{ hashFiles('ios/**/*.{swift,m,h}', 'ios/Podfile.lock') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-xcode-${{ hashFiles('ios/**/*.{swift,m,h}', 'ios/Podfile.lock') }}-
-            ${{ runner.os }}-xcode-
-
       - name: Install CocoaPods
         run: |
           cd ios


### PR DESCRIPTION
Remove Xcode DerivedData cache steps to ensure clean builds and eliminate potential hashFiles errors with Podfile.lock.