### PR TITLE
Remove persistent P2P identity and disable Rust logging in release mode

### DIFF
--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:io' show Platform;
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart' show kReleaseMode;
+
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/block_producer_status.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_mempool.dart';
@@ -100,8 +102,8 @@ class RustBackendService {
             : null,
       );
 
-      // Enable Rust-side logging only if RUST_LOG_LEVEL is explicitly set
-      if (AppConfig.rustLogLevel.isNotEmpty) {
+      // Enable Rust-side logging only if RUST_LOG_LEVEL is explicitly set and not in release mode
+      if (!kReleaseMode && AppConfig.rustLogLevel.isNotEmpty) {
         final rustLogLevel = _parseTracingLevel(AppConfig.rustLogLevel);
         final appSupportDir = await getApplicationSupportDirectory();
         final logDir = '${appSupportDir.path}/logs';
@@ -219,19 +221,6 @@ class RustBackendService {
       );
       builder.blockProducerHex(skHex: privateKeyHex);
       builder.mempoolAutoinsertInterval(secs: BigInt.from(1));
-
-      // Configure persistent P2P identity
-      String? p2pSecretKeyStr = await repo.getP2pSecretKey(account.id);
-      if (p2pSecretKeyStr == null) {
-        // First run: generate and save P2P key
-        _log.info('Generating new P2P identity for account ${account.id}');
-        p2pSecretKeyStr = builder.p2PSecKeyStr();
-        await repo.saveP2pSecretKey(account.id, p2pSecretKeyStr);
-      } else {
-        // Subsequent runs: use stored key
-        _log.trace('Using stored P2P identity');
-        builder.p2PSecKeyFromStr(key: p2pSecretKeyStr);
-      }
 
       // Configure persistent VRF storage path so VRF evaluation progress survives restarts.
       // Use network-specific path to avoid conflicts when switching networks.

--- a/lib/features/wallet/accounts_provider.dart
+++ b/lib/features/wallet/accounts_provider.dart
@@ -101,42 +101,6 @@ class AccountsRepository {
     }
   }
 
-  /// Get the P2P secret key for a specific account from secure storage
-  Future<String?> getP2pSecretKey(String accountId) async {
-    try {
-      final key = '$_network:p2p:$accountId:p2pSecretKey';
-      return await _secure.read(key: key);
-    } catch (e, st) {
-      _log.error('Failed to read P2P secret key for account $accountId',
-          error: e, stackTrace: st);
-      return null;
-    }
-  }
-
-  /// Save P2P secret key to secure storage
-  Future<void> saveP2pSecretKey(String accountId, String secretKeyStr) async {
-    try {
-      final key = '$_network:p2p:$accountId:p2pSecretKey';
-      await _secure.write(key: key, value: secretKeyStr);
-      _log.debug('Saved P2P secret key for account $accountId');
-    } catch (e, st) {
-      _log.error('Failed to save P2P secret key for account $accountId',
-          error: e, stackTrace: st);
-      rethrow;
-    }
-  }
-
-  /// Delete P2P secret key from secure storage
-  Future<void> deleteP2pSecretKey(String accountId) async {
-    try {
-      final key = '$_network:p2p:$accountId:p2pSecretKey';
-      await _secure.delete(key: key);
-    } catch (e, st) {
-      _log.error('Failed to delete P2P secret key for account $accountId',
-          error: e, stackTrace: st);
-    }
-  }
-
   /// Import an account from a hex-encoded private key.
   Future<AccountMeta?> importFromPrivateKey({
     required String name,


### PR DESCRIPTION
- Remove P2P secret key storage/retrieval; let node generate fresh peerID on each start
- Disable Rust-side logging (enableLogging) in release builds