### PR TITLE
Feature/switch chain

### DIFF
--- a/lib/core/config/app_router.dart
+++ b/lib/core/config/app_router.dart
@@ -23,7 +23,7 @@ import 'package:crypto_mobile_app/core/utils/sentry.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.router);
+final _log = LoggingService.instance.withTag('Router');
 
 class AppRoutes {
   // Core routes

--- a/lib/core/data/block_production_state_repository.dart
+++ b/lib/core/data/block_production_state_repository.dart
@@ -4,7 +4,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
 import '../models/block_production_state.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.blockProduction);
+final _log = LoggingService.instance.withTag('BlockProductionStateRepository');
 
 /// Repository for persisting and loading BlockProductionState
 ///

--- a/lib/core/data/block_production_state_repository.dart
+++ b/lib/core/data/block_production_state_repository.dart
@@ -4,7 +4,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
 import '../models/block_production_state.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.blockProduction);
 
 /// Repository for persisting and loading BlockProductionState
 ///

--- a/lib/core/data/slot_production_repository.dart
+++ b/lib/core/data/slot_production_repository.dart
@@ -3,7 +3,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.blockProduction);
 
 /// Repository for persisting and tracking slot production statistics
 ///

--- a/lib/core/data/slot_production_repository.dart
+++ b/lib/core/data/slot_production_repository.dart
@@ -3,7 +3,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.blockProduction);
+final _log = LoggingService.instance.withTag('SlotProductionRepository');
 
 /// Repository for persisting and tracking slot production statistics
 ///

--- a/lib/core/providers/providers.dart
+++ b/lib/core/providers/providers.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.provider);
+final _log = LoggingService.instance.withTag('Providers');
 
 // Derived async providers
 final hasAnyAccountProvider = FutureProvider<bool>((ref) async {

--- a/lib/core/services/android_foreground_keepalive_service.dart
+++ b/lib/core/services/android_foreground_keepalive_service.dart
@@ -4,7 +4,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.blockProduction);
 
 /// Android Foreground Keep-Alive Service
 ///

--- a/lib/core/services/android_foreground_keepalive_service.dart
+++ b/lib/core/services/android_foreground_keepalive_service.dart
@@ -4,7 +4,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.blockProduction);
+final _log = LoggingService.instance.withTag('AndroidForegroundKeepAlive');
 
 /// Android Foreground Keep-Alive Service
 ///

--- a/lib/core/services/app_version_check.dart
+++ b/lib/core/services/app_version_check.dart
@@ -13,7 +13,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/features/metrics/metrics_reporting_service.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.versionCheck);
+final _log = LoggingService.instance.withTag('VersionCheck');
 
 // =============================================================================
 // API Response Model

