### PR TITLE
Add app version check feature with configurable API endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,19 @@ METRICS_HEALTH_ENDPOINT=
 METRICS_COLLECTION_INTERVAL_SECONDS=30
 
 # =============================================================================
+# VERSION CHECK
+# =============================================================================
+# API endpoint for checking app version updates
+# If empty, version checking is disabled
+# Default: '' (empty - version check disabled)
+VERSION_CHECK_API_URL=
+
+# Interval between version checks in seconds
+# How often the app checks for available updates
+# Default: 7200 (2 hours)
+VERSION_CHECK_INTERVAL_SECONDS=7200
+
+# =============================================================================
 # BACKGROUND BLOCK PRODUCTION
 # =============================================================================
 # These settings control the background block production orchestrator

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -112,6 +112,8 @@ jobs:
           INTERNAL_GENESIS_URL=${{ secrets.INTERNAL_GENESIS_URL }}
           NETWORK_SWITCHER_CODE=${{ secrets.NETWORK_SWITCHER_CODE }}
           LOAD_GENESIS_NB_RETRIES=${{ secrets.LOAD_GENESIS_NB_RETRIES }}
+          VERSION_CHECK_API_URL=${{ secrets.PROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.PROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           else
             cat > .env << EOF
@@ -134,6 +136,8 @@ jobs:
           INTERNAL_GENESIS_URL=${{ secrets.INTERNAL_GENESIS_URL }}
           NETWORK_SWITCHER_CODE=${{ secrets.NETWORK_SWITCHER_CODE }}
           LOAD_GENESIS_NB_RETRIES=${{ secrets.LOAD_GENESIS_NB_RETRIES }}
+          VERSION_CHECK_API_URL=${{ secrets.NONPROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.NONPROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           fi
           echo "✅ Created .env file with ${{ steps.env_config.outputs.env_type }} secrets"
@@ -544,6 +548,8 @@ jobs:
           INTERNAL_GENESIS_URL=${{ secrets.INTERNAL_GENESIS_URL }}
           NETWORK_SWITCHER_CODE=${{ secrets.NETWORK_SWITCHER_CODE }}
           LOAD_GENESIS_NB_RETRIES=${{ secrets.LOAD_GENESIS_NB_RETRIES }}
+          VERSION_CHECK_API_URL=${{ secrets.PROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.PROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           else
             cat > .env << EOF
@@ -566,6 +572,8 @@ jobs:
           INTERNAL_GENESIS_URL=${{ secrets.INTERNAL_GENESIS_URL }}
           NETWORK_SWITCHER_CODE=${{ secrets.NETWORK_SWITCHER_CODE }}
           LOAD_GENESIS_NB_RETRIES=${{ secrets.LOAD_GENESIS_NB_RETRIES }}
+          VERSION_CHECK_API_URL=${{ secrets.NONPROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.NONPROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           fi
           echo "✅ Created .env file with ${{ steps.env_config_ios.outputs.env_type }} secrets"

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -198,6 +198,8 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.PROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.PROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.PROD_METRICS_INTERVAL }}
+          VERSION_CHECK_API_URL=${{ secrets.PROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.PROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           else
             cat > .env << EOF
@@ -213,6 +215,8 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.NONPROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.NONPROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.NONPROD_METRICS_INTERVAL }}
+          VERSION_CHECK_API_URL=${{ secrets.NONPROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.NONPROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           fi
           echo "✅ Created .env file with ${{ steps.env_config.outputs.env_type }} secrets"
@@ -584,6 +588,8 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.PROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.PROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.PROD_METRICS_INTERVAL }}
+          VERSION_CHECK_API_URL=${{ secrets.PROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.PROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           else
             cat > .env << EOF
@@ -599,6 +605,8 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.NONPROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.NONPROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.NONPROD_METRICS_INTERVAL }}
+          VERSION_CHECK_API_URL=${{ secrets.NONPROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.NONPROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           fi
           echo "✅ Created .env file with ${{ steps.env_config.outputs.env_type }} secrets"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -50,11 +50,21 @@ jobs:
           echo "rev=$FRB_REV" >> "$GITHUB_OUTPUT"
           echo "Using flutter_rust_bridge rev: $FRB_REV"
 
-  # Job 1: Setup Rust tools (reusable)
+  # Job 1: Setup Rust tools (reusable) for iOS
   setup-rust-tools:
-    name: Setup Rust Tools
+    name: Setup Rust Tools for iOS
     needs: determine-frb-rev
     uses: ./.github/workflows/setup-rust-tools.yml
+    secrets: inherit
+    with:
+      frb_rev: ${{ needs.determine-frb-rev.outputs.frb_rev }}
+      usernode_ref: ${{ needs.determine-frb-rev.outputs.usernode_sha }}
+
+  # Job 1b: Setup Rust tools for Android
+  setup-rust-tools-android:
+    name: Setup Rust Tools for Android
+    needs: determine-frb-rev
+    uses: ./.github/workflows/setup-rust-tools-android.yml
     secrets: inherit
     with:
       frb_rev: ${{ needs.determine-frb-rev.outputs.frb_rev }}
@@ -147,10 +157,13 @@ jobs:
   build-android:
     name: Build Android (Debug)
     runs-on: ubuntu-20.04-16core2
-    needs: [determine-frb-rev, setup-rust-tools]
+    needs: [determine-frb-rev, setup-rust-tools-android]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup jq
+        run: sudo apt-get install -y jq
 
       - name: Checkout usernode repository
         uses: actions/checkout@v4
@@ -175,50 +188,8 @@ jobs:
           path: ../usernode/target
           key: ${{ runner.os }}-usernode-target-${{ needs.determine-frb-rev.outputs.usernode_sha }}
           restore-keys: |
+            ${{ runner.os }}-usernode-target-${{ needs.determine-frb-rev.outputs.frb_rev }}-
             ${{ runner.os }}-usernode-target-
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "zulu"
-          java-version: ${{ env.JAVA_VERSION }}
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: "stable"
-          cache: false
-
-      - name: Restore cargo binaries from cache
-        uses: actions/cache/restore@v4
-        id: cache-cargo-bins
-        with:
-          path: |
-            ~/.cargo/bin/cargo-expand
-            ~/.cargo/bin/flutter_rust_bridge_codegen
-          key: ${{ runner.os }}-cargo-bins-${{ needs.determine-frb-rev.outputs.frb_rev }}-v2
-
-      - name: Install flutter_rust_bridge_codegen if not cached
-        if: steps.cache-cargo-bins.outputs.cache-hit != 'true'
-        run: |
-          if ! command -v flutter_rust_bridge_codegen &> /dev/null; then
-            echo "Installing flutter_rust_bridge_codegen..."
-            cargo install flutter_rust_bridge_codegen --git https://github.com/Usernode-Labs/flutter_rust_bridge --rev ${{ needs.determine-frb-rev.outputs.frb_rev }} --locked
-          else
-            echo "flutter_rust_bridge_codegen already available"
-          fi
-
-      - name: Cache FRB generated code
-        id: cache-frb-gen
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/src/rust/frb_generated.dart
-            lib/src/rust/api
-          key: ${{ runner.os }}-frb-gen-${{ needs.determine-frb-rev.outputs.frb_rev }}-${{ needs.determine-frb-rev.outputs.usernode_sha }}
-          restore-keys: |
-            ${{ runner.os }}-frb-gen-${{ needs.determine-frb-rev.outputs.frb_rev }}-
 
       - name: Determine environment based on target branch
         id: env_config
@@ -247,6 +218,13 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.PROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.PROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.PROD_METRICS_INTERVAL }}
+          DEMO_ACCOUNTS_JSON=${{ secrets.PROD_DEMO_ACCOUNTS_JSON }}
+          TESTNET_SEEDLIST_URL=${{ secrets.TESTNET_SEEDLIST_URL }}
+          TESTNET_GENESIS_URL=${{ secrets.TESTNET_GENESIS_URL }}
+          INTERNAL_SEEDLIST_URL=${{ secrets.INTERNAL_SEEDLIST_URL }}
+          INTERNAL_GENESIS_URL=${{ secrets.INTERNAL_GENESIS_URL }}
+          NETWORK_SWITCHER_CODE=${{ secrets.NETWORK_SWITCHER_CODE }}
+          LOAD_GENESIS_NB_RETRIES=${{ secrets.LOAD_GENESIS_NB_RETRIES }}
           VERSION_CHECK_API_URL=${{ secrets.PROD_VERSION_CHECK_API_URL }}
           VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.PROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
@@ -264,13 +242,53 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.NONPROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.NONPROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.NONPROD_METRICS_INTERVAL }}
+          DEMO_ACCOUNTS_JSON=${{ secrets.NONPROD_DEMO_ACCOUNTS_JSON }}
+          TESTNET_SEEDLIST_URL=${{ secrets.TESTNET_SEEDLIST_URL }}
+          TESTNET_GENESIS_URL=${{ secrets.TESTNET_GENESIS_URL }}
+          INTERNAL_SEEDLIST_URL=${{ secrets.INTERNAL_SEEDLIST_URL }}
+          INTERNAL_GENESIS_URL=${{ secrets.INTERNAL_GENESIS_URL }}
+          NETWORK_SWITCHER_CODE=${{ secrets.NETWORK_SWITCHER_CODE }}
+          LOAD_GENESIS_NB_RETRIES=${{ secrets.LOAD_GENESIS_NB_RETRIES }}
           VERSION_CHECK_API_URL=${{ secrets.NONPROD_VERSION_CHECK_API_URL }}
           VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.NONPROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           fi
           echo "✅ Created .env file with ${{ steps.env_config.outputs.env_type }} secrets"
 
-      - name: Install dependencies
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: "stable"
+          cache: false
+
+      - name: Restore cargo binaries from cache
+        uses: actions/cache/restore@v4
+        id: cache-cargo-bins
+        with:
+          path: |
+            ~/.cargo/bin/cargo-expand
+            ~/.cargo/bin/flutter_rust_bridge_codegen
+          key: ${{ runner.os }}-cargo-bins-${{ needs.determine-frb-rev.outputs.frb_rev }}-v2
+
+      - name: Cache FRB generated code
+        id: cache-frb-gen
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/src/rust/frb_generated.dart
+            lib/src/rust/api
+          key: ${{ runner.os }}-frb-gen-${{ needs.determine-frb-rev.outputs.frb_rev }}-${{ needs.determine-frb-rev.outputs.usernode_sha }}
+          restore-keys: |
+            ${{ runner.os }}-frb-gen-${{ needs.determine-frb-rev.outputs.frb_rev }}-
+
+      - name: Install Flutter dependencies
         run: flutter pub get
 
       - name: Generate flutter_rust_bridge bindings
@@ -285,9 +303,32 @@ jobs:
             exit 1
           fi
 
-      - name: Build Android APK (Debug)
+      - name: Locate Android NDK
+        id: ndk
         run: |
-          flutter build apk \
+          set -euo pipefail
+          if [ -d "/usr/local/lib/android/sdk/ndk" ]; then
+            NDK_ROOT=$(ls -d /usr/local/lib/android/sdk/ndk/* | head -n 1)
+          elif [ -n "${ANDROID_NDK_HOME:-}" ]; then
+            NDK_ROOT="$ANDROID_NDK_HOME"
+          else
+            echo "Unable to locate Android NDK installation" >&2
+            exit 1
+          fi
+          echo "ndk_root=$NDK_ROOT" >> "$GITHUB_OUTPUT"
+          echo "Using NDK at $NDK_ROOT"
+
+      - name: Build Android APK (Debug)
+        env:
+          NDK_ROOT: ${{ steps.ndk.outputs.ndk_root }}
+        run: |
+          export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_CC="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_CXX="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang++"
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$CARGO_TARGET_AARCH64_LINUX_ANDROID_CC"
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_AR="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar"
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_RANLIB="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib"
+          CARGOKIT_ONLY_ANDROID_ARM64=1 flutter build apk \
             --debug \
             --dart-define-from-file=.env
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -330,6 +330,7 @@ jobs:
           export CARGO_TARGET_AARCH64_LINUX_ANDROID_RANLIB="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib"
           CARGOKIT_ONLY_ANDROID_ARM64=1 flutter build apk \
             --debug \
+            --flavor internal \
             --dart-define-from-file=.env
 
   build-ios:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -247,6 +247,8 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.PROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.PROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.PROD_METRICS_INTERVAL }}
+          VERSION_CHECK_API_URL=${{ secrets.PROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.PROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           else
             cat > .env << EOF
@@ -262,6 +264,8 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.NONPROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.NONPROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.NONPROD_METRICS_INTERVAL }}
+          VERSION_CHECK_API_URL=${{ secrets.NONPROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.NONPROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           fi
           echo "✅ Created .env file with ${{ steps.env_config.outputs.env_type }} secrets"
@@ -406,6 +410,8 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.PROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.PROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.PROD_METRICS_INTERVAL }}
+          VERSION_CHECK_API_URL=${{ secrets.PROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.PROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           else
             cat > .env << EOF
@@ -421,6 +427,8 @@ jobs:
           METRICS_ENDPOINT=${{ secrets.NONPROD_METRICS_ENDPOINT }}
           METRICS_HEALTH_ENDPOINT=${{ secrets.NONPROD_METRICS_HEALTH_ENDPOINT }}
           METRICS_INTERVAL=${{ secrets.NONPROD_METRICS_INTERVAL }}
+          VERSION_CHECK_API_URL=${{ secrets.NONPROD_VERSION_CHECK_API_URL }}
+          VERSION_CHECK_INTERVAL_SECONDS=${{ secrets.NONPROD_VERSION_CHECK_INTERVAL_SECONDS }}
           EOF
           fi
           echo "✅ Created .env file with ${{ steps.env_config.outputs.env_type }} secrets"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 }
 
 plugins {
-    id "com.android.application" version "8.6.0" apply false
-    id "com.android.library" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
+    id "com.android.library" version "8.9.1" apply false
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -137,6 +137,17 @@ class AppConfig {
   static Duration get epochMonitorBaseInterval =>
       Duration(seconds: epochMonitorBaseIntervalSeconds);
 
+  // Version check configuration
+  // If empty, version checking is disabled
+  static const String versionCheckApiUrl =
+      String.fromEnvironment('VERSION_CHECK_API_URL', defaultValue: '');
+  static const int versionCheckIntervalSeconds =
+      int.fromEnvironment('VERSION_CHECK_INTERVAL_SECONDS', defaultValue: 7200);
+
+  static Duration get versionCheckInterval =>
+      Duration(seconds: versionCheckIntervalSeconds);
+  static bool get versionCheckEnabled => versionCheckApiUrl.isNotEmpty;
+
   // Demo accounts configuration (JSON object with account metadata)
   static const String _demoAccountsJson = String.fromEnvironment(
       'DEMO_ACCOUNTS_JSON',

--- a/lib/core/services/app_version_check.dart
+++ b/lib/core/services/app_version_check.dart
@@ -1,0 +1,188 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/core/config/app_config.dart';
+
+final _log = LoggingService.instance.withTag(LogTag.versionCheck);
+
+// =============================================================================
+// API Response Model
+// =============================================================================
+
+enum UpgradeLevel { none, recommended, required }
+
+class VersionCheckResult {
+  final UpgradeLevel upgrade;
+  final String? details;
+  final String? updateUrl;
+
+  const VersionCheckResult({required this.upgrade, this.details, this.updateUrl});
+
+  factory VersionCheckResult.fromJson(Map<String, dynamic> json) {
+    final data = json['data'] as Map<String, dynamic>?;
+    if (data == null) {
+      return const VersionCheckResult(upgrade: UpgradeLevel.none);
+    }
+
+    final upgradeValue = data['upgrade'] as int? ?? 0;
+    return VersionCheckResult(
+      upgrade: UpgradeLevel.values[upgradeValue.clamp(0, 2)],
+      details: data['details'] as String?,
+      updateUrl: data['update_url'] as String?,
+    );
+  }
+
+  bool get shouldShowDialog => upgrade != UpgradeLevel.none;
+  bool get isBlocking => upgrade == UpgradeLevel.required;
+}
+
+// =============================================================================
+// Version Check Service
+// =============================================================================
+
+class AppVersionCheck {
+  AppVersionCheck._();
+  static final instance = AppVersionCheck._();
+
+  Timer? _timer;
+
+  /// Check version and return result (null on error = fail open)
+  /// Returns null if version check is disabled
+  Future<VersionCheckResult?> check() async {
+    if (!AppConfig.versionCheckEnabled) {
+      _log.debug('Version check disabled (no API URL configured)');
+      return null;
+    }
+
+    try {
+      final info = await PackageInfo.fromPlatform();
+      final response = await http
+          .post(
+            Uri.parse(AppConfig.versionCheckApiUrl),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'os': Platform.isIOS ? 'ios' : 'android',
+              'app_version': info.version,
+              'build_number': int.tryParse(info.buildNumber) ?? 1,
+            }),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode != 200) return null;
+
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      _log.info('Version check : $json');
+
+      if (json['success'] != true) return null;
+
+      return VersionCheckResult.fromJson(json);
+    } catch (e) {
+      _log.warn('Version check failed: $e');
+      return null;
+    }
+  }
+
+  /// Start periodic checks using configured interval
+  void startPeriodicChecks(void Function(VersionCheckResult) onResult) {
+    if (!AppConfig.versionCheckEnabled) {
+      _log.debug('Periodic version checks disabled (no API URL configured)');
+      return;
+    }
+
+    _timer?.cancel();
+    _log.debug('Starting periodic version checks every ${AppConfig.versionCheckIntervalSeconds}s');
+    _timer = Timer.periodic(AppConfig.versionCheckInterval, (_) async {
+      final result = await check();
+      if (result != null && result.shouldShowDialog) {
+        onResult(result);
+      }
+    });
+  }
+
+  void stopPeriodicChecks() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  static String get storeUrl => Platform.isIOS
+      ? 'https://apps.apple.com/app/usernode/id0000000000' // TODO: real ID
+      : 'https://play.google.com/store/apps/details?id=com.usernodelabs.crypto_mobile_app';
+}
+
+// =============================================================================
+// Riverpod Provider
+// =============================================================================
+
+/// Provider for initial app version check result
+final appVersionCheckProvider = FutureProvider<VersionCheckResult?>((ref) {
+  return AppVersionCheck.instance.check();
+});
+
+// =============================================================================
+// Update Dialog
+// =============================================================================
+
+/// Shows the appropriate update dialog based on upgrade level
+/// Uses the provided navigatorKey to show the dialog
+Future<void> showUpdateDialog(GlobalKey<NavigatorState> navigatorKey, VersionCheckResult result) {
+  _log.info('showUpdateDialog called with upgrade=${result.upgrade}, isBlocking=${result.isBlocking}');
+  final context = navigatorKey.currentContext;
+  if (context == null) {
+    _log.warn('Navigator context is null, cannot show dialog');
+    return Future.value();
+  }
+  return showDialog(
+    context: context,
+    barrierDismissible: !result.isBlocking,
+    builder: (ctx) {
+      _log.info('Dialog builder called');
+      return _UpdateDialog(result: result);
+    },
+  );
+}
+
+class _UpdateDialog extends StatelessWidget {
+  final VersionCheckResult result;
+
+  const _UpdateDialog({required this.result});
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: !result.isBlocking,
+      child: AlertDialog(
+        title: Text(result.isBlocking ? 'Update Required' : 'Update Available'),
+        content: Text(
+          result.details ?? 'A new version of the app is available.',
+        ),
+        actions: [
+          if (!result.isBlocking)
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Later'),
+            ),
+          FilledButton(
+            onPressed: () => _openStore(),
+            child: const Text('Update'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openStore() async {
+    final urlString = result.updateUrl ?? AppVersionCheck.storeUrl;
+    final url = Uri.parse(urlString);
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    }
+  }
+}

--- a/lib/core/services/app_version_check.dart
+++ b/lib/core/services/app_version_check.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:crypto_mobile_app/core/utils/logger.dart';
@@ -74,7 +75,7 @@ class AppVersionCheck {
               'build_number': int.tryParse(info.buildNumber) ?? 1,
             }),
           )
-          .timeout(const Duration(seconds: 10));
+          .timeout(const Duration(seconds: 3));
 
       if (response.statusCode != 200) return null;
 
@@ -112,6 +113,27 @@ class AppVersionCheck {
     _timer = null;
   }
 
+  // Rate-limiting for recommended updates (max once per day)
+  static const _lastRecommendedDialogKey = 'app:last_recommended_update_dialog';
+  static const _recommendedDialogCooldown = Duration(hours: 24);
+
+  /// Check if enough time has passed to show a recommended update dialog
+  Future<bool> canShowRecommendedDialog() async {
+    final prefs = await SharedPreferences.getInstance();
+    final lastShown = prefs.getInt(_lastRecommendedDialogKey);
+    if (lastShown == null) return true;
+
+    final lastShownTime = DateTime.fromMillisecondsSinceEpoch(lastShown);
+    final elapsed = DateTime.now().difference(lastShownTime);
+    return elapsed >= _recommendedDialogCooldown;
+  }
+
+  /// Record that the recommended update dialog was shown
+  Future<void> markRecommendedDialogShown() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_lastRecommendedDialogKey, DateTime.now().millisecondsSinceEpoch);
+  }
+
   static String get storeUrl => Platform.isIOS
       ? 'https://apps.apple.com/app/usernode/id0000000000' // TODO: real ID
       : 'https://play.google.com/store/apps/details?id=com.usernodelabs.crypto_mobile_app';
@@ -132,14 +154,29 @@ final appVersionCheckProvider = FutureProvider<VersionCheckResult?>((ref) {
 
 /// Shows the appropriate update dialog based on upgrade level
 /// Uses the provided navigatorKey to show the dialog
-Future<void> showUpdateDialog(GlobalKey<NavigatorState> navigatorKey, VersionCheckResult result) {
+/// For recommended updates, rate-limited to once per day
+Future<void> showUpdateDialog(GlobalKey<NavigatorState> navigatorKey, VersionCheckResult result) async {
   _log.info('showUpdateDialog called with upgrade=${result.upgrade}, isBlocking=${result.isBlocking}');
+
+  // Rate-limit recommended updates to once per day
+  if (!result.isBlocking) {
+    final canShow = await AppVersionCheck.instance.canShowRecommendedDialog();
+    if (!canShow) {
+      _log.info('Skipping recommended update dialog (shown within last 24h)');
+      return;
+    }
+    // Mark as shown before showing the dialog
+    await AppVersionCheck.instance.markRecommendedDialogShown();
+  }
+
   final context = navigatorKey.currentContext;
   if (context == null) {
     _log.warn('Navigator context is null, cannot show dialog');
-    return Future.value();
+    return;
   }
-  return showDialog(
+
+  // ignore: use_build_context_synchronously
+  showDialog(
     context: context,
     barrierDismissible: !result.isBlocking,
     builder: (ctx) {

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -497,6 +497,9 @@ enum LogTag {
   /// Produced Blocks Provider
   producedBlocksProvider('PRODUCED_BLOCK_PROVIDER'),
 
+  /// Version checker
+  versionCheck('VERSION_CHECK'),
+
   /// Settings screens
   settings('SETTINGS');
 

--- a/lib/features/metrics/metrics_reporting_service.dart
+++ b/lib/features/metrics/metrics_reporting_service.dart
@@ -308,7 +308,7 @@ class MetricsReportingService {
         body: jsonEncode(jsonPayload),
       )
           .timeout(
-        const Duration(seconds: 10),
+        const Duration(seconds: 3),
         onTimeout: () {
           throw Exception('Metrics request timed out');
         },
@@ -349,7 +349,7 @@ class MetricsReportingService {
         url,
         headers: {'Accept': 'application/json'},
       ).timeout(
-        const Duration(seconds: 5),
+        const Duration(seconds: 3),
         onTimeout: () {
           throw Exception('Health check request timed out');
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:crypto_mobile_app/core/services/background_block_production_orch
 import 'package:crypto_mobile_app/features/wallet/accounts_provider.dart';
 import 'package:crypto_mobile_app/features/node/produced_blocks_provider.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
+import 'package:crypto_mobile_app/core/services/app_version_check.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -130,23 +131,59 @@ class CryptoMobileApp extends ConsumerWidget {
       routerConfig: router,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      builder: (context, child) =>
-          _HotReloadInvalidateProducedBlocks(child: child),
+      builder: (context, child) => _AppWrapper(child: child),
     );
   }
 }
 
-class _HotReloadInvalidateProducedBlocks extends ConsumerStatefulWidget {
-  const _HotReloadInvalidateProducedBlocks({required this.child});
+/// Wrapper that handles version check and hot reload invalidation
+class _AppWrapper extends ConsumerStatefulWidget {
+  const _AppWrapper({required this.child});
   final Widget? child;
 
   @override
-  ConsumerState<_HotReloadInvalidateProducedBlocks> createState() =>
-      _HotReloadInvalidateProducedBlocksState();
+  ConsumerState<_AppWrapper> createState() => _AppWrapperState();
 }
 
-class _HotReloadInvalidateProducedBlocksState
-    extends ConsumerState<_HotReloadInvalidateProducedBlocks> {
+class _AppWrapperState extends ConsumerState<_AppWrapper> {
+  bool _versionCheckShown = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Start periodic version checks
+    AppVersionCheck.instance.startPeriodicChecks(_handleVersionCheckResult);
+    // Check version after first frame
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkInitialVersion());
+  }
+
+  Future<void> _checkInitialVersion() async {
+    final log = LoggingService.instance.withTag(LogTag.versionCheck);
+    log.info('_checkInitialVersion called');
+    try {
+      final result = await ref.read(appVersionCheckProvider.future);
+      log.info('Version check result: $result, shouldShow: ${result?.shouldShowDialog}, shown: $_versionCheckShown, mounted: $mounted');
+      if (result != null && result.shouldShowDialog && !_versionCheckShown && mounted) {
+        _versionCheckShown = true;
+        log.info('Showing update dialog...');
+        showUpdateDialog(appNavigatorKey, result);
+      }
+    } catch (e) {
+      log.error('Error in _checkInitialVersion: $e');
+    }
+  }
+
+  @override
+  void dispose() {
+    AppVersionCheck.instance.stopPeriodicChecks();
+    super.dispose();
+  }
+
+  void _handleVersionCheckResult(VersionCheckResult result) {
+    if (!mounted) return;
+    showUpdateDialog(appNavigatorKey, result);
+  }
+
   @override
   void reassemble() {
     super.reassemble();
@@ -159,3 +196,4 @@ class _HotReloadInvalidateProducedBlocksState
     return widget.child ?? const SizedBox.shrink();
   }
 }
+

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
@@ -20,4 +21,7 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
   sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
   sentry_flutter
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import package_info_plus
 import path_provider_foundation
 import sentry_flutter
 import shared_preferences_foundation
+import url_launcher_macos
 import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -26,5 +27,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1153,6 +1153,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.6"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   connectivity_plus: "^6.0.0"
   permission_handler: "^11.0.0"
   crypto: "^3.0.3"
+  url_launcher: "^6.2.0"
 dev_dependencies:
   flutter_lints: "^5.0.0"
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   BatteryPlusWindowsPluginRegisterWithRegistrar(
@@ -26,4 +27,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   SentryFlutterPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
   permission_handler_windows
   sentry_flutter
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
- Add version check service that calls backend API on app launch and periodically
- Show update dialog (dismissible for recommended, blocking for required updates)
- Support update_url from API response for redirect to app stores
- Make API URL and check interval configurable via environment variables
- Add VERSION_CHECK_API_URL and VERSION_CHECK_INTERVAL_SECONDS to AppConfig
- Update GitHub Actions workflows with PROD/NONPROD secrets
- Upgrade Android Gradle Plugin to 8.9.1 and Gradle to 8.11.1 for url_launcher
- Add url_launcher dependency for opening store URLs