### PR TITLE
Hash device ID before sending to metrics API

### DIFF
--- a/lib/features/metrics/metrics_collector_service.dart
+++ b/lib/features/metrics/metrics_collector_service.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
+
+import 'package:crypto/crypto.dart';
 import 'package:battery_plus/battery_plus.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
@@ -17,6 +20,13 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 final _log = LoggingService.instance.withTag(LogTag.metrics);
+
+/// Hashes a device ID using SHA-256 (truncated to 16 chars) for privacy
+String _hashDeviceId(String deviceId) {
+  final bytes = utf8.encode(deviceId);
+  final digest = sha256.convert(bytes);
+  return digest.toString().substring(0, 16);
+}
 
 /// Service responsible for collecting all metrics from various sources
 ///
@@ -304,7 +314,7 @@ class MetricsCollectorService {
     }
 
     return DeviceMetrics(
-      deviceId: deviceId,
+      deviceId: _hashDeviceId(deviceId),
       deviceManufacturer: manufacturer,
       deviceModel: model,
       isPhysicalDevice: isPhysical,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -218,7 +218,7 @@ packages:
     source: hosted
     version: "0.3.5"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
@@ -697,10 +697,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1125,10 +1125,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   battery_plus: "^6.0.0"
   connectivity_plus: "^6.0.0"
   permission_handler: "^11.0.0"
+  crypto: "^3.0.3"
 dev_dependencies:
   flutter_lints: "^5.0.0"
   flutter_test:


### PR DESCRIPTION
For privacy, the device ID is now hashed using SHA-256 (truncated to 16 chars) before being sent to the backend metrics API.