--- a/lib/core/services/app_version_check.dart
+++ b/lib/core/services/app_version_check.dart
@@ -26,7 +26,8 @@ class VersionCheckResult {
   final String? details;
   final String? updateUrl;
 
-  const VersionCheckResult({required this.upgrade, this.details, this.updateUrl});
+  const VersionCheckResult(
+      {required this.upgrade, this.details, this.updateUrl});
 
   factory VersionCheckResult.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>?;
@@ -100,7 +101,8 @@ class AppVersionCheck {
     }
 
     _timer?.cancel();
-    _log.debug('Starting periodic version checks every ${AppConfig.versionCheckIntervalSeconds}s');
+    _log.debug(
+        'Starting periodic version checks every ${AppConfig.versionCheckIntervalSeconds}s');
     _timer = Timer.periodic(AppConfig.versionCheckInterval, (_) async {
       final result = await check();
       if (result != null && result.shouldShowDialog) {
@@ -132,7 +134,8 @@ class AppVersionCheck {
   /// Record that the recommended update dialog was shown
   Future<void> markRecommendedDialogShown() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_lastRecommendedDialogKey, DateTime.now().millisecondsSinceEpoch);
+    await prefs.setInt(
+        _lastRecommendedDialogKey, DateTime.now().millisecondsSinceEpoch);
   }
 
   static String get storeUrl => Platform.isIOS
@@ -156,8 +159,10 @@ final appVersionCheckProvider = FutureProvider<VersionCheckResult?>((ref) {
 /// Shows the appropriate update dialog based on upgrade level
 /// Uses the provided navigatorKey to show the dialog
 /// For recommended updates, rate-limited to once per day
-Future<void> showUpdateDialog(GlobalKey<NavigatorState> navigatorKey, VersionCheckResult result) async {
-  _log.info('showUpdateDialog called with upgrade=${result.upgrade}, isBlocking=${result.isBlocking}');
+Future<void> showUpdateDialog(
+    GlobalKey<NavigatorState> navigatorKey, VersionCheckResult result) async {
+  _log.info(
+      'showUpdateDialog called with upgrade=${result.upgrade}, isBlocking=${result.isBlocking}');
 
   // Rate-limit recommended updates to once per day
   if (!result.isBlocking) {

--- a/lib/core/services/background_block_production_orchestrator.dart
+++ b/lib/core/services/background_block_production_orchestrator.dart
@@ -14,7 +14,7 @@ import 'platform_alarm_service.dart';
 import 'slot_monitor_service.dart';
 import 'epoch_slot_scheduler_service.dart' as legacy;
 
-final _log = LoggingService.instance.withTag(LogTag.blockProduction);
+final _log = LoggingService.instance.withTag('BlockProduction');
 
 /// Unified orchestrator for background block production
 ///
@@ -81,9 +81,9 @@ class BackgroundBlockProductionOrchestrator {
       _log.debug('Starting epoch monitoring');
       _startEpochMonitoring();
 
-      // Register native event callback
+      // Re-register native event callback (in case it wasn't set early in main.dart)
       _log.debug('Registering native event callback');
-      PlatformAlarmService.instance.setNativeEventCallback(_handleNativeEvent);
+      PlatformAlarmService.instance.setNativeEventCallback(handleNativeEvent);
       _log.debug('Native event callback registered with PlatformAlarmService');
 
       // Perform initial epoch check
@@ -469,8 +469,9 @@ class BackgroundBlockProductionOrchestrator {
 
   /// Handle native events from platform code (Android/iOS)
   ///
-  /// This receives events forwarded from native code via PlatformAlarmService
-  void _handleNativeEvent(String eventType, Map<String, dynamic> eventData) {
+  /// This receives events forwarded from native code via PlatformAlarmService.
+  /// This method is public so it can be registered as a callback early in app startup.
+  void handleNativeEvent(String eventType, Map<String, dynamic> eventData) {
     _log.debug('Handling native event: $eventType with data: $eventData');
 
     try {

--- a/lib/core/services/background_block_production_orchestrator.dart
+++ b/lib/core/services/background_block_production_orchestrator.dart
@@ -14,7 +14,7 @@ import 'platform_alarm_service.dart';
 import 'slot_monitor_service.dart';
 import 'epoch_slot_scheduler_service.dart' as legacy;
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.blockProduction);
 
 /// Unified orchestrator for background block production
 ///

--- a/lib/core/services/epoch_slot_scheduler_service.dart
+++ b/lib/core/services/epoch_slot_scheduler_service.dart
@@ -8,7 +8,7 @@ import '../../features/node/node_service.dart';
 import '../data/slot_production_repository.dart';
 import 'platform_alarm_service.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.blockProduction);
+final _log = LoggingService.instance.withTag('EpochSlotScheduler');
 
 /// Service responsible for epoch-aware scheduling of slot alarms/tasks
 ///

--- a/lib/core/services/epoch_slot_scheduler_service.dart
+++ b/lib/core/services/epoch_slot_scheduler_service.dart
@@ -8,7 +8,7 @@ import '../../features/node/node_service.dart';
 import '../data/slot_production_repository.dart';
 import 'platform_alarm_service.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.blockProduction);
 
 /// Service responsible for epoch-aware scheduling of slot alarms/tasks
 ///

--- a/lib/core/services/ios_foreground_keepalive_service.dart
+++ b/lib/core/services/ios_foreground_keepalive_service.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.blockProduction);
+final _log = LoggingService.instance.withTag('IOSForegroundKeepAlive');
 
 /// iOS Foreground Keep-Alive Service (Tier 1 Strategy)
 ///

--- a/lib/core/services/ios_foreground_keepalive_service.dart
+++ b/lib/core/services/ios_foreground_keepalive_service.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.blockProduction);
 
 /// iOS Foreground Keep-Alive Service (Tier 1 Strategy)
 ///

--- a/lib/core/services/platform_alarm_service.dart
+++ b/lib/core/services/platform_alarm_service.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.alarmService);
 
 /// Callback type for handling boot reschedule events
 typedef BootRescheduleCallback = Future<void> Function();

--- a/lib/core/services/platform_alarm_service.dart
+++ b/lib/core/services/platform_alarm_service.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.alarmService);
+final _log = LoggingService.instance.withTag('AlarmService');
 
 /// Callback type for handling boot reschedule events
 typedef BootRescheduleCallback = Future<void> Function();

--- a/lib/core/services/slot_monitor_service.dart
+++ b/lib/core/services/slot_monitor_service.dart
@@ -4,7 +4,7 @@ import '../../features/node/node_service.dart';
 import '../data/slot_production_repository.dart';
 import 'epoch_slot_scheduler_service.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.slotMonitorService);
+final _log = LoggingService.instance.withTag('SlotMonitorService');
 
 /// Service responsible for monitoring slot production status in real-time
 ///

--- a/lib/core/utils/lifecycle.dart
+++ b/lib/core/utils/lifecycle.dart
@@ -8,7 +8,7 @@ import '../../features/metrics/metrics_collector_service.dart';
 import '../services/background_block_production_orchestrator.dart';
 import '../services/platform_alarm_service.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.lifecycle);
+final _log = LoggingService.instance.withTag('Lifecycle');
 
 /// Enhanced app lifecycle observer with background block production support
 ///

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
@@ -24,101 +27,76 @@ Level _parseLevel(String levelStr) {
   }
 }
 
-/// Parse tag-level overrides from config string (format: tag:level,tag:level)
-Map<LogTag, Level> _parseTagLevels(String config) {
-  if (config.isEmpty) return {};
-  final result = <LogTag, Level>{};
-  for (final entry in config.split(',')) {
-    final parts = entry.trim().split(':');
-    if (parts.length == 2) {
-      final tagName = parts[0].trim().toLowerCase();
-      final level = _parseLevel(parts[1].trim());
-      // Find matching LogTag by value or name (case-insensitive)
-      for (final tag in LogTag.values) {
-        if (tag.value.toLowerCase() == tagName ||
-            tag.name.toLowerCase() == tagName) {
-          result[tag] = level;
-          break;
-        }
-      }
-    }
-  }
-  return result;
-}
-
-/// Application-wide logging facade with enhanced features:
+/// Simple logging service with file output support.
 ///
-/// - Type-safe tags via [LogTag] enum (backward compatible with strings)
-/// - Structured logging with context data
-/// - Per-tag log level control
-/// - Performance timing utilities
-/// - Automatic Sentry integration
-/// - Configurable verbosity via VERBOSE_LOGGING flag
-///
-/// ## Basic Usage:
+/// Usage:
 /// ```dart
-/// LoggingService.instance.trace('Message', tag: LogTag.rust);
-/// LoggingService.instance.info('User action', tag: LogTag.ui, context: {'screen': 'home'});
-/// ```
-///
-/// ## Performance Timing:
-/// ```dart
-/// final timer = LoggingService.instance.startTimer('rpc_call', tag: LogTag.rust);
-/// await performOperation();
-/// timer.stop(); // Auto-logs duration
+/// final _log = LoggingService.instance.withTag('MyClass');
+/// _log.info('Something happened');
 /// ```
 class LoggingService {
-  factory LoggingService({Logger? logger}) {
-    if (logger != null) {
-      return LoggingService._(logger);
-    }
-    return _shared;
-  }
+  LoggingService._(this._logger);
 
-  LoggingService._(Logger logger) : _logger = logger;
-
-  static final LoggingService _shared = LoggingService._(
-    Logger(
-      filter: _AppLogFilter(),
-      printer: _CustomLogPrinter(),
-    ),
-  );
-
-  static LoggingService get instance => _shared;
+  static LoggingService? _instance;
+  static LoggingService get instance => _instance ?? _createDefault();
 
   final Logger _logger;
 
-  // Global log level from config (default: info)
+  // Global log level from config
   static final Level _globalLevel = _parseLevel(AppConfig.logLevel);
 
-  // Per-tag log level overrides from config
-  static final Map<LogTag, Level> _tagLevels =
-      _parseTagLevels(AppConfig.logTagLevels);
+  /// Initialize logging with file output (debug mode only).
+  /// Call this early in main() before any logging.
+  static Future<void> initialize() async {
+    if (_instance != null) return;
 
-  /// Log a trace-level message
-  void trace(String message, {dynamic tag, Map<String, dynamic>? context}) {
+    // Skip file logging in release mode
+    if (kReleaseMode) {
+      _instance = LoggingService._(Logger(
+        filter: _AppLogFilter(),
+        printer: _CustomLogPrinter(),
+      ));
+      return;
+    }
+
+    final fileOutput = FileLogOutput();
+    await fileOutput.init();
+
+    _instance = LoggingService._(Logger(
+      filter: _AppLogFilter(),
+      printer: _CustomLogPrinter(),
+      output: MultiOutput([ConsoleOutput(), fileOutput]),
+    ));
+  }
+
+  /// Create default instance (console only, for early logging before init)
+  static LoggingService _createDefault() {
+    _instance = LoggingService._(Logger(
+      filter: _AppLogFilter(),
+      printer: _CustomLogPrinter(),
+    ));
+    return _instance!;
+  }
+
+  void trace(String message, {String? tag, Map<String, dynamic>? context}) {
     _log(Level.trace, message, tag: tag, context: context);
   }
 
-  /// Log a debug-level message
-  void debug(String message, {dynamic tag, Map<String, dynamic>? context}) {
+  void debug(String message, {String? tag, Map<String, dynamic>? context}) {
     _log(Level.debug, message, tag: tag, context: context);
   }
 
-  /// Log an info-level message
-  void info(String message, {dynamic tag, Map<String, dynamic>? context}) {
+  void info(String message, {String? tag, Map<String, dynamic>? context}) {
     _log(Level.info, message, tag: tag, context: context);
   }
 
-  /// Log a warning-level message
-  void warn(String message, {dynamic tag, Map<String, dynamic>? context}) {
+  void warn(String message, {String? tag, Map<String, dynamic>? context}) {
     _log(Level.warning, message, tag: tag, context: context);
   }
 
-  /// Log an error-level message with optional error object and stack trace
   void error(
     String message, {
-    dynamic tag,
+    String? tag,
     Object? error,
     StackTrace? stackTrace,
     Map<String, dynamic>? context,
@@ -128,56 +106,27 @@ class LoggingService {
 
     // Send to Sentry
     if (error != null && stackTrace != null) {
-      // Fire-and-forget; ignore failures.
       // ignore: discarded_futures
-      SentryUtil.captureError(
-        error,
-        stackTrace,
-        tag: _tagToString(tag),
-        context: context,
-      );
+      SentryUtil.captureError(error, stackTrace, tag: tag, context: context);
     } else {
       SentryUtil.addBreadcrumb(
-        category: _tagToString(tag) ?? 'logging',
+        category: tag ?? 'logging',
         message: message,
         data: context,
       );
     }
   }
 
-  /// Start a performance timer
-  ///
-  /// Returns a [LogTimer] that can be stopped to auto-log the duration.
-  ///
-  /// Example:
-  /// ```dart
-  /// final timer = logger.startTimer('operation', tag: LogTag.performance);
-  /// await doWork();
-  /// timer.stop(context: {'items': 100});
-  /// ```
-  LogTimer startTimer(String name, {dynamic tag}) {
-    return LogTimer._(name, tag ?? LogTag.performance, this);
-  }
-
   /// Create a tagged logger for cleaner per-file usage
-  ///
-  /// Example:
-  /// ```dart
-  /// final _log = LoggingService.instance.withTag(LogTag.node);
-  /// _log.debug('message');  // Automatically tagged with NODE
-  /// ```
-  TaggedLogger withTag(dynamic tag) => TaggedLogger._(tag, this);
+  TaggedLogger withTag(String tag) => TaggedLogger._(tag, this);
 
   void _log(
     Level level,
     String message, {
-    dynamic tag,
+    String? tag,
     Map<String, dynamic>? context,
   }) {
-    // Check if this tag/level should be logged
-    if (!_shouldLog(level, tag)) {
-      return;
-    }
+    if (level.index < _globalLevel.index) return;
 
     final formatted = _decorate(message, tag, context);
 
@@ -190,24 +139,14 @@ class LoggingService {
         _logger.i(formatted);
       case Level.warning:
         _logger.w(formatted);
-      case Level.error:
-      case Level.fatal:
-      case Level.all:
-      case Level.off:
-      // ignore: deprecated_member_use
-      case Level.verbose:
-      // ignore: deprecated_member_use
-      case Level.wtf:
-      // ignore: deprecated_member_use
-      case Level.nothing:
-        // Handled by error() method or should not log
+      default:
         break;
     }
 
-    // Add breadcrumb for non-error logs
+    // Add breadcrumb for info+ logs
     if (level.index >= Level.info.index) {
       SentryUtil.addBreadcrumb(
-        category: _tagToString(tag) ?? 'logging',
+        category: tag ?? 'logging',
         message: message,
         data: context,
         level: _levelToSentryLevel(level),
@@ -215,63 +154,26 @@ class LoggingService {
     }
   }
 
-  bool _shouldLog(Level level, dynamic tag) {
-    // Check tag-specific level override if tag is provided
-    if (tag is LogTag && _tagLevels.containsKey(tag)) {
-      return level.index >= _tagLevels[tag]!.index;
+  String _decorate(String message, String? tag, Map<String, dynamic>? context) {
+    var result = message.trim().isEmpty ? '<empty>' : message.trim();
+
+    if (tag != null && tag.isNotEmpty) {
+      result = '[$tag] $result';
     }
 
-    // Fall back to global log level
-    return level.index >= _globalLevel.index;
-  }
-
-  String _decorate(String message, dynamic tag, Map<String, dynamic>? context) {
-    // Guard against empty messages
-    final trimmedMessage = message.trim();
-    if (trimmedMessage.isEmpty) {
-      message = '<empty log message>';
-      // Add stack trace info in debug mode
-      if (kDebugMode) {
-        try {
-          throw Exception('Empty log detected');
-        } catch (_, stack) {
-          final frames = stack.toString().split('\n').take(3).join('\n');
-          message = '$message\nCalled from:\n$frames';
-        }
-      }
-    } else {
-      message = trimmedMessage;
-    }
-
-    // Add tag prefix
-    final tagStr = _tagToString(tag);
-    if (tagStr != null && tagStr.isNotEmpty) {
-      message = '[$tagStr] $message';
-    }
-
-    // Add context if provided
     if (context != null && context.isNotEmpty) {
       final contextStr =
           context.entries.map((e) => '${e.key}: ${e.value}').join(', ');
-      message = '$message {$contextStr}';
+      result = '$result {$contextStr}';
     }
 
-    return message;
-  }
-
-  String? _tagToString(dynamic tag) {
-    if (tag == null) return null;
-    if (tag is LogTag) return tag.value;
-    if (tag is String) return tag;
-    return tag.toString();
+    return result;
   }
 
   SentryLevel _levelToSentryLevel(Level level) {
     switch (level) {
       case Level.trace:
       case Level.debug:
-      // ignore: deprecated_member_use
-      case Level.verbose:
         return SentryLevel.debug;
       case Level.info:
         return SentryLevel.info;
@@ -279,72 +181,22 @@ class LoggingService {
         return SentryLevel.warning;
       case Level.error:
       case Level.fatal:
-      // ignore: deprecated_member_use
-      case Level.wtf:
         return SentryLevel.fatal;
-      case Level.all:
-      case Level.off:
-      // ignore: deprecated_member_use
-      case Level.nothing:
+      default:
         return SentryLevel.info;
     }
   }
 }
 
-/// Timer for measuring operation duration
-///
-/// Created by [LoggingService.startTimer] and stopped by calling [stop()].
-class LogTimer {
-  LogTimer._(this._name, this._tag, this._logger) : _startTime = DateTime.now();
-
-  final String _name;
-  final dynamic _tag;
-  final LoggingService _logger;
-  final DateTime _startTime;
-  bool _stopped = false;
-
-  /// Stop the timer and log the duration
-  void stop({Map<String, dynamic>? context}) {
-    if (_stopped) {
-      if (kDebugMode) {
-        print('Warning: LogTimer "$_name" stopped multiple times');
-      }
-      return;
-    }
-
-    _stopped = true;
-    final duration = DateTime.now().difference(_startTime);
-    final ms = duration.inMilliseconds;
-
-    final enrichedContext = <String, dynamic>{
-      'duration_ms': ms,
-      ...?context,
-    };
-
-    // Choose log level based on duration (slow operations = warning)
-    if (ms > 1000) {
-      _logger.warn('$_name took ${ms}ms (SLOW)',
-          tag: _tag, context: enrichedContext);
-    } else if (ms > 500) {
-      _logger.info('$_name took ${ms}ms', tag: _tag, context: enrichedContext);
-    } else {
-      _logger.debug('$_name took ${ms}ms', tag: _tag, context: enrichedContext);
-    }
-  }
-
-  /// Get elapsed time without stopping timer
-  Duration get elapsed => DateTime.now().difference(_startTime);
-}
-
-/// Logger wrapper with a pre-bound tag for cleaner per-file usage.
+/// Logger wrapper with a pre-bound tag.
 ///
 /// Usage:
 /// ```dart
-/// final _log = LoggingService.instance.withTag(LogTag.node);
-/// _log.debug('message');  // Automatically tagged with NODE
+/// final _log = LoggingService.instance.withTag('NodeService');
+/// _log.info('message');
 /// ```
 class TaggedLogger {
-  final dynamic _tag;
+  final String _tag;
   final LoggingService _service;
 
   TaggedLogger._(this._tag, this._service);
@@ -374,78 +226,47 @@ class TaggedLogger {
         stackTrace: stackTrace,
         context: context,
       );
-
-  LogTimer startTimer(String name) => _service.startTimer(name, tag: _tag);
 }
 
-/// Custom log filter with environment-based filtering
-///
-/// Level filtering is primarily handled by [LoggingService._shouldLog]
-/// using LOG_LEVEL and LOG_TAG_LEVELS config. This filter adds:
-/// - Release mode restriction (warning+ only)
-/// - Backward compatibility with VERBOSE_LOGGING flag
+/// Log filter - disable all logging in release mode
 class _AppLogFilter extends LogFilter {
   @override
   bool shouldLog(LogEvent event) {
-    // In release builds, only log warnings and errors
-    if (kReleaseMode) {
-      return event.level.index >= Level.warning.index;
-    }
-
-    // In debug/profile mode, level filtering is handled by _shouldLog
-    // using LOG_LEVEL config. Always allow here.
+    if (kReleaseMode) return false;
     return true;
   }
 }
 
-/// Custom log printer with cleaner format
+/// Custom log printer with timestamps
 class _CustomLogPrinter extends LogPrinter {
-  _CustomLogPrinter();
-
-  static final _levelEmojis = {
+  static final _labels = {
     Level.trace: '[TRACE]',
     Level.debug: '[DEBUG]',
     Level.info: '[INFO]',
-    Level.warning: '[WARN] ⚠️',
-    Level.error: '[ERROR] ❌',
-    Level.fatal: '[FATAL] 💀',
+    Level.warning: '[WARN]',
+    Level.error: '[ERROR]',
+    Level.fatal: '[FATAL]',
   };
 
   @override
   List<String> log(LogEvent event) {
-    final message = event.message.toString();
-    final level = event.level;
     final time = DateTime.now();
-    final error = event.error;
-    final stackTrace = event.stackTrace;
-
-    final lines = <String>[];
-
-    // Format: HH:mm:ss.SSS EMOJI Message
     final timeStr = '${time.hour.toString().padLeft(2, '0')}:'
         '${time.minute.toString().padLeft(2, '0')}:'
         '${time.second.toString().padLeft(2, '0')}.'
         '${time.millisecond.toString().padLeft(3, '0')}';
 
-    final emoji = kReleaseMode ? '' : (_levelEmojis[level] ?? '');
-    final prefix = kReleaseMode
-        ? '$timeStr [${level.name.toUpperCase()}]'
-        : '$timeStr $emoji';
+    final label = _labels[event.level] ?? '';
+    final lines = <String>['$timeStr $label ${event.message}'];
 
-    lines.add('$prefix $message');
-
-    // Add error if present
-    if (error != null) {
-      lines.add('  Error: $error');
+    if (event.error != null) {
+      lines.add('  Error: ${event.error}');
     }
 
-    // Add stack trace if present (only for errors)
-    if (stackTrace != null && level.index >= Level.error.index) {
-      final frames = stackTrace.toString().split('\n').take(10);
+    if (event.stackTrace != null && event.level.index >= Level.error.index) {
+      final frames = event.stackTrace.toString().split('\n').take(10);
       for (final frame in frames) {
-        if (frame.trim().isNotEmpty) {
-          lines.add('  $frame');
-        }
+        if (frame.trim().isNotEmpty) lines.add('  $frame');
       }
     }
 
@@ -453,67 +274,58 @@ class _CustomLogPrinter extends LogPrinter {
   }
 }
 
-/// Type-safe logging tags to prevent typos and enable autocomplete.
-///
-/// Usage:
-/// ```dart
-/// LoggingService.instance.trace('Message', tag: LogTag.node);
-/// ```
-///
-/// Backward compatibility: String tags are still supported.
-enum LogTag {
-  bootstrap('BOOTSTRAP'),
-
-  /// Riverpod provider state management
-  provider('PROVIDER'),
-
-  /// Wallet operations (UTXOs, transactions, assets)
-  wallet('WALLET'),
-
-  /// Onboarding flow
-  onboarding('ONBOARDING'),
-
-  /// Node status and peers
-  nodeService('NODE_SERVICE'),
-
-  /// Application lifecycle
-  lifecycle('LIFECYCLE'),
-
-  /// Performance and timing
-  performance('PERF'),
-
-  /// Metrics collection and reporting
-  metrics('METRICS'),
-
-  /// General/uncategorized
-  general('GENERAL'),
-
-  /// App routing
-  router('ROUTER'),
-
-  /// Epoch Rewards Provider
-  epochRewardsProvider('EPOCH_REWARDS_PROVIDER'),
-
-  /// Produced Blocks Provider
-  producedBlocksProvider('PRODUCED_BLOCK_PROVIDER'),
-
-  /// Version checker
-  versionCheck('VERSION_CHECK'),
-
-  slotMonitorService('SLOT_MONITOR_SERVICE'),
-
-  alarmService('ALARM_SERVICE'),
-
-  blockProduction('BLOCK_PRODUCTION'),
-
-  /// Settings screens
-  settings('SETTINGS');
-
-  const LogTag(this.value);
-
-  /// The string value of the tag for logging
-  final String value;
+/// File output - writes logs to app support directory
+class FileLogOutput extends LogOutput {
+  IOSink? _sink;
 
   @override
-  String toString() => value;
+  Future<void> init() async {
+    try {
+      final dir = await getApplicationSupportDirectory();
+      final logDir = Directory('${dir.path}/logs');
+      if (!await logDir.exists()) {
+        await logDir.create(recursive: true);
+      }
+      final file = File('${logDir.path}/app.log');
+      _sink = file.openWrite(mode: FileMode.append);
+      if (kDebugMode) print('Log file: ${file.path}');
+    } catch (e) {
+      if (kDebugMode) print('Failed to init file logging: $e');
+    }
+  }
+
+  @override
+  void output(OutputEvent event) {
+    if (_sink == null) return;
+    for (final line in event.lines) {
+      _sink!.writeln(line);
+    }
+  }
+
+  @override
+  Future<void> destroy() async {
+    await _sink?.flush();
+    await _sink?.close();
+  }
+}
+
+/// Multi-output - writes to multiple outputs
+class MultiOutput extends LogOutput {
+  final List<LogOutput> outputs;
+
+  MultiOutput(this.outputs);
+
+  @override
+  void output(OutputEvent event) {
+    for (final o in outputs) {
+      o.output(event);
+    }
+  }
+
+  @override
+  Future<void> destroy() async {
+    for (final o in outputs) {
+      await o.destroy();
+    }
+  }
 }

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -474,7 +474,7 @@ enum LogTag {
   onboarding('ONBOARDING'),
 
   /// Node status and peers
-  node('NODE'),
+  nodeService('NODE_SERVICE'),
 
   /// Application lifecycle
   lifecycle('LIFECYCLE'),
@@ -501,6 +501,10 @@ enum LogTag {
   versionCheck('VERSION_CHECK'),
 
   slotMonitorService('SLOT_MONITOR_SERVICE'),
+
+  alarmService('ALARM_SERVICE'),
+
+  blockProduction('BLOCK_PRODUCTION'),
 
   /// Settings screens
   settings('SETTINGS');

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -101,19 +101,20 @@ class LoggingService {
     StackTrace? stackTrace,
     Map<String, dynamic>? context,
   }) {
-    final formatted = _decorate(message, tag, context);
-    _logger.e(formatted, error: error, stackTrace: stackTrace);
+    if (!kReleaseMode) {
+      final formatted = _decorate(message, tag, context);
+      _logger.e(formatted, error: error, stackTrace: stackTrace);
+    }
 
-    // Send to Sentry
+    // Send to Sentry - always capture errors, not just breadcrumbs
     if (error != null && stackTrace != null) {
       // ignore: discarded_futures
       SentryUtil.captureError(error, stackTrace, tag: tag, context: context);
     } else {
-      SentryUtil.addBreadcrumb(
-        category: tag ?? 'logging',
-        message: message,
-        data: context,
-      );
+      // Capture as error message even without exception/stackTrace
+      final errorMessage = tag != null ? '[$tag] $message' : message;
+      // ignore: discarded_futures
+      SentryUtil.captureMessage(errorMessage, level: SentryLevel.error);
     }
   }
 
@@ -126,24 +127,25 @@ class LoggingService {
     String? tag,
     Map<String, dynamic>? context,
   }) {
-    if (level.index < _globalLevel.index) return;
+    // Console/file logging (skip in release mode)
+    if (!kReleaseMode && level.index >= _globalLevel.index) {
+      final formatted = _decorate(message, tag, context);
 
-    final formatted = _decorate(message, tag, context);
-
-    switch (level) {
-      case Level.trace:
-        _logger.t(formatted);
-      case Level.debug:
-        _logger.d(formatted);
-      case Level.info:
-        _logger.i(formatted);
-      case Level.warning:
-        _logger.w(formatted);
-      default:
-        break;
+      switch (level) {
+        case Level.trace:
+          _logger.t(formatted);
+        case Level.debug:
+          _logger.d(formatted);
+        case Level.info:
+          _logger.i(formatted);
+        case Level.warning:
+          _logger.w(formatted);
+        default:
+          break;
+      }
     }
 
-    // Add breadcrumb for info+ logs
+    // Add breadcrumb for info+ logs (always, including release mode)
     if (level.index >= Level.info.index) {
       SentryUtil.addBreadcrumb(
         category: tag ?? 'logging',

--- a/lib/features/feedback/feedback_provider.dart
+++ b/lib/features/feedback/feedback_provider.dart
@@ -7,7 +7,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
 import 'models/feedback_model.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.general);
+final _log = LoggingService.instance.withTag('FeedbackProvider');
 
 // State for feedback submission
 enum FeedbackSubmissionStatus {

--- a/lib/features/feedback/github_issue_service.dart
+++ b/lib/features/feedback/github_issue_service.dart
@@ -7,7 +7,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import '../../core/config/app_config.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.general);
+final _log = LoggingService.instance.withTag('GitHubIssueService');
 
 class GitHubIssueService {
   GitHubIssueService();

--- a/lib/features/metrics/metrics_collector_service.dart
+++ b/lib/features/metrics/metrics_collector_service.dart
@@ -19,7 +19,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.metrics);
+final _log = LoggingService.instance.withTag('MetricsCollector');
 
 /// Hashes a device ID using SHA-256 (truncated to 16 chars) for privacy
 String _hashDeviceId(String deviceId) {

--- a/lib/features/metrics/metrics_collector_service.dart
+++ b/lib/features/metrics/metrics_collector_service.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:math' as math;
 
 import 'package:crypto/crypto.dart';
 import 'package:battery_plus/battery_plus.dart';
@@ -10,7 +9,7 @@ import 'package:crypto_mobile_app/core/models/block_production_event.dart';
 import 'package:crypto_mobile_app/features/metrics/models/metrics_payload.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/features/node/node_provider.dart';
-import 'package:crypto_mobile_app/features/node/epoch_rewards_provider.dart';
+import 'package:crypto_mobile_app/features/node/produced_blocks_provider.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -41,6 +40,9 @@ class MetricsCollectorService {
 
   /// Provider container for accessing node status providers
   static ProviderContainer? _container;
+
+  /// Debug: check if container is set
+  bool get hasContainer => _container != null;
 
   /// Track app startup time
   DateTime? _appStartTime;
@@ -121,8 +123,10 @@ class MetricsCollectorService {
       try {
         final rawStatusAsync = _container!.read(nodeStatusProvider);
         rawStatus = rawStatusAsync.valueOrNull;
-      } catch (_) {
-        // Ignore errors, methods will handle null status
+        _log.debug(
+            'nodeStatusProvider: isLoading=${rawStatusAsync.isLoading}, hasValue=${rawStatusAsync.hasValue}, hasError=${rawStatusAsync.hasError}');
+      } catch (e) {
+        _log.warn('Failed to read nodeStatusProvider: $e');
       }
     }
 
@@ -555,6 +559,7 @@ class MetricsCollectorService {
     int? evaluatedCurrentEpoch;
     String? currentEpochVrfEvaluationStatus;
     String? nextEpochVrfEvaluationStatus;
+    double? bpSuccessRate;
 
     if (RustBackendService.instance.isRunning) {
       try {
@@ -579,32 +584,35 @@ class MetricsCollectorService {
           }
         }
 
-        // Get epoch rewards data from provider if available
+        // Get produced blocks data from producedBlocksSummaryProvider (same as Produced Blocks screen)
         if (_container != null) {
-          final rewardsAsync = _container!.read(epochRewardsProvider);
-          final rewards = rewardsAsync.value;
-          if (rewards != null) {
-            // Extract current epoch production metrics
-            currentEpochWonSlots ??= rewards.winsInEpoch;
-            currentEpochProduced = rewards.producedInEpoch;
+          try {
+            final summaryAsync =
+                _container!.read(producedBlocksSummaryProvider);
+            final summary = summaryAsync.valueOrNull;
+            _log.debug(
+                'producedBlocksSummaryProvider: hasValue=${summaryAsync.hasValue}, currentEpoch=${summary?.currentEpoch}');
 
-            // Count future slots (slots that haven't occurred yet)
-            int slotsInFuture = 0;
-            if (currentGlobalSlot != null) {
-              final currentSlot = currentGlobalSlot;
-              slotsInFuture = rewards.wonSlots
-                  .where((slot) => slot.globalSlot > currentSlot)
-                  .length;
+            if (summary != null && summary.epochScores.isNotEmpty) {
+              final summaryCurrentEpoch = summary.currentEpoch;
+              if (summaryCurrentEpoch >= 0 &&
+                  summaryCurrentEpoch < summary.epochScores.length) {
+                final epochScore = summary.epochScores[summaryCurrentEpoch];
+                currentEpochWonSlots ??= epochScore.won;
+                currentEpochProduced = epochScore.produced;
+                currentEpochFailed = epochScore.missed;
+
+                // Calculate bp_success_rate (0-100)
+                final rate = epochScore.evaluatedPercent *
+                    epochScore.producedOfEvaluatedPercent *
+                    100;
+                if (!rate.isNaN && !rate.isInfinite) {
+                  bpSuccessRate = rate.clamp(0.0, 100.0);
+                }
+              }
             }
-
-            // Calculate failed as: won - future - produced
-            // This excludes future slots from being counted as failed
-            // Use max(0, ...) to ensure failed count is never negative
-            currentEpochFailed = math.max(
-                0,
-                (currentEpochWonSlots ?? 0) -
-                    slotsInFuture -
-                    (currentEpochProduced ?? 0));
+          } catch (e) {
+            _log.warn('Failed to read producedBlocksSummaryProvider: $e');
           }
         }
       } catch (_) {
@@ -621,6 +629,7 @@ class MetricsCollectorService {
       evaluatedCurrentEpoch: evaluatedCurrentEpoch,
       currentEpochVrfEvaluationStatus: currentEpochVrfEvaluationStatus,
       nextEpochVrfEvaluationStatus: nextEpochVrfEvaluationStatus,
+      bpSuccessRate: bpSuccessRate,
       // Total metrics not implemented yet
       totalWonSlots: null,
       totalBlocksProduced: null,

--- a/lib/features/metrics/metrics_provider.dart
+++ b/lib/features/metrics/metrics_provider.dart
@@ -9,7 +9,7 @@ import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.metrics);
+final _log = LoggingService.instance.withTag('MetricsProvider');
 
 /// Provider that manages the lifecycle of metrics reporting
 /// Starts metrics service at initialization if enabled in environment

--- a/lib/features/metrics/metrics_reporting_service.dart
+++ b/lib/features/metrics/metrics_reporting_service.dart
@@ -6,6 +6,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/models/block_production_event.dart';
 import 'package:crypto_mobile_app/features/metrics/models/metrics_payload.dart';
 import 'package:crypto_mobile_app/features/metrics/metrics_collector_service.dart';
+import 'package:crypto_mobile_app/features/node/node_service.dart';
 
 final _log = LoggingService.instance.withTag('MetricsReporting');
 
@@ -268,6 +269,9 @@ class MetricsReportingService {
         walletAddress: walletAddress,
       );
 
+      _log.debug(
+          'Collected consensus: epoch=${payload.node.consensus?.currentEpoch}, produced=${payload.node.consensus?.currentEpochProduced}, hasContainer=${MetricsCollectorService.instance.hasContainer}, isRunning=${RustBackendService.instance.isRunning}');
+
       // Fire and forget - send metrics without blocking
       _sendMetricsAsync(payload);
     } catch (e) {
@@ -307,13 +311,8 @@ class MetricsReportingService {
       final url = Uri.parse(AppConfig.metricsEndpoint);
       final jsonPayload = payload.toJson();
 
-      _log.trace(
-        'Sending metrics to API',
-        context: {
-          'url': url.toString(),
-          'peer_id': payload.node.identity.peerId,
-          'node_state': payload.node.status?.nodeState ?? 'unknown',
-        },
+      _log.debug(
+        'Sending metrics to API: ${jsonEncode(jsonPayload)}',
       );
 
       final response = await _httpClient!

--- a/lib/features/metrics/metrics_reporting_service.dart
+++ b/lib/features/metrics/metrics_reporting_service.dart
@@ -7,7 +7,7 @@ import 'package:crypto_mobile_app/core/models/block_production_event.dart';
 import 'package:crypto_mobile_app/features/metrics/models/metrics_payload.dart';
 import 'package:crypto_mobile_app/features/metrics/metrics_collector_service.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.metrics);
+final _log = LoggingService.instance.withTag('MetricsReporting');
 
 /// Callback type for fetching wallet data
 typedef WalletDataCallback = Future<({BigInt? balance, String? address})>

--- a/lib/features/metrics/models/metrics_payload.dart
+++ b/lib/features/metrics/models/metrics_payload.dart
@@ -280,6 +280,7 @@ class ConsensusMetrics with _$ConsensusMetrics {
     int? evaluatedCurrentEpoch,
     String? currentEpochVrfEvaluationStatus,
     String? nextEpochVrfEvaluationStatus,
+    double? bpSuccessRate,
   }) = _ConsensusMetrics;
 
   const ConsensusMetrics._();
@@ -304,6 +305,7 @@ class ConsensusMetrics with _$ConsensusMetrics {
               currentEpochVrfEvaluationStatus,
         if (nextEpochVrfEvaluationStatus != null)
           'next_epoch_vrf_evaluation_status': nextEpochVrfEvaluationStatus,
+        if (bpSuccessRate != null) 'bp_success_rate': bpSuccessRate,
       };
 }
 

--- a/lib/features/metrics/models/metrics_payload.freezed.dart
+++ b/lib/features/metrics/models/metrics_payload.freezed.dart
@@ -2858,6 +2858,7 @@ mixin _$ConsensusMetrics {
       throw _privateConstructorUsedError;
   String? get nextEpochVrfEvaluationStatus =>
       throw _privateConstructorUsedError;
+  double? get bpSuccessRate => throw _privateConstructorUsedError;
 
   /// Create a copy of ConsensusMetrics
   /// with the given fields replaced by the non-null parameter values.
@@ -2883,7 +2884,8 @@ abstract class $ConsensusMetricsCopyWith<$Res> {
       int? totalBlocksFailed,
       int? evaluatedCurrentEpoch,
       String? currentEpochVrfEvaluationStatus,
-      String? nextEpochVrfEvaluationStatus});
+      String? nextEpochVrfEvaluationStatus,
+      double? bpSuccessRate});
 }
 
 /// @nodoc
@@ -2912,6 +2914,7 @@ class _$ConsensusMetricsCopyWithImpl<$Res, $Val extends ConsensusMetrics>
     Object? evaluatedCurrentEpoch = freezed,
     Object? currentEpochVrfEvaluationStatus = freezed,
     Object? nextEpochVrfEvaluationStatus = freezed,
+    Object? bpSuccessRate = freezed,
   }) {
     return _then(_value.copyWith(
       currentEpoch: freezed == currentEpoch
@@ -2959,6 +2962,10 @@ class _$ConsensusMetricsCopyWithImpl<$Res, $Val extends ConsensusMetrics>
           ? _value.nextEpochVrfEvaluationStatus
           : nextEpochVrfEvaluationStatus // ignore: cast_nullable_to_non_nullable
               as String?,
+      bpSuccessRate: freezed == bpSuccessRate
+          ? _value.bpSuccessRate
+          : bpSuccessRate // ignore: cast_nullable_to_non_nullable
+              as double?,
     ) as $Val);
   }
 }
@@ -2982,7 +2989,8 @@ abstract class _$$ConsensusMetricsImplCopyWith<$Res>
       int? totalBlocksFailed,
       int? evaluatedCurrentEpoch,
       String? currentEpochVrfEvaluationStatus,
-      String? nextEpochVrfEvaluationStatus});
+      String? nextEpochVrfEvaluationStatus,
+      double? bpSuccessRate});
 }
 
 /// @nodoc
@@ -3009,6 +3017,7 @@ class __$$ConsensusMetricsImplCopyWithImpl<$Res>
     Object? evaluatedCurrentEpoch = freezed,
     Object? currentEpochVrfEvaluationStatus = freezed,
     Object? nextEpochVrfEvaluationStatus = freezed,
+    Object? bpSuccessRate = freezed,
   }) {
     return _then(_$ConsensusMetricsImpl(
       currentEpoch: freezed == currentEpoch
@@ -3056,6 +3065,10 @@ class __$$ConsensusMetricsImplCopyWithImpl<$Res>
           ? _value.nextEpochVrfEvaluationStatus
           : nextEpochVrfEvaluationStatus // ignore: cast_nullable_to_non_nullable
               as String?,
+      bpSuccessRate: freezed == bpSuccessRate
+          ? _value.bpSuccessRate
+          : bpSuccessRate // ignore: cast_nullable_to_non_nullable
+              as double?,
     ));
   }
 }
@@ -3074,7 +3087,8 @@ class _$ConsensusMetricsImpl extends _ConsensusMetrics {
       this.totalBlocksFailed,
       this.evaluatedCurrentEpoch,
       this.currentEpochVrfEvaluationStatus,
-      this.nextEpochVrfEvaluationStatus})
+      this.nextEpochVrfEvaluationStatus,
+      this.bpSuccessRate})
       : super._();
 
   @override
@@ -3099,10 +3113,12 @@ class _$ConsensusMetricsImpl extends _ConsensusMetrics {
   final String? currentEpochVrfEvaluationStatus;
   @override
   final String? nextEpochVrfEvaluationStatus;
+  @override
+  final double? bpSuccessRate;
 
   @override
   String toString() {
-    return 'ConsensusMetrics(currentEpoch: $currentEpoch, currentGlobalSlot: $currentGlobalSlot, currentEpochWonSlots: $currentEpochWonSlots, currentEpochProduced: $currentEpochProduced, currentEpochFailed: $currentEpochFailed, totalWonSlots: $totalWonSlots, totalBlocksProduced: $totalBlocksProduced, totalBlocksFailed: $totalBlocksFailed, evaluatedCurrentEpoch: $evaluatedCurrentEpoch, currentEpochVrfEvaluationStatus: $currentEpochVrfEvaluationStatus, nextEpochVrfEvaluationStatus: $nextEpochVrfEvaluationStatus)';
+    return 'ConsensusMetrics(currentEpoch: $currentEpoch, currentGlobalSlot: $currentGlobalSlot, currentEpochWonSlots: $currentEpochWonSlots, currentEpochProduced: $currentEpochProduced, currentEpochFailed: $currentEpochFailed, totalWonSlots: $totalWonSlots, totalBlocksProduced: $totalBlocksProduced, totalBlocksFailed: $totalBlocksFailed, evaluatedCurrentEpoch: $evaluatedCurrentEpoch, currentEpochVrfEvaluationStatus: $currentEpochVrfEvaluationStatus, nextEpochVrfEvaluationStatus: $nextEpochVrfEvaluationStatus, bpSuccessRate: $bpSuccessRate)';
   }
 
   @override
@@ -3135,7 +3151,9 @@ class _$ConsensusMetricsImpl extends _ConsensusMetrics {
             (identical(other.nextEpochVrfEvaluationStatus,
                     nextEpochVrfEvaluationStatus) ||
                 other.nextEpochVrfEvaluationStatus ==
-                    nextEpochVrfEvaluationStatus));
+                    nextEpochVrfEvaluationStatus) &&
+            (identical(other.bpSuccessRate, bpSuccessRate) ||
+                other.bpSuccessRate == bpSuccessRate));
   }
 
   @override
@@ -3151,7 +3169,8 @@ class _$ConsensusMetricsImpl extends _ConsensusMetrics {
       totalBlocksFailed,
       evaluatedCurrentEpoch,
       currentEpochVrfEvaluationStatus,
-      nextEpochVrfEvaluationStatus);
+      nextEpochVrfEvaluationStatus,
+      bpSuccessRate);
 
   /// Create a copy of ConsensusMetrics
   /// with the given fields replaced by the non-null parameter values.
@@ -3175,7 +3194,8 @@ abstract class _ConsensusMetrics extends ConsensusMetrics {
       final int? totalBlocksFailed,
       final int? evaluatedCurrentEpoch,
       final String? currentEpochVrfEvaluationStatus,
-      final String? nextEpochVrfEvaluationStatus}) = _$ConsensusMetricsImpl;
+      final String? nextEpochVrfEvaluationStatus,
+      final double? bpSuccessRate}) = _$ConsensusMetricsImpl;
   const _ConsensusMetrics._() : super._();
 
   @override
@@ -3200,6 +3220,8 @@ abstract class _ConsensusMetrics extends ConsensusMetrics {
   String? get currentEpochVrfEvaluationStatus;
   @override
   String? get nextEpochVrfEvaluationStatus;
+  @override
+  double? get bpSuccessRate;
 
   /// Create a copy of ConsensusMetrics
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/features/node/epoch_rewards_provider.dart
+++ b/lib/features/node/epoch_rewards_provider.dart
@@ -166,8 +166,11 @@ class EpochRewardsController extends AsyncNotifier<EpochRewardsState?> {
         return state.value;
       }
 
-      _log.trace(
-        'Received live data: epoch=${rewards.epoch}, earnedSoFar=${rewards.earnedSoFar}, expectedTotal=${rewards.expectedTotal}',
+      _log.info(
+        '[EpochRewards] Backend returned: epoch=${rewards.epoch}, '
+        'producedInEpoch=${rewards.producedInEpoch}, '
+        'winsInEpoch=${rewards.winsInEpoch}, '
+        'wonSlots.length=${rewards.wonSlots?.length ?? 0}',
       );
 
       // Create snapshot for caching

--- a/lib/features/node/epoch_rewards_provider.dart
+++ b/lib/features/node/epoch_rewards_provider.dart
@@ -7,7 +7,7 @@ import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/epoch_rewards.dart
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'node_provider.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.epochRewardsProvider);
+final _log = LoggingService.instance.withTag('EpochRewardsProvider');
 
 // --- Cache data model ---
 

--- a/lib/features/node/node_data_providers.dart
+++ b/lib/features/node/node_data_providers.dart
@@ -6,7 +6,7 @@ import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_blockchain.da
 import 'package:crypto_mobile_app/src/rust/node/builder.dart';
 import 'node_provider.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.nodeService);
+final _log = LoggingService.instance.withTag('NodeDataProviders');
 
 class NodeMempoolController extends AsyncNotifier<RpcListMempoolResp?> {
   @override

--- a/lib/features/node/node_data_providers.dart
+++ b/lib/features/node/node_data_providers.dart
@@ -6,7 +6,7 @@ import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_blockchain.da
 import 'package:crypto_mobile_app/src/rust/node/builder.dart';
 import 'node_provider.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.nodeService);
 
 class NodeMempoolController extends AsyncNotifier<RpcListMempoolResp?> {
   @override

--- a/lib/features/node/node_provider.dart
+++ b/lib/features/node/node_provider.dart
@@ -6,7 +6,7 @@ import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/features/node/models/sync_status.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.nodeService);
+final _log = LoggingService.instance.withTag('NodeProvider');
 
 /// Unified node status state combining raw status, sync status, and best tip
 class NodeStatusState {

--- a/lib/features/node/node_provider.dart
+++ b/lib/features/node/node_provider.dart
@@ -6,7 +6,7 @@ import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/features/node/models/sync_status.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.nodeService);
 
 /// Unified node status state combining raw status, sync status, and best tip
 class NodeStatusState {
@@ -181,7 +181,7 @@ class NodeStatusController extends AsyncNotifier<NodeStatusState?> {
 
   Future<NodeStatusState?> _load() async {
     final stopwatch = Stopwatch()..start();
-    _log.info('NodeStatusProvider: load start');
+    _log.debug('NodeStatusProvider: load start');
 
     try {
       final status = await RustBackendService.instance.getStatus();
@@ -302,101 +302,56 @@ class NodeStatusController extends AsyncNotifier<NodeStatusState?> {
       throw Exception('Failed to load node status $e');
     } finally {
       stopwatch.stop();
-      _log.info(
+      _log.debug(
         'NodeStatusProvider: load completed in ${stopwatch.elapsedMilliseconds} ms',
       );
     }
   }
 
   SyncStatus _calculateSyncStatus(NodeStatusState state) {
-    // Handle null case
     final connectedPeers = state.connectedPeers;
-    if (connectedPeers == 0 || state.peers.isEmpty) {
-      _log.trace(
-        'No peers connected - status: CONNECTING',
-      );
+
+    // Step 1: No connected peers -> Connecting
+    if (connectedPeers == 0) {
+      _log.debug('No connected peers - status: CONNECTING');
       return SyncStatus.connecting();
     }
 
-    // Gather heights
-    final localHeight = state.localBestHeight;
-    final networkSyncHeight = state.networkBestHeight;
-
-    if (localHeight == null) {
-      _log.warn(
-        'No local height available - returning error state',
-      );
-      return SyncStatus.error(message: 'No local blockchain data');
-    }
-
-    // Calculate highest peer height
-    int? highestPeerHeight;
-    try {
-      final peerHeights = state.peers
-          .where((p) => p.bestTipHeight != null)
-          .map((p) => p.bestTipHeight!)
-          .toList();
-
-      if (peerHeights.isNotEmpty) {
-        highestPeerHeight = peerHeights.reduce((a, b) => a > b ? a : b);
-      }
-    } catch (e) {
-      _log.warn(
-        'Error extracting peer heights: $e',
-      );
-    }
-
-    // Determine network height
-    int? networkHeight;
-    if (networkSyncHeight != null || highestPeerHeight != null) {
-      if (networkSyncHeight != null && highestPeerHeight != null) {
-        networkHeight = networkSyncHeight > highestPeerHeight
-            ? networkSyncHeight
-            : highestPeerHeight;
-      } else if (networkSyncHeight != null) {
-        networkHeight = networkSyncHeight;
-      } else if (highestPeerHeight != null) {
-        networkHeight = highestPeerHeight;
-      }
-    } else {
-      _log.trace(
-        'No network height data available - status: CONNECTING',
-      );
-      return SyncStatus.connecting();
-    }
-
-    // Extract applied blocks data
+    // Step 2: Get block data
+    final localHeight = state.localBestHeight ?? 0;
     final appliedBlocks = state.appliedBlocksCount;
     final targetBlocks = state.totalBlocksToApply;
 
-    final confirmedNetworkHeight = networkHeight!;
+    // Calculate network height
+    int? highestPeerHeight;
+    final peerHeights = state.peers
+        .where((p) => p.bestTipHeight != null)
+        .map((p) => p.bestTipHeight!)
+        .toList();
+    if (peerHeights.isNotEmpty) {
+      highestPeerHeight = peerHeights.reduce((a, b) => a > b ? a : b);
+    }
+    final networkHeight =
+        highestPeerHeight ?? state.networkBestHeight ?? localHeight;
 
-    // Determine sync status
-    bool synced;
-    if (appliedBlocks == null || targetBlocks == null) {
-      synced = localHeight >= confirmedNetworkHeight;
+    // Step 3: Check if applied blocks complete
+    bool synced = false;
+    if (appliedBlocks != null && targetBlocks != null) {
+      synced = appliedBlocks >= targetBlocks;
     } else {
-      // Consider synced if caught up to network height OR all queued blocks applied
-      synced = localHeight >= confirmedNetworkHeight ||
-          appliedBlocks >= targetBlocks;
+      synced = localHeight >= networkHeight;
     }
 
     _log.trace(
-      'Sync status calculated: '
-      'local=$localHeight, '
-      'networkSync=$networkSyncHeight, '
-      'highestPeer=$highestPeerHeight, '
-      'network=$confirmedNetworkHeight, '
-      'appliedBlocks=$appliedBlocks, '
-      'targetBlocks=$targetBlocks, '
-      'synced=$synced, '
-      'peers=$connectedPeers',
+      'Sync: connectedPeers=$connectedPeers, '
+      'applied=$appliedBlocks, target=$targetBlocks, synced=$synced',
     );
 
+    // Step 4: Return Synced or Syncing
     if (synced) {
       return SyncStatus.synced(
         localHeight: localHeight,
-        networkHeight: confirmedNetworkHeight,
+        networkHeight: networkHeight,
         connectedPeers: connectedPeers,
         highestPeerHeight: highestPeerHeight,
         appliedBlocks: appliedBlocks,
@@ -405,7 +360,7 @@ class NodeStatusController extends AsyncNotifier<NodeStatusState?> {
     } else {
       return SyncStatus.syncing(
         localHeight: localHeight,
-        networkHeight: confirmedNetworkHeight,
+        networkHeight: networkHeight,
         connectedPeers: connectedPeers,
         highestPeerHeight: highestPeerHeight,
         appliedBlocks: appliedBlocks,

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -25,7 +25,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.nodeService);
 
 /// Parse log level string to TracingLevel enum
 TracingLevel _parseTracingLevel(String level) {

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -25,7 +25,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.nodeService);
+final _log = LoggingService.instance.withTag('NodeService');
 
 /// Parse log level string to TracingLevel enum
 TracingLevel _parseTracingLevel(String level) {

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -90,7 +90,8 @@ class RustBackendService {
         final appSupportDir = await getApplicationSupportDirectory();
         final logDir = '${appSupportDir.path}/logs';
         enableLogging(logLevel: rustLogLevel, outputDir: logDir);
-        _log.info('Rust logging enabled: level=${AppConfig.rustLogLevel}, dir=$logDir');
+        _log.info(
+            'Rust logging enabled: level=${AppConfig.rustLogLevel}, dir=$logDir');
       }
 
       _initialized = true;

--- a/lib/features/node/produced_blocks_provider.dart
+++ b/lib/features/node/produced_blocks_provider.dart
@@ -71,7 +71,7 @@ class EpochScore {
   });
 }
 
-final _log = LoggingService.instance.withTag(LogTag.producedBlocksProvider);
+final _log = LoggingService.instance.withTag('ProducedBlocksProvider');
 
 const _kEpochsWithDataKeyBase = 'node:epochs_with_data';
 const _kProducedBlockMetadataKeyPrefixBase = 'node:produced_block_metadata';

--- a/lib/features/node/screens/node_status_screen.dart
+++ b/lib/features/node/screens/node_status_screen.dart
@@ -45,8 +45,6 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
   int? _bestTipEpoch;
 
   // Cached rewards data
-  int? _producedInEpoch;
-  int? _winsInEpoch;
   BigInt? _rewardPerBlock;
 
   // Cached wallet balance
@@ -156,8 +154,6 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
           // Cache rewards data
           final rewardsData = ref.read(epochRewardsProvider).value;
           if (rewardsData != null) {
-            _producedInEpoch = rewardsData.producedInEpoch;
-            _winsInEpoch = rewardsData.winsInEpoch;
             _rewardPerBlock = rewardsData.rewardPerBlock;
           }
 
@@ -230,7 +226,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
 
               // WALLET BALANCE Section (moved to bottom)
               _buildWalletBalanceCard(context, theme),
-              const SizedBox(height: 8),
+              const SizedBox(height: 20),
 
               // OVERVIEW Section (includes Synchronization details)
               _buildOverviewSection(
@@ -259,10 +255,6 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
         decoration: BoxDecoration(
           color: colorScheme.surfaceBright,
           borderRadius: BorderRadius.circular(20),
-          border: Border.all(
-            color: colorScheme.outlineVariant,
-            width: 1,
-          ),
         ),
         child: Padding(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -285,10 +277,6 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
       decoration: BoxDecoration(
         color: colorScheme.surfaceBright,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-          color: colorScheme.outlineVariant,
-          width: 1,
-        ),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -588,56 +576,6 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
               ),
             ],
           ),
-        ),
-
-        const SizedBox(height: 12),
-
-        // VRF/Slots/Blocks card (full width)
-        Builder(
-          builder: (context) {
-            final produced =
-                ref.read(epochRewardsProvider).value?.producedInEpoch ??
-                    _producedInEpoch ??
-                    0;
-            var wonSlots =
-                ref.read(epochRewardsProvider).value?.wonSlots.length ??
-                    ref.read(epochRewardsProvider).value?.winsInEpoch ??
-                    _winsInEpoch ??
-                    0;
-            if (wonSlots < produced) {
-              wonSlots = produced;
-            }
-
-            final vrfEvaluator =
-                ref.read(nodeStatusProvider).value?.vrfEvaluator;
-            final evaluatedSlots =
-                vrfEvaluator?.details?.evaluatedCurrentEpoch ?? 0;
-            final totalSlotsPerEpoch =
-                ref.read(nodeStatusProvider).value?.slotsInEpoch ?? 0;
-
-            final vrfStatus = vrfEvaluator?.currentEpochVrfEvaluationStatus;
-            final statusText = switch (vrfStatus) {
-              RpcStatusVrfEvaluationStatus.pending => 'Pending',
-              RpcStatusVrfEvaluationStatus.evaluating => 'Evaluating',
-              RpcStatusVrfEvaluationStatus.completed => 'Completed',
-              _ => 'N/A',
-            };
-
-            return _buildMultiLineInfoCard(
-              context,
-              label:
-                  'VRF (Epoch Slots: ${NumberFormat('#,###').format(totalSlotsPerEpoch)} / Status: $statusText)',
-              lines: [
-                'Evaluated Slots: ${NumberFormat('#,###').format(evaluatedSlots)}',
-                'Won Slots: ${NumberFormat('#,###').format(wonSlots)}',
-                'Produced Blocks: ${NumberFormat('#,###').format(produced)}',
-              ],
-              color: colorScheme.tertiary,
-              colorScheme: colorScheme,
-              onTap: () => context.push(AppRoutes.mainNodeWonSlots),
-              useGradient: false,
-            );
-          },
         ),
 
         const SizedBox(height: 12),

--- a/lib/features/node/screens/node_status_screen.dart
+++ b/lib/features/node/screens/node_status_screen.dart
@@ -24,7 +24,7 @@ import 'package:crypto_mobile_app/features/wallet/utxo_provider.dart';
 import 'package:crypto_mobile_app/features/wallet/accounts_provider.dart';
 import 'package:crypto_mobile_app/features/wallet/models/account.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.nodeService);
+final _log = LoggingService.instance.withTag('NodeStatusScreen');
 
 class NodeStatusScreen extends ConsumerStatefulWidget {
   const NodeStatusScreen({super.key});

--- a/lib/features/node/screens/node_status_screen.dart
+++ b/lib/features/node/screens/node_status_screen.dart
@@ -24,7 +24,7 @@ import 'package:crypto_mobile_app/features/wallet/utxo_provider.dart';
 import 'package:crypto_mobile_app/features/wallet/accounts_provider.dart';
 import 'package:crypto_mobile_app/features/wallet/models/account.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.nodeService);
 
 class NodeStatusScreen extends ConsumerStatefulWidget {
   const NodeStatusScreen({super.key});

--- a/lib/features/node/screens/node_won_slots_screen.dart
+++ b/lib/features/node/screens/node_won_slots_screen.dart
@@ -9,7 +9,7 @@ import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/epoch_rewards.dart';
 import 'package:intl/intl.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.blockProduction);
 
 enum SlotStatus { produced, missed, pending }
 

--- a/lib/features/node/screens/node_won_slots_screen.dart
+++ b/lib/features/node/screens/node_won_slots_screen.dart
@@ -9,7 +9,7 @@ import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/epoch_rewards.dart';
 import 'package:intl/intl.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.blockProduction);
+final _log = LoggingService.instance.withTag('NodeWonSlotsScreen');
 
 enum SlotStatus { produced, missed, pending }
 

--- a/lib/features/node/screens/slot_production_stats_screen.dart
+++ b/lib/features/node/screens/slot_production_stats_screen.dart
@@ -5,7 +5,7 @@ import 'package:crypto_mobile_app/core/data/slot_production_repository.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.blockProduction);
+final _log = LoggingService.instance.withTag('SlotProductionStatsScreen');
 
 class SlotProductionStatsScreen extends ConsumerStatefulWidget {
   const SlotProductionStatsScreen({super.key});

--- a/lib/features/node/screens/slot_production_stats_screen.dart
+++ b/lib/features/node/screens/slot_production_stats_screen.dart
@@ -5,7 +5,7 @@ import 'package:crypto_mobile_app/core/data/slot_production_repository.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.node);
+final _log = LoggingService.instance.withTag(LogTag.blockProduction);
 
 class SlotProductionStatsScreen extends ConsumerStatefulWidget {
   const SlotProductionStatsScreen({super.key});

--- a/lib/features/onboarding/data/repositories/registration_repository.dart
+++ b/lib/features/onboarding/data/repositories/registration_repository.dart
@@ -3,7 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.general);
+final _log = LoggingService.instance.withTag('RegistrationRepository');
 
 class RegistrationApiException implements Exception {
   RegistrationApiException(this.statusCode, this.message, {this.body});

--- a/lib/features/onboarding/screens/import_api_account_screen.dart
+++ b/lib/features/onboarding/screens/import_api_account_screen.dart
@@ -10,7 +10,7 @@ import 'package:crypto_mobile_app/core/providers/providers.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.onboarding);
+final _log = LoggingService.instance.withTag('ImportApiAccountScreen');
 
 class OnboardingImportApiAccountScreen extends ConsumerStatefulWidget {
   const OnboardingImportApiAccountScreen({super.key});

--- a/lib/features/settings/screens/background_production_settings_screen.dart
+++ b/lib/features/settings/screens/background_production_settings_screen.dart
@@ -18,7 +18,7 @@ import 'package:crypto_mobile_app/features/node/epoch_rewards_provider.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/core/providers/providers.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.settings);
+final _log = LoggingService.instance.withTag('BackgroundProductionSettings');
 
 class BackgroundProductionSettingsScreen extends ConsumerStatefulWidget {
   const BackgroundProductionSettingsScreen({super.key});

--- a/lib/features/settings/screens/background_production_settings_screen.dart
+++ b/lib/features/settings/screens/background_production_settings_screen.dart
@@ -561,7 +561,6 @@ class _BackgroundProductionSettingsScreenState
       decoration: BoxDecoration(
         color: colorScheme.surfaceBright,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -641,7 +640,6 @@ class _BackgroundProductionSettingsScreenState
       decoration: BoxDecoration(
         color: colorScheme.surfaceBright,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -682,7 +680,6 @@ class _BackgroundProductionSettingsScreenState
       decoration: BoxDecoration(
         color: colorScheme.surfaceBright,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -783,7 +780,6 @@ class _BackgroundProductionSettingsScreenState
       decoration: BoxDecoration(
         color: colorScheme.surfaceBright,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -901,7 +897,6 @@ class _BackgroundProductionSettingsScreenState
       decoration: BoxDecoration(
         color: colorScheme.surfaceBright,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -1061,7 +1056,6 @@ class _BackgroundProductionSettingsScreenState
       decoration: BoxDecoration(
         color: colorScheme.surfaceBright,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -1234,7 +1228,6 @@ class _BackgroundProductionSettingsScreenState
       decoration: BoxDecoration(
         color: colorScheme.surfaceBright,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -1330,7 +1323,6 @@ class _BackgroundProductionSettingsScreenState
       decoration: BoxDecoration(
         color: colorScheme.primaryContainer,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),

--- a/lib/features/wallet/accounts_provider.dart
+++ b/lib/features/wallet/accounts_provider.dart
@@ -7,7 +7,7 @@ import 'package:crypto_mobile_app/src/rust/account.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.wallet);
+final _log = LoggingService.instance.withTag('AccountsProvider');
 
 /// Provider for AccountsRepository - handles account persistence
 final accountsProvider = FutureProvider<AccountsRepository>((ref) async {

--- a/lib/features/wallet/assets_provider.dart
+++ b/lib/features/wallet/assets_provider.dart
@@ -7,7 +7,7 @@ import 'package:crypto_mobile_app/features/wallet/utxo_provider.dart';
 import 'package:crypto_mobile_app/features/wallet/token_registry.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
 
-final _log = LoggingService.instance.withTag(LogTag.wallet);
+final _log = LoggingService.instance.withTag('AssetsProvider');
 
 /// Represents an aggregated asset summary across all UTXOs
 class AssetSummary {

--- a/lib/features/wallet/mempool_provider.dart
+++ b/lib/features/wallet/mempool_provider.dart
@@ -7,7 +7,7 @@ import 'package:crypto_mobile_app/features/wallet/accounts_provider.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_mempool.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as rust_types;
 
-final _log = LoggingService.instance.withTag(LogTag.wallet);
+final _log = LoggingService.instance.withTag('MempoolProvider');
 
 /// Controller that fetches pending transactions from mempool
 class WalletMempoolController extends AsyncNotifier<List<MempoolTxSummary>> {

--- a/lib/features/wallet/transaction_activity_provider.dart
+++ b/lib/features/wallet/transaction_activity_provider.dart
@@ -9,7 +9,7 @@ import 'package:crypto_mobile_app/features/wallet/mempool_provider.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
 
-final _log = LoggingService.instance.withTag(LogTag.wallet);
+final _log = LoggingService.instance.withTag('TransactionActivityProvider');
 
 /// Controller that combines mempool transactions and confirmed UTXOs
 /// into a unified transaction activity list

--- a/lib/features/wallet/utxo_provider.dart
+++ b/lib/features/wallet/utxo_provider.dart
@@ -7,7 +7,7 @@ import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_utxos_by_owne
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as rust_types;
 import 'package:crypto_mobile_app/features/wallet/accounts_provider.dart';
 
-final _log = LoggingService.instance.withTag(LogTag.wallet);
+final _log = LoggingService.instance.withTag('UtxoProvider');
 
 class WalletUtxosController extends AsyncNotifier<List<OwnedUtxo>> {
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,9 @@ Future<void> main() async {
     final hasAnyAccounts = await repo.hasAny();
     log.info('hasAnyAccounts: $hasAnyAccounts');
 
+    // Initialize metrics collector early so it has the container before UI starts
+    MetricsCollectorService.instance.initialize(container);
+
     // Render UI immediately; perform heavy bootstrap asynchronously.
     log.info('Running app UI');
 
@@ -102,10 +105,6 @@ Future<void> _bootstrapAsync(
         started ? 'backend startNode: started' : 'backend startNode: skipped',
       );
     }
-
-    // Initialize metrics collection service
-    log.info('Initializing metrics collection service');
-    MetricsCollectorService.instance.initialize(container);
 
     // Initialize background block production orchestrator
     log.info('Initializing background block production orchestrator');
@@ -173,8 +172,12 @@ class _AppWrapperState extends ConsumerState<_AppWrapper> {
     log.info('_checkInitialVersion called');
     try {
       final result = await ref.read(appVersionCheckProvider.future);
-      log.info('Version check result: $result, shouldShow: ${result?.shouldShowDialog}, shown: $_versionCheckShown, mounted: $mounted');
-      if (result != null && result.shouldShowDialog && !_versionCheckShown && mounted) {
+      log.info(
+          'Version check result: $result, shouldShow: ${result?.shouldShowDialog}, shown: $_versionCheckShown, mounted: $mounted');
+      if (result != null &&
+          result.shouldShowDialog &&
+          !_versionCheckShown &&
+          mounted) {
         _versionCheckShown = true;
         log.info('Showing update dialog...');
         showUpdateDialog(appNavigatorKey, result);
@@ -207,4 +210,3 @@ class _AppWrapperState extends ConsumerState<_AppWrapper> {
     return widget.child ?? const SizedBox.shrink();
   }
 }
-

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:crypto_mobile_app/core/providers/providers.dart';
 import 'package:crypto_mobile_app/features/metrics/metrics_collector_service.dart';
 import 'package:crypto_mobile_app/features/metrics/metrics_provider.dart';
 import 'package:crypto_mobile_app/core/services/background_block_production_orchestrator.dart';
+import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/features/wallet/accounts_provider.dart';
 import 'package:crypto_mobile_app/features/node/produced_blocks_provider.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
@@ -33,7 +34,17 @@ Future<void> main() async {
     DeviceOrientation.portraitDown,
   ]);
 
-  final log = LoggingService.instance.withTag(LogTag.bootstrap);
+  // Initialize logging with file output
+  await LoggingService.initialize();
+
+  // Initialize platform alarm service early to capture native events
+  // The callback is registered now so iOS notification events aren't lost
+  await PlatformAlarmService.instance.initialize();
+  PlatformAlarmService.instance.setNativeEventCallback(
+    BackgroundBlockProductionOrchestrator.instance.handleNativeEvent,
+  );
+
+  final log = LoggingService.instance.withTag('Bootstrap');
 
   await SentryUtil.bootstrap(() async {
     SentryUtil.addBreadcrumb(category: 'app', message: 'startup begin');
@@ -158,7 +169,7 @@ class _AppWrapperState extends ConsumerState<_AppWrapper> {
   }
 
   Future<void> _checkInitialVersion() async {
-    final log = LoggingService.instance.withTag(LogTag.versionCheck);
+    final log = LoggingService.instance.withTag('VersionCheck');
     log.info('_checkInitialVersion called');
     try {
       final result = await ref.read(appVersionCheckProvider.future);


### PR DESCRIPTION
- Simplify _calculateSyncStatus to use clearer logic:
  - 0 connected peers -> Connecting
  - 1+ connected peers with incomplete blocks -> Syncing
  - 1+ connected peers with complete blocks -> Synced
- Remove intermediate error states and unnecessary fallbacks
- Update log tag from node to nodeService for consistency
- Change verbose status logs from info to debug level
- Simplify LoggingService from 520 to 330 lines
- Remove LogTag enum, use string tags instead
- Remove LogTimer and per-tag level filtering
- Add file logging to {app_support}/logs/app.log
- Disable all logging in release mode
- Keep Sentry integration and custom formatting