### PR TITLE
config: set default log levels to warning for production readiness

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -32,16 +32,16 @@ class AppConfig {
   // Logging configuration
   // Global log level (trace, debug, info, warning, error)
   static const String logLevel =
-      String.fromEnvironment('LOG_LEVEL', defaultValue: 'info');
+      String.fromEnvironment('LOG_LEVEL', defaultValue: 'warning');
 
   // Per-tag log level overrides (format: tag:level,tag:level)
   static const String logTagLevels =
       String.fromEnvironment('LOG_TAG_LEVELS', defaultValue: '');
 
   // Rust-side log level (trace, debug, info, warn, error)
-  // If not set, Rust logging is disabled
+  // Default to warn level for production readiness
   static const String rustLogLevel =
-      String.fromEnvironment('RUST_LOG_LEVEL', defaultValue: '');
+      String.fromEnvironment('RUST_LOG_LEVEL', defaultValue: 'warn');
 
   static AppConfig get instance => AppConfig._(
         environment: _env,


### PR DESCRIPTION
- Change Flutter LOG_LEVEL default from 'info' to 'warning'
- Change Rust RUST_LOG_LEVEL default from disabled to 'warn'
- Reduce log noise in production builds while maintaining error visibility
- Developers can still override with environment variables for debugging
- Improve app performance by reducing unnecessary logging overhead