### PR TITLE
feat: add recent recipient history in send

### DIFF
--- a/lib/features/wallet/recipient_history_provider.dart
+++ b/lib/features/wallet/recipient_history_provider.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
+
+class RecipientHistoryNotifier extends AsyncNotifier<List<String>> {
+  static const String _keyBase = 'wallet:recent_recipients';
+  static const int _maxEntries = 5;
+
+  static String get _key => NetworkPrefs.prefixKey(_keyBase);
+
+  @override
+  Future<List<String>> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_key) ?? const [];
+  }
+
+  Future<void> addRecipient(String address) async {
+    final trimmed = address.trim();
+    if (trimmed.isEmpty) return;
+
+    final current = state.value ?? const <String>[];
+    final next = <String>[
+      trimmed,
+      ...current.where((entry) => entry != trimmed),
+    ];
+    final capped =
+        next.length > _maxEntries ? next.sublist(0, _maxEntries) : next;
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, capped);
+    state = AsyncValue.data(capped);
+  }
+}
+
+final recipientHistoryProvider =
+    AsyncNotifierProvider<RecipientHistoryNotifier, List<String>>(
+  RecipientHistoryNotifier.new,
+);

--- a/lib/features/wallet/screens/send_screen.dart
+++ b/lib/features/wallet/screens/send_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/features/wallet/accounts_provider.dart';
+import 'package:crypto_mobile_app/features/wallet/recipient_history_provider.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
 import 'package:crypto_mobile_app/core/config/app_router.dart';
 
@@ -69,6 +70,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
       if (mounted) {
         if (response != null && response.queued) {
+          await ref
+              .read(recipientHistoryProvider.notifier)
+              .addRecipient(recipientAddress);
           // Transaction successful
           context.push(AppRoutes.walletSendSuccess, extra: {
             'amount': amountStr,
@@ -102,6 +106,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final recipientHistory = ref.watch(recipientHistoryProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -125,6 +130,14 @@ class _SendScreenState extends ConsumerState<SendScreen> {
                   theme: theme,
                   controller: _addressController,
                   hint: 'Recipient address',
+                  suffixIcon: IconButton(
+                    icon: const Icon(Icons.history),
+                    tooltip: 'Recent recipients',
+                    onPressed: () => _showRecipientHistory(
+                      context,
+                      recipientHistory.value ?? const [],
+                    ),
+                  ),
                   validator:
                       _validateRequired('recipient address', minLength: 20),
                 ),
@@ -168,6 +181,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     required String hint,
     bool isNumeric = false,
     int maxLines = 1,
+    Widget? suffixIcon,
     String? Function(String?)? validator,
   }) {
     return ClipRRect(
@@ -202,6 +216,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
             contentPadding: const EdgeInsets.all(16),
             hintText: hint,
             hintStyle: const TextStyle(color: Colors.black87, fontSize: 16),
+            suffixIcon: suffixIcon,
           ),
           style: const TextStyle(fontSize: 16),
         ),
@@ -297,5 +312,43 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       }
       return null;
     };
+  }
+
+  void _showRecipientHistory(BuildContext context, List<String> recipients) {
+    showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        if (recipients.isEmpty) {
+          return const Padding(
+            padding: EdgeInsets.all(24),
+            child: Center(
+              child: Text('No recent addresses'),
+            ),
+          );
+        }
+        return ListView.separated(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          itemCount: recipients.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (context, index) {
+            final address = recipients[index];
+            return ListTile(
+              leading: const Icon(Icons.history),
+              title: Text(
+                address,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              onTap: () {
+                _addressController.text = address;
+                Navigator.of(sheetContext).pop();
+              },
+            );
+          },
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
Adds a minimal recent recipient history without new UI patterns.

Stores up to 5 recent recipient addresses per network (SharedPreferences + NetworkPrefs).

Exposes history via a Riverpod AsyncNotifier.

Adds a history icon to the recipient field; opens a bottom sheet listing recent addresses (with empty state), and selecting fills the field.

Updates history on successful send.