### PR TITLE
fix: migrate account secrets to bech32m

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -93,23 +93,23 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/wakelock_plus/ios"
 
 SPEC CHECKSUMS:
-  battery_plus: 34f72fa2afeeea83bbae306c72a25828d3ec727a
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
-  device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
+  battery_plus: b42253f6d2dde71712f8c36fef456d99121c5977
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
+  device_info_plus: 335f3ce08d2e174b9fdc3db3db0f4e3b1f66bd89
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  objective_c: 77e887b5ba1827970907e10e832eec1683f3431d
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  rust_lib_crypto_mobile_app: b14c41db44a5333f6b460d8e38f59b2bf5070e20
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  objective_c: 89e720c30d716b036faf9c9684022048eee1eee2
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  rust_lib_crypto_mobile_app: 0097bc2ea6160d2db5cb396a7d4132173623e336
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
-  sentry_flutter: b71c80b7a071cc42af82576046ff2db19fc12f57
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
-  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
+  sentry_flutter: 7f88e12d1882ec6e648644a7c0ff5b1466f07f99
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 
 PODFILE CHECKSUM: 88878223b39aac3d382e587cc8966c435961b27b
 

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -198,25 +198,37 @@ class AppConfig {
 
 /// Demo account model with metadata
 class DemoAccount {
-  final String secretKeyHex;
-  final String publicKeyHex;
-  final String publicKeyHashBech32m;
+  final String secretKey;
+  final String publicKey;
+  final String address;
   final int amount;
   final String tier;
 
   DemoAccount({
-    required this.secretKeyHex,
-    required this.publicKeyHex,
-    required this.publicKeyHashBech32m,
+    required this.secretKey,
+    required this.publicKey,
+    required this.address,
     required this.amount,
     required this.tier,
   });
 
   factory DemoAccount.fromJson(Map<String, dynamic> json) {
+    String requiredString(List<String> keys) {
+      for (final key in keys) {
+        final value = json[key];
+        if (value is String && value.isNotEmpty) return value;
+      }
+      throw FormatException('Missing required field: ${keys.join(' or ')}');
+    }
+
     return DemoAccount(
-      secretKeyHex: json['secret_key_hex'] as String,
-      publicKeyHex: json['public_key_hex'] as String,
-      publicKeyHashBech32m: json['public_key_hash_bech32m'] as String,
+      secretKey: requiredString(['secret_key', 'secret_key_hex']),
+      publicKey: requiredString(['public_key', 'public_key_hex']),
+      address: requiredString([
+        'address',
+        'public_key_hash_bech32m',
+        'public_key_hash',
+      ]),
       amount: json['amount'] as int,
       tier: json['tier'] as String,
     );

--- a/lib/core/widgets/produced_block_card.dart
+++ b/lib/core/widgets/produced_block_card.dart
@@ -45,7 +45,7 @@ class ProducedBlockCard extends StatelessWidget {
 
     String producerPubkey;
     try {
-      producerPubkey = customProducer ?? block.producerPubkey;
+      producerPubkey = customProducer ?? block.producerPubkey.toString();
     } catch (_) {
       producerPubkey = '';
     }

--- a/lib/features/node/node_data_providers.dart
+++ b/lib/features/node/node_data_providers.dart
@@ -3,7 +3,7 @@ import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_mempool.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_blockchain.dart';
-import 'package:crypto_mobile_app/src/rust/node/builder.dart';
+import 'package:crypto_mobile_app/src/rust/frb_types.dart';
 import 'node_provider.dart';
 
 final _log = LoggingService.instance.withTag('usernode/NodeDataProviders');

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -15,6 +15,7 @@ import 'package:crypto_mobile_app/features/wallet/accounts_provider.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:crypto_mobile_app/src/rust/frb_generated.dart';
+import 'package:crypto_mobile_app/src/rust/frb_types.dart';
 import 'package:crypto_mobile_app/src/rust/lib.dart' show enableLogging;
 import 'package:crypto_mobile_app/src/rust/tracing.dart' show TracingLevel;
 import 'package:crypto_mobile_app/src/rust/node.dart';
@@ -141,7 +142,7 @@ class RustBackendService {
     }
   }
 
-  /// Start the node using the active account's private key.
+  /// Start the node using the active account's secret key.
   /// Returns true if started successfully, false if no account or error.
   /// Safe to call multiple times; subsequent calls return true if already running.
   Future<bool> startNode({int? httpPort}) async {
@@ -180,23 +181,23 @@ class RustBackendService {
 
     _log.debug('Active account: ${account.id} (${account.name})');
 
-    // Get private key for active account
-    _log.trace('Retrieving private key for account ${account.id}...');
-    final privateKeyHex = await repo.getPrivateKey(account.id);
+    // Get secret key for active account
+    _log.trace('Retrieving secret key for account ${account.id}...');
+    final secretKey = await repo.getSecretKey(account.id);
 
-    if (privateKeyHex == null || privateKeyHex.isEmpty) {
+    if (secretKey == null || secretKey.isEmpty) {
       _log.error(
-        'Cannot start node: private key unavailable for account ${account.id}',
+        'Cannot start node: secret key unavailable for account ${account.id}',
       );
       await SentryUtil.captureMessage(
-        'Node start failed: private key unavailable',
+        'Node start failed: secret key unavailable',
         level: SentryLevel.error,
       );
       return false;
     }
 
     // SECURITY: Only log key length, not value
-    _log.trace('Private key retrieved (length: ${privateKeyHex.length})');
+    _log.trace('Secret key retrieved (length: ${secretKey.length})');
 
     // Start node
     try {
@@ -216,9 +217,9 @@ class RustBackendService {
       await _configureNetworkFromUrls(builder);
 
       _log.trace(
-        'Configuring block producer with user private key (length: ${privateKeyHex.length})',
+        'Configuring block producer with user secret key (length: ${secretKey.length})',
       );
-      builder.blockProducerHex(skHex: privateKeyHex);
+      builder.blockProducerSecretKey(secretKey: secretKey);
       builder.mempoolAutoinsertInterval(secs: BigInt.from(1));
 
       // Configure persistent VRF storage path so VRF evaluation progress survives restarts.
@@ -250,11 +251,12 @@ class RustBackendService {
       try {
         _log.debug('Configuring wallet signer for account ${account.id}...');
         final signerResponse = await _rpc!.walletSetSignerFromSecret(
-          secretKeyHex: privateKeyHex,
+          secretKey: secretKey,
         );
-        
+
         if (signerResponse != null && signerResponse.ok) {
-          _log.info('Wallet signer configured successfully for account ${account.id}');
+          _log.info(
+              'Wallet signer configured successfully for account ${account.id}');
         } else {
           final error = signerResponse?.error ?? 'Unknown error';
           _log.warn('Failed to configure wallet signer: $error');
@@ -449,7 +451,7 @@ class RustBackendService {
               'height': bestTip.height,
               'global_slot': bestTip.globalSlot,
               'epoch': bestTip.epoch,
-              'producer_pubkey': bestTip.producerPubkey,
+              'producer_pubkey': bestTip.producerPubkey.toString(),
               'transactions': bestTip.transactions.toString(),
               'batches': bestTip.batches
                   .map((b) => {
@@ -465,7 +467,7 @@ class RustBackendService {
                         'height': syncBlocks.bestTip.height,
                         'global_slot': syncBlocks.bestTip.globalSlot,
                         'epoch': syncBlocks.bestTip.epoch,
-                        'producer_pubkey': syncBlocks.bestTip.producerPubkey,
+                        'producer_pubkey': syncBlocks.bestTip.producerPubkey.toString(),
                         'transactions':
                             syncBlocks.bestTip.transactions.toString(),
                         'batches': syncBlocks.bestTip.batches
@@ -633,7 +635,7 @@ class RustBackendService {
                 'epoch': block.epoch,
                 'globalSlot': block.globalSlot,
                 'hash': block.hash.toString(),
-                'producerPubkey': block.producerPubkey,
+                'producerPubkey': block.producerPubkey.toString(),
                 'batches': block.batches.length,
                 'batchTransactions': block.batches
                     .map((b) => b.transactions.toString())
@@ -806,7 +808,7 @@ class RustBackendService {
       final winsInEpoch = rewards?.winsInEpoch ?? 0;
       final earnedSoFar = rewards?.earnedSoFar ?? BigInt.zero;
       final expectedTotal = rewards?.expectedTotal ?? BigInt.zero;
-      final producerPubkey = rewards?.producerPubkey;
+      final producerPubkey = rewards?.producerPubkey?.toString();
       final wonSlots = rewards?.wonSlots;
 
       // Build detailed won slots list

--- a/lib/features/node/screens/block_details_screen.dart
+++ b/lib/features/node/screens/block_details_screen.dart
@@ -236,9 +236,17 @@ class _BlockDetailsScreenState extends State<BlockDetailsScreen> {
                   const SizedBox(height: 12),
                   _InfoRow(
                     label: l10n.blockProducer,
-                    value: block.producerPubkey.length > 24
-                        ? '${block.producerPubkey.substring(0, 24)}...'
-                        : block.producerPubkey,
+                    value: (() {
+                      String producer;
+                      try {
+                        producer = block.producerPubkey.toString();
+                      } catch (_) {
+                        producer = '';
+                      }
+                      return producer.length > 24
+                          ? '${producer.substring(0, 24)}...'
+                          : producer;
+                    })(),
                   ),
                   const SizedBox(height: 12),
                   _InfoRow(

--- a/lib/features/node/screens/node_status_screen.dart
+++ b/lib/features/node/screens/node_status_screen.dart
@@ -2092,7 +2092,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
 
         String producerPubkey;
         try {
-          producerPubkey = block.producerPubkey;
+          producerPubkey = block.producerPubkey.toString();
         } catch (e) {
           producerPubkey = '';
         }

--- a/lib/features/onboarding/data/repositories/registration_repository.dart
+++ b/lib/features/onboarding/data/repositories/registration_repository.dart
@@ -141,33 +141,46 @@ class RegistrationRepository {
 
 class RegistrationResult {
   RegistrationResult({
-    required this.identityUidHex,
-    required this.publicKeyHex,
-    required this.publicKeyHashBech32m,
+    required this.identityUid,
+    required this.publicKey,
+    required this.address,
     required this.tier,
-    required this.secretKeyHex,
+    required this.secretKey,
     this.phaseId,
     this.phaseName,
     this.phaseEndsAt,
   });
 
-  final String identityUidHex;
-  final String publicKeyHex;
-  final String publicKeyHashBech32m;
+  final String identityUid;
+  final String publicKey;
+  final String address;
   final String tier;
-  final String secretKeyHex;
+  final String secretKey;
   final int? phaseId;
   final String? phaseName;
   final String? phaseEndsAt;
 
   factory RegistrationResult.fromJson(Map<String, dynamic> json) {
     final phase = json['phase'];
+
+    String requiredString(List<String> keys) {
+      for (final key in keys) {
+        final value = json[key];
+        if (value is String && value.isNotEmpty) return value;
+      }
+      throw FormatException('Missing required field: ${keys.join(' or ')}');
+    }
+
     return RegistrationResult(
-      identityUidHex: json['identity_uid_hex'] as String,
-      publicKeyHex: json['public_key_hex'] as String,
-      publicKeyHashBech32m: json['public_key_hash_bech32m'] as String,
+      identityUid: requiredString(['identity_uid', 'identity_uid_hex']),
+      publicKey: requiredString(['public_key', 'public_key_hex']),
+      address: requiredString([
+        'address',
+        'public_key_hash_bech32m',
+        'public_key_hash',
+      ]),
       tier: json['tier'] as String,
-      secretKeyHex: json['secret_key_hex'] as String,
+      secretKey: requiredString(['secret_key', 'secret_key_hex']),
       phaseId: phase is Map<String, dynamic> ? phase['id'] as int? : null,
       phaseName:
           phase is Map<String, dynamic> ? phase['name'] as String? : null,

--- a/lib/features/onboarding/screens/import_api_account_screen.dart
+++ b/lib/features/onboarding/screens/import_api_account_screen.dart
@@ -58,13 +58,12 @@ class _OnboardingImportApiAccountScreenState
       final contact = _contactController.text.trim();
       final activationCode = _activationCodeController.text.trim();
 
-      final privateKeyHex =
-          await _requestPrivateKeyFromApi(contact, activationCode);
+      final secretKey = await _requestSecretKeyFromApi(contact, activationCode);
 
       final repo = await AccountsRepository.create();
-      final result = await repo.importFromPrivateKey(
+      final result = await repo.importFromSecretKey(
         name: 'API Account',
-        privateKeyHex: privateKeyHex,
+        secretKey: secretKey,
       );
 
       if (!mounted) return;
@@ -110,11 +109,11 @@ class _OnboardingImportApiAccountScreenState
     }
   }
 
-  Future<String> _requestPrivateKeyFromApi(String contact, String code) async {
+  Future<String> _requestSecretKeyFromApi(String contact, String code) async {
     final repo = RegistrationRepository();
     final result =
         await repo.register(registrationCode: code, identifier: contact);
-    return result.secretKeyHex;
+    return result.secretKey;
   }
 
   @override

--- a/lib/features/wallet/accounts_provider.dart
+++ b/lib/features/wallet/accounts_provider.dart
@@ -88,39 +88,39 @@ class AccountsRepository {
     }
   }
 
-  /// Get the private key for a specific account from secure storage
-  Future<String?> getPrivateKey(String accountId) async {
+  /// Get the secret key for a specific account from secure storage.
+  Future<String?> getSecretKey(String accountId) async {
     try {
-      final key = '$_network:account:$accountId:privateKey';
-      final privateKey = await _secure.read(key: key);
-      return privateKey;
+      final key = '$_network:account:$accountId:secretKey';
+      final secretKey = await _secure.read(key: key);
+      return secretKey;
     } catch (e, st) {
-      _log.error('Failed to read private key for account $accountId',
+      _log.error('Failed to read secret key for account $accountId',
           error: e, stackTrace: st);
       return null;
     }
   }
 
-  /// Import an account from a hex-encoded private key.
-  Future<AccountMeta?> importFromPrivateKey({
+  /// Import an account from a bech32m-encoded secret key (HRP `utsk`).
+  Future<AccountMeta?> importFromSecretKey({
     required String name,
-    required String privateKeyHex,
+    required String secretKey,
     bool isDemo = false,
   }) async {
-    _log.trace('importFromPrivateKey - start (name: $name, isDemo: $isDemo)');
+    _log.trace('importFromSecretKey - start (name: $name, isDemo: $isDemo)');
 
     try {
       // Use Rust backend to derive public key and address from private key
       final accountExport = accountFromPrivateKey(
-        privateKeyHex: privateKeyHex.trim(),
+        secretKey: secretKey.trim(),
       );
 
       // Extract keys from AccountExport
-      final privateKey = accountExport.secretKeyHex;
-      final publicKey = accountExport.publicKeyHex;
-      final address = accountExport.publicKeyHashBech32M;
+      final derivedSecretKey = accountExport.secretKey;
+      final publicKey = accountExport.publicKey;
+      final address = accountExport.address;
 
-      _log.trace('Private key length: ${privateKey.length}');
+      _log.trace('Secret key length: ${derivedSecretKey.length}');
       _log.trace('Public key length: ${publicKey.length}');
       _log.trace('Address: $address');
 
@@ -128,14 +128,14 @@ class AccountsRepository {
         name: name,
         address: address,
         publicKey: publicKey,
-        privateKey: privateKey,
+        secretKey: derivedSecretKey,
         derivationPath: 'imported', // Mark as imported rather than HD path
         isDemo: isDemo,
       );
-      _log.trace('importFromPrivateKey - success (account id: ${result.id})');
+      _log.trace('importFromSecretKey - success (account id: ${result.id})');
       return result;
     } catch (e, stackTrace) {
-      _log.error('importFromPrivateKey - FAILED with exception',
+      _log.error('importFromSecretKey - FAILED with exception',
           error: e, stackTrace: stackTrace);
       return null;
     }
@@ -145,7 +145,7 @@ class AccountsRepository {
     required String name,
     required String address,
     required String publicKey,
-    required String privateKey,
+    required String secretKey,
     String? derivationPath,
     bool isDemo = false,
   }) async {
@@ -171,7 +171,7 @@ class AccountsRepository {
 
     _log.debug('Writing to secure storage (4 keys) for network: $_network...');
     await _secure.write(
-        key: '$_network:account:$id:privateKey', value: privateKey);
+        key: '$_network:account:$id:secretKey', value: secretKey);
     await _secure.write(
         key: '$_network:account:$id:publicKey', value: publicKey);
     await _secure.write(key: '$_network:account:$id:address', value: address);


### PR DESCRIPTION
These changes are needed once https://github.com/Usernode-Labs/usernode/pull/430 gets merged into usernode.

For the moment we also have fallback support the old key names of the accounts' json (they can still be used in topochain), but the values must be encoded in the new format.