### PR TITLE
Add visual network indicator with bottom navigation color changes

### DIFF
--- a/lib/core/config/theme.dart
+++ b/lib/core/config/theme.dart
@@ -19,6 +19,12 @@ class MaterialTheme {
   static const Color greyDark = Color(0xFF78909C);
   static const Color deactivatedTextDark = Color(0xFF9E9E9E);
 
+  // Internal network colors (amber/warm theme)
+  static const Color internalNetworkLightBackground = Color(0xFFFFF4E6);
+  static const Color internalNetworkLightBorder = Color(0xFFE5C878);
+  static const Color internalNetworkDarkBackground = Color(0xFF3D2914);
+  static const Color internalNetworkDarkBorder = Color(0xFF8B7355);
+
   static ColorScheme lightScheme() {
     return const ColorScheme(
       brightness: Brightness.light,
@@ -347,6 +353,15 @@ class MaterialTheme {
 
   ThemeData darkHighContrast() {
     return theme(darkHighContrastScheme());
+  }
+
+  // Helper methods for internal network colors
+  static Color getInternalNetworkBackgroundColor(bool isDark) {
+    return isDark ? internalNetworkDarkBackground : internalNetworkLightBackground;
+  }
+
+  static Color getInternalNetworkBorderColor(bool isDark) {
+    return isDark ? internalNetworkDarkBorder : internalNetworkLightBorder;
   }
 
   ThemeData theme(ColorScheme colorScheme) => ThemeData(

--- a/lib/core/providers/providers.dart
+++ b/lib/core/providers/providers.dart
@@ -94,3 +94,34 @@ final themeModeProvider =
     StateNotifierProvider<ThemeModeController, ThemeMode>((ref) {
   return ThemeModeController();
 });
+
+// Current network provider for reactive network state tracking
+class CurrentNetworkController extends StateNotifier<String> {
+  CurrentNetworkController() : super('testnet') {
+    _init();
+  }
+
+  Future<void> _init() async {
+    // Initialize from cached network value
+    state = NetworkPrefs.currentNetwork;
+  }
+
+  Future<void> refresh() async {
+    // Force refresh from SharedPreferences 
+    final newNetwork = await NetworkPrefs.getNetwork();
+    if (mounted) {
+      state = newNetwork;
+    }
+  }
+
+  void updateNetwork(String network) {
+    if (mounted) {
+      state = network;
+    }
+  }
+}
+
+final currentNetworkProvider =
+    StateNotifierProvider<CurrentNetworkController, String>((ref) {
+  return CurrentNetworkController();
+});

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -5,6 +5,8 @@ import 'package:crypto_mobile_app/features/node/screens/node_status_screen.dart'
 import 'package:crypto_mobile_app/features/settings/screens/background_production_settings_screen.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
+import 'package:crypto_mobile_app/core/providers/providers.dart';
+import 'package:crypto_mobile_app/core/config/theme.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -30,6 +32,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final currentNetwork = ref.watch(currentNetworkProvider);
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    
+    // Conditional colors based on network
+    final backgroundColor = currentNetwork == 'internal'
+        ? MaterialTheme.getInternalNetworkBackgroundColor(isDark)
+        : theme.colorScheme.surfaceBright;
+    
+    final borderColor = currentNetwork == 'internal'
+        ? MaterialTheme.getInternalNetworkBorderColor(isDark)
+        : theme.colorScheme.outlineVariant;
 
     return Scaffold(
       body: IndexedStack(
@@ -42,10 +56,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ),
       bottomNavigationBar: Container(
         decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surfaceBright,
+          color: backgroundColor,
           border: Border(
             top: BorderSide(
-              color: Theme.of(context).colorScheme.outlineVariant,
+              color: borderColor,
               width: 1,
             ),
           ),


### PR DESCRIPTION
- Implement distinctive amber theme for Internal network bottom navigation
- Keep Testnet appearance unchanged with existing blue theme
- Add reactive network state provider for real-time UI updates
- Support both light and dark modes with appropriate color variants