### PR TITLE
Update Flutter bindings and GitHub workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
-          ref: tmp-bining-fix
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Move usernode repository next to workspace
@@ -302,7 +302,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
-          ref: tmp-bining-fix
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Determine usernode revision
@@ -344,7 +344,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
-          ref: tmp-bining-fix
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Move usernode repository next to workspace

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
-          ref: tmp-bining-fix
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Determine usernode revision
@@ -124,7 +124,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
-          ref: tmp-bining-fix
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Move usernode repository next to workspace
@@ -385,7 +385,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
-          ref: tmp-bining-fix
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Move usernode repository next to workspace

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Determine usernode revision
@@ -72,6 +73,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Move usernode repository next to workspace
@@ -155,6 +157,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Move usernode repository next to workspace
@@ -297,6 +300,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Move usernode repository next to workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Get FRB revision and usernode SHA
@@ -67,6 +68,7 @@ jobs:
         with:
           repository: Usernode-Labs/usernode
           path: usernode
+          ref: main
           token: ${{ secrets.USERNODE_ACCESS_TOKEN }}
 
       - name: Move usernode repository next to workspace

--- a/lib/core/models/backend_rpc_response.dart
+++ b/lib/core/models/backend_rpc_response.dart
@@ -1,5 +1,6 @@
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/epoch_rewards.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
+import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/block_producer_status.dart';
 import 'vrf_status.dart';
 
 /// Enhanced response from backend RPC that includes VRF calculation status
@@ -58,18 +59,18 @@ class BackendRPCResponse {
   /// - RpcStatusVrfEvaluationStatus.evaluating → VRFStatus.inProgress
   /// - RpcStatusVrfEvaluationStatus.completed → VRFStatus.complete
   ///
-  /// Requires [statusResp] to access the actual VRF evaluator status from backend.
+  /// Requires [blockProducerStatus] to access the actual VRF evaluator status from backend.
   factory BackendRPCResponse.fromEpochRewards(
     RpcEpochRewardsResp epochRewards, {
     required int currentSlot,
-    required RpcStatusResp? statusResp,
+    required RpcBlockProducerStatusResp? blockProducerStatus,
   }) {
     // Map backend VRF status to Flutter VRF status
     VRFStatus status = VRFStatus.notStarted;
 
-    if (statusResp?.vrfEvaluator != null) {
+    if (blockProducerStatus?.vrfEvaluator != null) {
       final backendStatus =
-          statusResp!.vrfEvaluator!.currentEpochVrfEvaluationStatus;
+          blockProducerStatus!.vrfEvaluator!.currentEpochVrfEvaluationStatus;
       status = switch (backendStatus) {
         RpcStatusVrfEvaluationStatus.pending => VRFStatus.notStarted,
         RpcStatusVrfEvaluationStatus.evaluating => VRFStatus.inProgress,

--- a/lib/core/services/background_block_production_orchestrator.dart
+++ b/lib/core/services/background_block_production_orchestrator.dart
@@ -422,8 +422,9 @@ class BackgroundBlockProductionOrchestrator {
       // Get node state for the monitoring start event
       String nodeState = 'unknown';
       try {
-        final status = await RustBackendService.instance.getStatus();
-        nodeState = status?.blockProducer?.status.toString() ?? 'unknown';
+        final bpStatus =
+            await RustBackendService.instance.getBlockProducerStatus();
+        nodeState = bpStatus?.blockProducer?.status.toString() ?? 'unknown';
       } catch (e) {
         _log.warn('Could not get node state: $e');
       }

--- a/lib/core/services/epoch_slot_scheduler_service.dart
+++ b/lib/core/services/epoch_slot_scheduler_service.dart
@@ -532,8 +532,12 @@ class EpochSlotSchedulerService {
         return null;
       }
 
+      // Get VRF evaluator from block producer status
+      final bpStatus =
+          await RustBackendService.instance.getBlockProducerStatus();
+
       // Use backend-provided epoch upper bound
-      final epochEndSlot = status.vrfEvaluator?.details?.status.whenOrNull(
+      final epochEndSlot = bpStatus?.vrfEvaluator?.details?.status.whenOrNull(
         readyToEvaluate: (_, __, ___, upperBound, ____, _____) => upperBound,
       );
       if (epochEndSlot == null) {
@@ -579,8 +583,13 @@ class EpochSlotSchedulerService {
         return null;
       }
 
+      // Get VRF evaluator from block producer status
+      final bpStatus =
+          await RustBackendService.instance.getBlockProducerStatus();
+
       // Use backend-provided epoch boundaries
-      final epochUpperBound = status.vrfEvaluator?.details?.status.whenOrNull(
+      final epochUpperBound =
+          bpStatus?.vrfEvaluator?.details?.status.whenOrNull(
         readyToEvaluate: (_, __, ___, upperBound, ____, _____) => upperBound,
       );
       if (epochUpperBound == null) {

--- a/lib/core/services/slot_monitor_service.dart
+++ b/lib/core/services/slot_monitor_service.dart
@@ -161,7 +161,9 @@ class SlotMonitorService {
       }
 
       // Get node state from block producer status
-      final nodeState = status.blockProducer?.status.toString() ?? 'idle';
+      final bpStatus =
+          await RustBackendService.instance.getBlockProducerStatus();
+      final nodeState = bpStatus?.blockProducer?.status.toString() ?? 'idle';
 
       // Use backend-provided current global slot
       final bestTipSlot = status.node.curGlobalSlot;

--- a/lib/features/node/node_provider.dart
+++ b/lib/features/node/node_provider.dart
@@ -187,8 +187,12 @@ class NodeStatusController extends AsyncNotifier<NodeStatusState?> {
       final status = await RustBackendService.instance.getStatus();
       if (status == null) return null;
 
+      // Fetch block producer status (includes VRF evaluator)
+      final bpStatus =
+          await RustBackendService.instance.getBlockProducerStatus();
+
       // Log VRF response for debugging
-      final vrf = status.vrfEvaluator;
+      final vrf = bpStatus?.vrfEvaluator;
       if (vrf != null) {
         final vrfJson = {
           'statusTimeMs': vrf.statusTimeMs.toString(),
@@ -262,8 +266,8 @@ class NodeStatusController extends AsyncNotifier<NodeStatusState?> {
         networkBest: networkBest,
         fetchProgress: fetchProgress,
         applyProgress: applyProgress,
-        blockProducer: status.blockProducer,
-        vrfEvaluator: status.vrfEvaluator,
+        blockProducer: bpStatus?.blockProducer,
+        vrfEvaluator: bpStatus?.vrfEvaluator,
         node: status.node,
         slotsInEpoch: status.node.slotsInEpoch,
         blockInterval: status.node.blockInterval,
@@ -281,8 +285,8 @@ class NodeStatusController extends AsyncNotifier<NodeStatusState?> {
         networkBest: networkBest,
         fetchProgress: fetchProgress,
         applyProgress: applyProgress,
-        blockProducer: status.blockProducer,
-        vrfEvaluator: status.vrfEvaluator,
+        blockProducer: bpStatus?.blockProducer,
+        vrfEvaluator: bpStatus?.vrfEvaluator,
         node: status.node,
         slotsInEpoch: status.node.slotsInEpoch,
         blockInterval: status.node.blockInterval,

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -2,6 +2,7 @@ import 'dart:io' show Platform;
 import 'dart:convert';
 
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
+import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/block_producer_status.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_mempool.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_utxos_by_owner.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/transfer_funds.dart';
@@ -211,8 +212,7 @@ class RustBackendService {
     final r = _rpc;
     if (r == null) return null;
     try {
-      final status =
-          await r.status(includeLastReorg: false, includeVrfDetails: false);
+      final status = await r.status(includeVrfDetails: false);
       return status?.node;
     } on PanicException catch (e, st) {
       _log.error('FRB panic during getStatusNode', error: e, stackTrace: st);
@@ -225,7 +225,6 @@ class RustBackendService {
 
   /// Convenience helper to fetch node status via RPC.
   Future<RpcStatusResp?> getStatus({
-    bool? includeLastReorg,
     bool includeVrfDetails = true,
   }) async {
     _log.trace('getStatus called');
@@ -236,7 +235,6 @@ class RustBackendService {
     RpcStatusResp? status;
     try {
       status = await r.status(
-        includeLastReorg: includeLastReorg,
         includeVrfDetails: includeVrfDetails,
       );
     } on PanicException catch (e, st) {
@@ -338,118 +336,9 @@ class RustBackendService {
         }
       }
 
-      // Build block producer data for logging
-      Map<String, dynamic>? blockProducerData;
-      final blockProducer = status?.blockProducer;
-      if (blockProducer != null) {
-        try {
-          final statusData = blockProducer.status;
-          Map<String, dynamic> statusMap = {
-            'type': statusData.toString().split('(').first.split('.').last,
-          };
-
-          // Extract won slot info if available
-          statusData.whenOrNull(
-            wonSlotDiscarded: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            wonSlot: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            wonSlotWait: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            wonSlotProduceInit: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            batchesAssemblePending: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            batchesAssembleSuccess: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            dbDiffPending: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            dbDiffSuccess: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            stakeProofWait: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            signingPending: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            produced: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-            injected: (wonSlot) => statusMap['won_slot'] = {
-              'global_slot': wonSlot.globalSlot,
-              'slot_timestamp': wonSlot.slotTimestamp.toString(),
-            },
-          );
-
-          blockProducerData = {
-            'pub_key': blockProducer.pubKey.toString(),
-            'status': statusMap,
-          };
-        } catch (e) {
-          blockProducerData = {
-            'error': 'Failed to parse block producer data: $e'
-          };
-        }
-      }
-
-      // Build mempool data for logging
-      Map<String, dynamic>? mempoolData;
-      final mempool = status?.mempool;
-      if (mempool != null) {
-        try {
-          Map<String, dynamic>? lastReorgData;
-          final lastReorg = mempool.lastReorg;
-          if (lastReorg != null) {
-            lastReorgData = {
-              'root': lastReorg.root,
-              'blocks_disconnected': lastReorg.blocksDisconnected,
-              'blocks_connected': lastReorg.blocksConnected,
-              'txs_readmitted_ok': lastReorg.txsReadmittedOk,
-              'txs_readmitted_orphaned': lastReorg.txsReadmittedOrphaned,
-              'txs_readmitted_conflict': lastReorg.txsReadmittedConflict,
-              'connected_removed': lastReorg.connectedRemoved,
-              'prepared_count': lastReorg.preparedCount,
-              'plan_elapsed_ms': lastReorg.planElapsedMs?.toString(),
-              'when': lastReorg.when.toString(),
-              'in_progress': lastReorg.inProgress,
-            };
-          }
-
-          mempoolData = {
-            'entries': mempool.entries.toString(),
-            'orphans': mempool.orphans.toString(),
-            'total_size': mempool.totalSize.toString(),
-            if (lastReorgData != null) 'last_reorg': lastReorgData,
-          };
-        } catch (e) {
-          mempoolData = {'error': 'Failed to parse mempool data: $e'};
-        }
-      }
-
       final fullResponse = {
         'peers': peers,
         if (blockchainData != null) 'blockchain': blockchainData,
-        if (blockProducerData != null) 'block_producer': blockProducerData,
-        if (mempoolData != null) 'mempool': mempoolData,
       };
       final json = jsonEncode(fullResponse);
       _log.trace('getStatus response: $json');
@@ -530,6 +419,34 @@ class RustBackendService {
           .warn('Failed to encode getStatus to JSON: $e\$st');
       // Report handled error to Sentry with context
       await SentryUtil.captureError(e, st, tag: 'getStatus');
+    }
+    return status;
+  }
+
+  /// Fetch block producer and VRF evaluator status via RPC.
+  Future<RpcBlockProducerStatusResp?> getBlockProducerStatus({
+    bool includeVrfDetails = true,
+  }) async {
+    _log.trace('getBlockProducerStatus called');
+    final r = _rpc;
+    if (r == null) return null;
+
+    RpcBlockProducerStatusResp? status;
+    try {
+      status = await r.blockProducerStatus(
+        includeVrfDetails: includeVrfDetails,
+      );
+    } on PanicException catch (e, st) {
+      _log.error('FRB panic during getBlockProducerStatus',
+          error: e, stackTrace: st);
+      _nodeRunning = false;
+      _rpc = null;
+      await SentryUtil.captureError(e, st, tag: 'frb_panic_getBlockProducerStatus');
+      return null;
+    } catch (e, st) {
+      _log.warn('RPC getBlockProducerStatus failed: $e\$st');
+      await SentryUtil.captureError(e, st, tag: 'rpc_getBlockProducerStatus');
+      return null;
     }
     return status;
   }
@@ -998,11 +915,14 @@ class RustBackendService {
         return null;
       }
 
+      // Get block producer status for VRF info
+      final bpStatus = await getBlockProducerStatus();
+
       // Create enhanced response with actual VRF status from backend
       final response = BackendRPCResponse.fromEpochRewards(
         epochRewardsResp,
         currentSlot: currentSlot,
-        statusResp: status,
+        blockProducerStatus: bpStatus,
       );
 
       _log.trace(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -697,10 +697,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1125,10 +1125,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:

--- a/test/frb/frb_contract_test.dart
+++ b/test/frb/frb_contract_test.dart
@@ -25,8 +25,7 @@ typedef ListBlockchainFn = Future<RpcListBlockchainResp?> Function(
     {int? limit, bool? fromTip});
 typedef ListMempoolFn = Future<RpcListMempoolResp?> Function();
 typedef EpochRewardsFn = Future<RpcEpochRewardsResp?> Function({int? epoch});
-typedef GetStatusFn = Future<RpcStatusResp?> Function(
-    {bool? includeLastReorg, bool includeVrfDetails});
+typedef GetStatusFn = Future<RpcStatusResp?> Function({bool includeVrfDetails});
 typedef BuildEnvFn = BuildInfo Function();
 typedef ListUtxosByOwnerFn = Future<RpcListUtxosByOwnerResp?> Function(
     {required PublicKeyHash owner, int? limit});
@@ -52,7 +51,7 @@ void main() {
       expect(f, isNotNull);
     });
 
-    test('getStatus({bool? includeLastReorg, bool? includeVrfDetails})', () {
+    test('getStatus({bool? includeVrfDetails})', () {
       final GetStatusFn f = RustBackendService.instance.getStatus;
       expect(f, isNotNull);
     });


### PR DESCRIPTION
- Update Flutter bindings for new usernode RPC API split
  - status() no longer includes blockProducer, vrfEvaluator, mempool
  - Add separate getBlockProducerStatus() call
  - Remove includeLastReorg parameter from status()

- Update all GitHub workflows to use ref: main for usernode checkout
  - test.yml, pr-checks.yml, manual-build.yml, build-and-deploy.yml