### PR TITLE
Feature recent activity balance using explorer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,32 @@ BLOCK_PRODUCTION_WAKE_BEFORE_SLOT_SECONDS=60
 EPOCH_MONITOR_BASE_INTERVAL_SECONDS=900
 
 # =============================================================================
+# EXPLORER API INTEGRATION
+# =============================================================================
+# Primary explorer API URL for balance and transaction data
+# Used as the first choice for fetching wallet data from external explorer
+# Default: https://alpha1.usernodelabs.org/explorer
+EXPLORER_PRIMARY_URL=https://alpha1.usernodelabs.org/explorer
+
+# Secondary explorer API URL for fallback when primary is unavailable
+# Used when the primary explorer API fails or times out
+# Default: https://alpha2.usernodelabs.org/explorer  
+EXPLORER_SECONDARY_URL=https://alpha2.usernodelabs.org/explorer
+
+# Chain ID is automatically detected from running node status
+# No configuration needed - uses the actual blockchain network chain ID
+
+# Timeout for explorer API requests in seconds (1-60)
+# How long to wait for explorer API responses before falling back
+# Default: 10
+EXPLORER_TIMEOUT_SECONDS=10
+
+# Explorer data cache TTL in minutes (1-60)
+# How long cached explorer data remains valid when APIs are down
+# Default: 5
+EXPLORER_CACHE_TTL_MINUTES=5
+
+# =============================================================================
 # NODE INITIALIZATION
 # =============================================================================
 # Genesis JSON URL for node initialization

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -175,6 +175,30 @@ class AppConfig {
       Duration(seconds: versionCheckIntervalSeconds);
   static bool get versionCheckEnabled => versionCheckApiUrl.isNotEmpty;
 
+  // Explorer API configuration
+  static const String primaryExplorerUrl = String.fromEnvironment(
+    'EXPLORER_PRIMARY_URL',
+    defaultValue: 'https://alpha1.usernodelabs.org/explorer',
+  );
+  static const String secondaryExplorerUrl = String.fromEnvironment(
+    'EXPLORER_SECONDARY_URL',
+    defaultValue: 'https://alpha2.usernodelabs.org/explorer',
+  );
+  static const int explorerTimeoutSeconds = int.fromEnvironment(
+    'EXPLORER_TIMEOUT_SECONDS',
+    defaultValue: 10,
+  );
+  static const int explorerCacheTtlMinutes = int.fromEnvironment(
+    'EXPLORER_CACHE_TTL_MINUTES',
+    defaultValue: 5,
+  );
+  
+  // Convert to Duration for convenience
+  static Duration get explorerTimeout =>
+      Duration(seconds: explorerTimeoutSeconds);
+  static Duration get explorerCacheTtl =>
+      Duration(minutes: explorerCacheTtlMinutes);
+
   // Demo accounts configuration (JSON object with account metadata)
   static const String _demoAccountsJson = String.fromEnvironment(
       'DEMO_ACCOUNTS_JSON',

--- a/lib/core/providers/node_provider.dart
+++ b/lib/core/providers/node_provider.dart
@@ -48,6 +48,9 @@ class NodeStatusState {
   int? get globalSlot => (networkBest ?? localBest)?.globalSlot;
   int? get currentEpoch => node.curEpoch;
   int? get currentGlobalSlot => node.curGlobalSlot;
+  
+  /// Get chain ID directly from node status
+  String? get chainId => node.chainId.toString();
 
   int? get epochUpperBound {
     final details = vrfEvaluator?.details;

--- a/lib/core/providers/wallet_provider.dart
+++ b/lib/core/providers/wallet_provider.dart
@@ -3,12 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:crypto_mobile_app/features/wallet/models/transaction_model.dart';
-import 'package:crypto_mobile_app/features/wallet/models/transaction_item.dart' as transaction_item;
+import 'package:crypto_mobile_app/features/wallet/models/transaction_item.dart'
+    as transaction_item;
 import 'package:crypto_mobile_app/core/providers/accounts_provider.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
-import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 import 'package:crypto_mobile_app/core/providers/mempool_provider.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/core/services/explorer_service.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
 
 final _log = LoggingService.instance.withTag('usernode/WalletProvider');
@@ -34,16 +35,9 @@ class WalletController extends AsyncNotifier<WalletState> {
     );
   }
 
-  /// Calculate wallet balance from UTXOs
+  /// Calculate wallet balance using explorer APIs with fallback to UTXOs
   Future<WalletBalance> _calculateBalance() async {
     try {
-      // Log current node status
-      final nodeStatusAsync = ref.read(nodeStatusProvider);
-      final nodeStatus = nodeStatusAsync.valueOrNull;
-      final syncStatus = nodeStatus?.syncStatus;
-
-      _log.debug('Node status: ${syncStatus?.label ?? 'unknown'}');
-
       // Get active account
       final accountsRepo = await AccountsRepository.create();
       final activeAccount = await accountsRepo.getActive();
@@ -54,101 +48,18 @@ class WalletController extends AsyncNotifier<WalletState> {
             'No active account found. Please create or select an account.');
       }
 
-      // Fetch UTXOs directly from backend
-      _log.debug('Fetching UTXOs for balance calculation',
-          context: {'address': activeAccount.address});
-      final owner = frb_types.publicKeyHashFromString(s: activeAccount.address);
-      final utxosResp =
-          await RustBackendService.instance.listUtxosByOwner(owner: owner);
-      final utxos = utxosResp?.items ?? [];
+      final userAddress = activeAccount.address;
+      _log.debug('Calculating balance for address: $userAddress');
 
-      // Log the full backend response
-      try {
-        if (utxosResp != null) {
-          _log.debug('UTXO backend response: ${json.encode({
-                'total_items': utxos.length,
-                'items': utxos
-                    .map((ownedUtxo) =>
-                        frb_types.utxoToJson(utxo: ownedUtxo.utxo))
-                    .map((jsonStr) => json.decode(jsonStr))
-                    .toList()
-              })}');
-        } else {
-          _log.debug('UTXO backend response: null');
-        }
-      } catch (e) {
-        _log.debug('Failed to log UTXO backend response: $e');
+      // Try explorer APIs first (primary -> secondary -> cached)
+      final explorerBalance = await _tryExplorerBalance(userAddress);
+      if (explorerBalance != null) {
+        return explorerBalance;
       }
 
-      _log.debug('Got ${utxos.length} UTXOs for balance calculation');
-
-      // Aggregate balances by token_id
-      final Map<String, BigInt> balancesByToken = {};
-      String? primaryTokenSymbol;
-
-      // Extract asset data from UTXOs via JSON serialization
-      for (var i = 0; i < utxos.length; i++) {
-        try {
-          final ownedUtxo = utxos[i];
-
-          // Serialize UTXO to JSON string
-          final jsonStr = frb_types.utxoToJson(utxo: ownedUtxo.utxo);
-          final utxoData = json.decode(jsonStr) as Map<String, dynamic>;
-
-          // Extract assets array
-          final assetsJson = utxoData['assets'] as List<dynamic>?;
-          if (assetsJson == null || assetsJson.isEmpty) {
-            _log.debug('  UTXO[$i]: No assets');
-            continue;
-          }
-
-          // Aggregate balances by token_id
-          for (final assetJson in assetsJson) {
-            final tokenId = assetJson['token_id'] as String;
-            final balance = BigInt.from(assetJson['balance'] as int);
-
-            balancesByToken[tokenId] =
-                (balancesByToken[tokenId] ?? BigInt.zero) + balance;
-          }
-        } catch (e, st) {
-          _log.error('Failed to parse UTXO[$i]', error: e, stackTrace: st);
-        }
-      }
-
-      // Calculate totals
-      final totalBalance = balancesByToken.values.fold<BigInt>(
-        BigInt.zero,
-        (sum, balance) => sum + balance,
-      );
-
-      // Get primary token info (first token or default)
-      if (balancesByToken.isNotEmpty) {
-        primaryTokenSymbol = 'TKN';
-      } else {
-        primaryTokenSymbol = 'TOKENS'; // Default fallback
-      }
-
-      // Parse transactions from UTXOs
-      _transactions = _parseTransactionsFromUtxos(utxos, primaryTokenSymbol);
-
-      // Log the calculated balance (matching MetricsProvider format)
-      _log.debug(
-        'Calculated wallet balance from UTXOs',
-        context: {
-          'utxo_count': utxos.length,
-          'raw_balance': totalBalance.toString(),
-        },
-      );
-
-      // Convert BigInt to double for display
-      final tokenAmount = totalBalance.toDouble();
-
-      return WalletBalance(
-        tokenAmount: tokenAmount,
-        tokenSymbol: primaryTokenSymbol,
-        usdValue: 0.0, // TODO: Add USD value calculation
-        totalBalance: totalBalance,
-      );
+      // Fallback to UTXO-based calculation
+      _log.debug('Falling back to UTXO-based balance calculation');
+      return await _calculateBalanceFromUtxos(userAddress);
     } catch (e, st) {
       _log.error('Failed to calculate wallet balance',
           error: e, stackTrace: st);
@@ -158,8 +69,91 @@ class WalletController extends AsyncNotifier<WalletState> {
         tokenSymbol: 'TOKENS',
         usdValue: 0.0,
         totalBalance: BigInt.zero,
+        dataSource: DataSource.local,
+        lastUpdated: DateTime.now(),
       );
     }
+  }
+
+  /// Try to get balance from explorer APIs (primary -> secondary -> cached)
+  Future<WalletBalance?> _tryExplorerBalance(String userAddress) async {
+    final explorerService = ExplorerService(ref);
+
+    // Try live explorer APIs
+    final explorerResponse =
+        await explorerService.getAccountBalance(userAddress);
+    if (explorerResponse != null) {
+      _log.debug(
+          'Got balance from explorer API: ${explorerResponse.dataSource}');
+      return WalletBalance.fromExplorerBalance(explorerResponse);
+    }
+
+    // Try cached data
+    final cachedResponse = await explorerService.getCachedBalance(userAddress);
+    if (cachedResponse != null) {
+      _log.debug('Using cached explorer balance');
+      return WalletBalance.fromExplorerBalance(cachedResponse);
+    }
+
+    _log.debug('No explorer balance data available');
+    return null;
+  }
+
+  /// Calculate balance from UTXOs (original implementation)
+  Future<WalletBalance> _calculateBalanceFromUtxos(String userAddress) async {
+    // Get active account for owner
+    final owner = frb_types.publicKeyHashFromString(s: userAddress);
+    final utxosResp =
+        await RustBackendService.instance.listUtxosByOwner(owner: owner);
+    final utxos = utxosResp?.items ?? [];
+
+    _log.debug('Got ${utxos.length} UTXOs for fallback balance calculation');
+
+    // Aggregate balances by token_id
+    final Map<String, BigInt> balancesByToken = {};
+
+    // Extract asset data from UTXOs via JSON serialization
+    for (var i = 0; i < utxos.length; i++) {
+      try {
+        final ownedUtxo = utxos[i];
+        final jsonStr = frb_types.utxoToJson(utxo: ownedUtxo.utxo);
+        final utxoData = json.decode(jsonStr) as Map<String, dynamic>;
+        final assetsJson = utxoData['assets'] as List<dynamic>?;
+
+        if (assetsJson == null || assetsJson.isEmpty) continue;
+
+        // Aggregate balances by token_id
+        for (final assetJson in assetsJson) {
+          final tokenId = assetJson['token_id'] as String;
+          final balance = BigInt.from(assetJson['balance'] as int);
+          balancesByToken[tokenId] =
+              (balancesByToken[tokenId] ?? BigInt.zero) + balance;
+        }
+      } catch (e, st) {
+        _log.error('Failed to parse UTXO[$i]', error: e, stackTrace: st);
+      }
+    }
+
+    // Calculate totals
+    final totalBalance = balancesByToken.values.fold<BigInt>(
+      BigInt.zero,
+      (sum, balance) => sum + balance,
+    );
+
+    // Parse transactions from UTXOs
+    final primaryTokenSymbol = balancesByToken.isNotEmpty ? 'TKN' : 'TOKENS';
+    _transactions = _parseTransactionsFromUtxos(utxos, primaryTokenSymbol);
+
+    _log.debug('Calculated balance from UTXOs: ${totalBalance.toString()}');
+
+    return WalletBalance(
+      tokenAmount: totalBalance.toDouble(),
+      tokenSymbol: primaryTokenSymbol,
+      usdValue: 0.0,
+      totalBalance: totalBalance,
+      dataSource: DataSource.local,
+      lastUpdated: DateTime.now(),
+    );
   }
 
   /// Parse transactions from UTXOs to populate recent activity
@@ -183,7 +177,7 @@ class WalletController extends AsyncNotifier<WalletState> {
 
           // Determine if this is a block reward (exactly 20 TKN)
           final isBlockReward = balance == 20;
-          
+
           // Create a transaction for each UTXO asset
           final transaction = TransactionModel(
             id: utxoData['id']?.toString() ?? 'utxo_$i',
@@ -191,11 +185,14 @@ class WalletController extends AsyncNotifier<WalletState> {
             subtitle: isBlockReward ? 'Mining reward' : 'Token transfer',
             amount: balance.toDouble(),
             tokenSymbol: tokenSymbol,
-            type: isBlockReward ? TransactionType.reward : TransactionType.receive,
+            type: isBlockReward
+                ? TransactionType.reward
+                : TransactionType.receive,
             status: TransactionStatus.completed,
             timestamp: _parseTimestampFromUtxo(utxoData),
             icon: isBlockReward ? Icons.star : Icons.south_west,
             color: isBlockReward ? Colors.orange : Colors.green,
+            dataSource: DataSource.local, // UTXO transactions are local
           );
 
           transactions.add(transaction);
@@ -231,39 +228,48 @@ class WalletController extends AsyncNotifier<WalletState> {
         Duration(minutes: (DateTime.now().millisecondsSinceEpoch % 1000)));
   }
 
-  /// Get all transactions (confirmed + pending) sorted by timestamp
+  /// Get all transactions (confirmed from explorer/UTXO + pending from mempool) sorted by timestamp
   Future<List<TransactionModel>> _getAllTransactions() async {
     try {
       // Get current user address
       final accountsRepo = await AccountsRepository.create();
       final activeAccount = await accountsRepo.getActive();
-      
+
       if (activeAccount == null || activeAccount.address.isEmpty) {
-        _log.debug('No active account for mempool fetch');
+        _log.debug('No active account for transaction fetch');
         return _transactions.take(10).toList();
       }
 
-      // Get pending transactions from mempool
-      final mempoolTransactions = await _getPendingTransactions(activeAccount.address);
-      
-      // Convert mempool transactions to TransactionModel format
-      final pendingTransactionModels = mempoolTransactions
-          .map((tx) => _convertMempoolToTransactionModel(tx))
-          .toList();
+      final userAddress = activeAccount.address;
 
-      // Combine confirmed and pending transactions
+      // Get confirmed transactions from explorer APIs or UTXO fallback
+      final confirmedTransactions =
+          await _getConfirmedTransactions(userAddress);
+
+      // Get pending transactions from mempool (always from local)
+      final pendingTransactionModels =
+          await _getPendingTransactionModels(userAddress);
+
+      // Combine and deduplicate transactions
       final allTransactions = <TransactionModel>[];
       allTransactions.addAll(pendingTransactionModels);
-      allTransactions.addAll(_transactions);
+      allTransactions.addAll(confirmedTransactions);
+
+      // Remove duplicates (same transaction ID)
+      final uniqueTransactions = <String, TransactionModel>{};
+      for (final tx in allTransactions) {
+        uniqueTransactions[tx.id] = tx;
+      }
+      final dedupedTransactions = uniqueTransactions.values.toList();
 
       // Sort by timestamp (newest first) with pending transactions prioritized
-      allTransactions.sort((a, b) {
+      dedupedTransactions.sort((a, b) {
         // Pending transactions should come first
-        if (a.status == TransactionStatus.pending && 
+        if (a.status == TransactionStatus.pending &&
             b.status == TransactionStatus.completed) {
           return -1;
         }
-        if (a.status == TransactionStatus.completed && 
+        if (a.status == TransactionStatus.completed &&
             b.status == TransactionStatus.pending) {
           return 1;
         }
@@ -272,23 +278,76 @@ class WalletController extends AsyncNotifier<WalletState> {
       });
 
       _log.debug(
-        'Combined transactions: ${pendingTransactionModels.length} pending + ${_transactions.length} confirmed'
-      );
+          'Combined transactions: ${pendingTransactionModels.length} pending + ${confirmedTransactions.length} confirmed (${dedupedTransactions.length} after deduplication)');
 
-      return allTransactions;
+      return dedupedTransactions;
     } catch (e, st) {
       _log.error('Failed to get all transactions', error: e, stackTrace: st);
-      // Return just confirmed transactions on error
+      // Return just local transactions on error
       return _transactions.take(10).toList();
     }
   }
 
+  /// Get confirmed transactions from explorer APIs with UTXO fallback
+  Future<List<TransactionModel>> _getConfirmedTransactions(
+      String userAddress) async {
+    final explorerService = ExplorerService(ref);
+
+    // Try explorer APIs first
+    final explorerResponse =
+        await explorerService.getAccountTransactions(userAddress);
+    if (explorerResponse != null) {
+      _log.debug(
+          'Got ${explorerResponse.transactions.length} transactions from explorer API: ${explorerResponse.dataSource}');
+      return explorerResponse.transactions
+          .map((explorerTx) => TransactionModel.fromExplorerTransaction(
+              explorerTx, explorerResponse.dataSource, userAddress))
+          .toList();
+    }
+
+    // Try cached explorer data
+    final cachedResponse =
+        await explorerService.getCachedTransactions(userAddress);
+    if (cachedResponse != null) {
+      _log.debug(
+          'Using ${cachedResponse.transactions.length} cached explorer transactions');
+      return cachedResponse.transactions
+          .map((explorerTx) => TransactionModel.fromExplorerTransaction(
+              explorerTx, cachedResponse.dataSource, userAddress))
+          .toList();
+    }
+
+    // Fallback to UTXO-based transactions
+    _log.debug('Using UTXO-based transactions as fallback');
+    await _ensureUtxoTransactionsLoaded();
+    return _transactions;
+  }
+
+  /// Get pending transaction models from mempool
+  Future<List<TransactionModel>> _getPendingTransactionModels(
+      String userAddress) async {
+    try {
+      // Get pending transactions from mempool
+      final mempoolTransactions = await _getPendingTransactions(userAddress);
+
+      // Convert mempool transactions to TransactionModel format
+      return mempoolTransactions
+          .map((tx) => _convertMempoolToTransactionModel(tx))
+          .toList();
+    } catch (e, st) {
+      _log.error('Failed to get pending transactions',
+          error: e, stackTrace: st);
+      return [];
+    }
+  }
+
   /// Get pending transactions from mempool for current user
-  Future<List<transaction_item.TransactionItem>> _getPendingTransactions(String ownerAddress) async {
+  Future<List<transaction_item.TransactionItem>> _getPendingTransactions(
+      String ownerAddress) async {
     try {
       final mempoolProvider = ref.read(walletMempoolProvider);
       final mempoolSummaries = mempoolProvider.valueOrNull ?? [];
-      
+
       return mempoolSummaries
           .map((tx) => transaction_item.TransactionItem.fromMempoolTx(
                 tx: tx,
@@ -296,13 +355,15 @@ class WalletController extends AsyncNotifier<WalletState> {
               ))
           .toList();
     } catch (e, st) {
-      _log.error('Failed to fetch pending transactions', error: e, stackTrace: st);
+      _log.error('Failed to fetch pending transactions',
+          error: e, stackTrace: st);
       return [];
     }
   }
 
   /// Convert TransactionItem (from mempool) to TransactionModel format
-  TransactionModel _convertMempoolToTransactionModel(transaction_item.TransactionItem txItem) {
+  TransactionModel _convertMempoolToTransactionModel(
+      transaction_item.TransactionItem txItem) {
     // Determine icon and color based on transaction type
     IconData icon;
     Color color;
@@ -358,7 +419,35 @@ class WalletController extends AsyncNotifier<WalletState> {
       timestamp: DateTime.now(), // Use current time for pending transactions
       icon: icon,
       color: color,
+      dataSource: DataSource.local, // Mempool transactions are always local
     );
+  }
+
+  /// Ensure UTXO transactions are loaded when needed as fallback
+  Future<void> _ensureUtxoTransactionsLoaded() async {
+    if (_transactions.isNotEmpty) return; // Already loaded
+    
+    try {
+      _log.debug('Loading UTXO transactions for fallback');
+      
+      // Get active account address for UTXO lookup
+      final accountsRepo = await AccountsRepository.create();
+      final activeAccount = await accountsRepo.getActive();
+      if (activeAccount == null || activeAccount.address.isEmpty) {
+        _log.debug('No active account for UTXO fallback');
+        return;
+      }
+      
+      final owner = frb_types.publicKeyHashFromString(s: activeAccount.address);
+      final utxosResp = await RustBackendService.instance.listUtxosByOwner(owner: owner);
+      final utxos = utxosResp?.items ?? [];
+      final primaryTokenSymbol = 'TKN';
+      _transactions = _parseTransactionsFromUtxos(utxos, primaryTokenSymbol);
+      _log.debug('Loaded ${_transactions.length} UTXO transactions for fallback');
+    } catch (e, st) {
+      _log.error('Failed to load UTXO transactions for fallback', error: e, stackTrace: st);
+      _transactions = [];
+    }
   }
 
   Future<void> refresh() async {
@@ -367,7 +456,7 @@ class WalletController extends AsyncNotifier<WalletState> {
     try {
       // Also refresh the mempool data
       await ref.read(walletMempoolProvider.notifier).refresh();
-      
+
       final balance = await _calculateBalance();
       final allTransactions = await _getAllTransactions();
       state = AsyncValue.data(WalletState(
@@ -384,7 +473,7 @@ class WalletController extends AsyncNotifier<WalletState> {
     try {
       // Silently refresh mempool data too
       await ref.read(walletMempoolProvider.notifier).refresh();
-      
+
       final balance = await _calculateBalance();
       final allTransactions = await _getAllTransactions();
       state = AsyncValue.data(WalletState(

--- a/lib/core/services/explorer_service.dart
+++ b/lib/core/services/explorer_service.dart
@@ -1,0 +1,465 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/core/providers/node_provider.dart';
+
+final _log = LoggingService.instance.withTag('ExplorerService');
+
+/// Data source for wallet data
+enum DataSource {
+  explorerPrimary,
+  explorerSecondary,
+  cached,
+  local,
+}
+
+/// Explorer API service with multi-tier fallback strategy
+class ExplorerService {
+  final Ref _ref;
+  final _client = http.Client();
+  
+  ExplorerService(this._ref);
+  
+  // Circuit breaker state tracking
+  final Map<String, DateTime> _lastFailureTime = {};
+  final Map<String, int> _failureCount = {};
+  static const int _circuitBreakerThreshold = 3;
+  static const Duration _circuitBreakerCooldown = Duration(minutes: 5);
+
+  /// Get account balance from explorer APIs with fallback
+  /// Returns null if all APIs fail - caller should use cached data or UTXO fallback
+  Future<ExplorerBalanceResponse?> getAccountBalance(String account) async {
+    // Get chain ID from node status
+    final chainId = _ref.read(nodeStatusProvider).value?.chainId;
+    if (chainId == null) {
+      _log.debug('Chain ID not available from node status, skipping explorer API');
+      return null;
+    }
+    
+    _log.debug('Fetching balance for account: $account on chain: $chainId');
+    
+    // Try primary explorer
+    final primaryResponse = await _tryGetBalance(
+      AppConfig.primaryExplorerUrl, 
+      account,
+      chainId,
+      DataSource.explorerPrimary
+    );
+    if (primaryResponse != null) return primaryResponse;
+    
+    // Try secondary explorer
+    final secondaryResponse = await _tryGetBalance(
+      AppConfig.secondaryExplorerUrl, 
+      account,
+      chainId,
+      DataSource.explorerSecondary
+    );
+    if (secondaryResponse != null) return secondaryResponse;
+    
+    _log.warn('All explorer APIs failed for balance request');
+    return null;
+  }
+
+  /// Get account transactions from explorer APIs with fallback
+  /// Returns null if all APIs fail - caller should use cached data or UTXO fallback
+  Future<ExplorerTransactionsResponse?> getAccountTransactions(String account) async {
+    // Get chain ID from node status
+    final chainId = _ref.read(nodeStatusProvider).value?.chainId;
+    if (chainId == null) {
+      _log.debug('Chain ID not available from node status, skipping explorer API');
+      return null;
+    }
+    
+    _log.debug('Fetching transactions for account: $account on chain: $chainId');
+    
+    // Try primary explorer
+    final primaryResponse = await _tryGetTransactions(
+      AppConfig.primaryExplorerUrl, 
+      account,
+      chainId,
+      DataSource.explorerPrimary
+    );
+    if (primaryResponse != null) return primaryResponse;
+    
+    // Try secondary explorer
+    final secondaryResponse = await _tryGetTransactions(
+      AppConfig.secondaryExplorerUrl, 
+      account,
+      chainId,
+      DataSource.explorerSecondary
+    );
+    if (secondaryResponse != null) return secondaryResponse;
+    
+    _log.warn('All explorer APIs failed for transactions request');
+    return null;
+  }
+
+  /// Try to get balance from a specific explorer endpoint
+  Future<ExplorerBalanceResponse?> _tryGetBalance(
+    String baseUrl, 
+    String account,
+    String chainId,
+    DataSource source
+  ) async {
+    if (_isCircuitBreakerOpen(baseUrl)) {
+      _log.debug('Circuit breaker is open for $baseUrl, skipping');
+      return null;
+    }
+
+    try {
+      final url = '$baseUrl/api/$chainId/blocks/best_tip/$account/balance';
+      _log.debug('Requesting balance from: $url');
+      
+      final response = await _client
+          .get(Uri.parse(url))
+          .timeout(AppConfig.explorerTimeout);
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final balanceResponse = ExplorerBalanceResponse.fromJson(data, source);
+        
+        // Check if we got meaningful data (non-zero balance or valid response structure)
+        if (balanceResponse.balance > 0 || _isValidBalanceResponse(data)) {
+          _recordSuccess(baseUrl);
+          _log.debug('Successfully fetched balance from $source: ${balanceResponse.balance}');
+          
+          // Cache the successful response
+          await _cacheBalanceResponse(account, balanceResponse);
+          
+          return balanceResponse;
+        } else {
+          _log.debug('Explorer returned empty/invalid balance data from $source');
+          // Don't record this as a failure, but also don't cache empty data
+          return null;
+        }
+      } else {
+        _log.warn('Explorer API returned ${response.statusCode}: ${response.body}');
+        _recordFailure(baseUrl);
+        return null;
+      }
+    } catch (e) {
+      _log.warn('Failed to fetch balance from $baseUrl: $e');
+      _recordFailure(baseUrl);
+      return null;
+    }
+  }
+
+  /// Try to get transactions from a specific explorer endpoint
+  Future<ExplorerTransactionsResponse?> _tryGetTransactions(
+    String baseUrl, 
+    String account,
+    String chainId,
+    DataSource source
+  ) async {
+    if (_isCircuitBreakerOpen(baseUrl)) {
+      _log.debug('Circuit breaker is open for $baseUrl, skipping');
+      return null;
+    }
+
+    try {
+      final url = '$baseUrl/api/$chainId/accounts/$account/txs';
+      _log.debug('Requesting transactions from: $url');
+      
+      final response = await _client
+          .get(Uri.parse(url))
+          .timeout(AppConfig.explorerTimeout);
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        final txResponse = ExplorerTransactionsResponse.fromJson(data, source);
+        
+        // Check if we got meaningful data (has transactions or valid response structure)
+        if (txResponse.transactions.isNotEmpty || _isValidTransactionsResponse(data)) {
+          _recordSuccess(baseUrl);
+          _log.debug('Successfully fetched ${txResponse.transactions.length} transactions from $source');
+          
+          // Cache the successful response
+          await _cacheTransactionsResponse(account, txResponse);
+          
+          return txResponse;
+        } else {
+          _log.debug('Explorer returned empty transaction data from $source');
+          // Don't record this as a failure, but also don't cache empty data
+          return null;
+        }
+      } else {
+        _log.warn('Explorer API returned ${response.statusCode}: ${response.body}');
+        _recordFailure(baseUrl);
+        return null;
+      }
+    } catch (e) {
+      _log.warn('Failed to fetch transactions from $baseUrl: $e');
+      _recordFailure(baseUrl);
+      return null;
+    }
+  }
+
+  /// Cache balance response for offline use
+  Future<void> _cacheBalanceResponse(String account, ExplorerBalanceResponse response) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final cacheKey = 'explorer_balance_$account';
+      final cacheData = {
+        'response': response.toJson(),
+        'cached_at': DateTime.now().millisecondsSinceEpoch,
+      };
+      await prefs.setString(cacheKey, json.encode(cacheData));
+      _log.debug('Cached balance response for $account');
+    } catch (e) {
+      _log.warn('Failed to cache balance response: $e');
+    }
+  }
+
+  /// Cache transactions response for offline use
+  Future<void> _cacheTransactionsResponse(String account, ExplorerTransactionsResponse response) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final cacheKey = 'explorer_transactions_$account';
+      final cacheData = {
+        'response': response.toJson(),
+        'cached_at': DateTime.now().millisecondsSinceEpoch,
+      };
+      await prefs.setString(cacheKey, json.encode(cacheData));
+      _log.debug('Cached transactions response for $account');
+    } catch (e) {
+      _log.warn('Failed to cache transactions response: $e');
+    }
+  }
+
+  /// Get cached balance if available and not expired
+  Future<ExplorerBalanceResponse?> getCachedBalance(String account) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final cacheKey = 'explorer_balance_$account';
+      final cachedData = prefs.getString(cacheKey);
+      
+      if (cachedData == null) return null;
+      
+      final cache = json.decode(cachedData);
+      final cachedAt = DateTime.fromMillisecondsSinceEpoch(cache['cached_at']);
+      
+      // Check if cache is still valid
+      if (DateTime.now().difference(cachedAt) > AppConfig.explorerCacheTtl) {
+        _log.debug('Cached balance for $account has expired');
+        return null;
+      }
+      
+      final response = ExplorerBalanceResponse.fromJson(
+        cache['response'], 
+        DataSource.cached
+      );
+      _log.debug('Retrieved cached balance for $account');
+      return response;
+    } catch (e) {
+      _log.warn('Failed to retrieve cached balance: $e');
+      return null;
+    }
+  }
+
+  /// Get cached transactions if available and not expired
+  Future<ExplorerTransactionsResponse?> getCachedTransactions(String account) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final cacheKey = 'explorer_transactions_$account';
+      final cachedData = prefs.getString(cacheKey);
+      
+      if (cachedData == null) return null;
+      
+      final cache = json.decode(cachedData);
+      final cachedAt = DateTime.fromMillisecondsSinceEpoch(cache['cached_at']);
+      
+      // Check if cache is still valid
+      if (DateTime.now().difference(cachedAt) > AppConfig.explorerCacheTtl) {
+        _log.debug('Cached transactions for $account have expired');
+        return null;
+      }
+      
+      final response = ExplorerTransactionsResponse.fromJson(
+        cache['response'], 
+        DataSource.cached
+      );
+      _log.debug('Retrieved cached transactions for $account');
+      return response;
+    } catch (e) {
+      _log.warn('Failed to retrieve cached transactions: $e');
+      return null;
+    }
+  }
+
+  /// Check if balance response contains valid data structure
+  bool _isValidBalanceResponse(Map<String, dynamic> data) {
+    // Consider response valid if it has proper structure even with 0 balance
+    // This handles new accounts that legitimately have 0 balance
+    return data.containsKey('balance') || 
+           data.containsKey('token_symbol') ||
+           data.containsKey('amount');
+  }
+
+  /// Check if transactions response contains valid data structure
+  bool _isValidTransactionsResponse(Map<String, dynamic> data) {
+    // Consider response valid if it has proper structure even with empty transactions
+    // This handles accounts that legitimately have no transactions yet
+    return data.containsKey('transactions') ||
+           data.containsKey('txs') ||
+           data.containsKey('data');
+  }
+
+  /// Circuit breaker logic
+  bool _isCircuitBreakerOpen(String endpoint) {
+    final failureCount = _failureCount[endpoint] ?? 0;
+    final lastFailure = _lastFailureTime[endpoint];
+    
+    if (failureCount < _circuitBreakerThreshold) return false;
+    
+    if (lastFailure == null) return false;
+    
+    // Check if cooldown period has passed
+    if (DateTime.now().difference(lastFailure) > _circuitBreakerCooldown) {
+      _log.debug('Circuit breaker cooldown passed for $endpoint, resetting');
+      _failureCount[endpoint] = 0;
+      _lastFailureTime.remove(endpoint);
+      return false;
+    }
+    
+    return true;
+  }
+
+  void _recordSuccess(String endpoint) {
+    _failureCount[endpoint] = 0;
+    _lastFailureTime.remove(endpoint);
+  }
+
+  void _recordFailure(String endpoint) {
+    _failureCount[endpoint] = (_failureCount[endpoint] ?? 0) + 1;
+    _lastFailureTime[endpoint] = DateTime.now();
+    
+    if (_failureCount[endpoint]! >= _circuitBreakerThreshold) {
+      _log.warn('Circuit breaker opened for $endpoint after ${_failureCount[endpoint]} failures');
+    }
+  }
+
+  void dispose() {
+    _client.close();
+  }
+}
+
+/// Response model for explorer balance API
+class ExplorerBalanceResponse {
+  final double balance;
+  final String tokenSymbol;
+  final DataSource dataSource;
+  final DateTime fetchedAt;
+
+  ExplorerBalanceResponse({
+    required this.balance,
+    required this.tokenSymbol,
+    required this.dataSource,
+    required this.fetchedAt,
+  });
+
+  factory ExplorerBalanceResponse.fromJson(Map<String, dynamic> json, DataSource source) {
+    return ExplorerBalanceResponse(
+      balance: (json['balance'] as num?)?.toDouble() ?? 0.0,
+      tokenSymbol: json['token_symbol'] as String? ?? 'TKN',
+      dataSource: source,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'balance': balance,
+      'token_symbol': tokenSymbol,
+      'data_source': dataSource.toString(),
+      'fetched_at': fetchedAt.millisecondsSinceEpoch,
+    };
+  }
+}
+
+/// Response model for explorer transactions API
+class ExplorerTransactionsResponse {
+  final List<ExplorerTransaction> transactions;
+  final DataSource dataSource;
+  final DateTime fetchedAt;
+
+  ExplorerTransactionsResponse({
+    required this.transactions,
+    required this.dataSource,
+    required this.fetchedAt,
+  });
+
+  factory ExplorerTransactionsResponse.fromJson(Map<String, dynamic> json, DataSource source) {
+    final txList = json['transactions'] as List<dynamic>? ?? [];
+    final transactions = txList
+        .map((tx) => ExplorerTransaction.fromJson(tx as Map<String, dynamic>))
+        .toList();
+
+    return ExplorerTransactionsResponse(
+      transactions: transactions,
+      dataSource: source,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'transactions': transactions.map((tx) => tx.toJson()).toList(),
+      'data_source': dataSource.toString(),
+      'fetched_at': fetchedAt.millisecondsSinceEpoch,
+    };
+  }
+}
+
+/// Individual transaction from explorer API
+class ExplorerTransaction {
+  final String id;
+  final String type;
+  final double amount;
+  final String tokenSymbol;
+  final DateTime timestamp;
+  final String status;
+  final String? fromAddress;
+  final String? toAddress;
+
+  ExplorerTransaction({
+    required this.id,
+    required this.type,
+    required this.amount,
+    required this.tokenSymbol,
+    required this.timestamp,
+    required this.status,
+    this.fromAddress,
+    this.toAddress,
+  });
+
+  factory ExplorerTransaction.fromJson(Map<String, dynamic> json) {
+    return ExplorerTransaction(
+      id: json['id'] as String? ?? '',
+      type: json['type'] as String? ?? 'unknown',
+      amount: (json['amount'] as num?)?.toDouble() ?? 0.0,
+      tokenSymbol: json['token_symbol'] as String? ?? 'TKN',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(
+        json['timestamp'] as int? ?? DateTime.now().millisecondsSinceEpoch
+      ),
+      status: json['status'] as String? ?? 'confirmed',
+      fromAddress: json['from_address'] as String?,
+      toAddress: json['to_address'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'type': type,
+      'amount': amount,
+      'token_symbol': tokenSymbol,
+      'timestamp': timestamp.millisecondsSinceEpoch,
+      'status': status,
+      'from_address': fromAddress,
+      'to_address': toAddress,
+    };
+  }
+}

--- a/lib/features/metrics/metrics_collector_service.dart
+++ b/lib/features/metrics/metrics_collector_service.dart
@@ -212,21 +212,25 @@ class MetricsCollectorService {
     _cachedPeerId ??= RustBackendService.instance.getPeerId();
     final peerId = _cachedPeerId;
 
-    // Get chain ID from node status
+    // Get chain ID from node status provider (shared cache)
     String? chainId;
-    try {
-      final status = await RustBackendService.instance.getStatus();
-      chainId = status?.node.chainId.toString();
-    } catch (e) {
-      _log.debug('Failed to get chain_id from status: $e');
+    if (_container != null) {
+      try {
+        final nodeStatusAsync = _container!.read(nodeStatusProvider);
+        chainId = nodeStatusAsync.value?.chainId;
+        _log.debug('Got chain_id from nodeStatusProvider: $chainId');
+      } catch (e) {
+        _log.debug('Failed to get chain_id from nodeStatusProvider: $e');
+      }
     }
 
-    // Fallback: derive from selected network if chain_id unavailable
+    // Fallback: derive from selected network if chain_id unavailable from provider
     if (chainId == null || chainId.isEmpty) {
       try {
         final networkType =
             await RustBackendService.instance.getSelectedNetwork();
         chainId = networkType.name; // 'testnet' or 'internal'
+        _log.debug('Using network type as chain_id fallback: $chainId');
       } catch (e) {
         _log.debug('Failed to get network type for chain_id fallback: $e');
         chainId = null;

--- a/lib/features/node/screens/node_peers_screen.dart
+++ b/lib/features/node/screens/node_peers_screen.dart
@@ -105,8 +105,6 @@ class NodePeersScreen extends StatelessWidget {
                 ),
                 itemBuilder: (_, i) {
                   final p = sortedPeers[i];
-                  final status = p.connectionStatus.toString().split('.').last;
-                  final statusColor = _statusColor(theme, p.connectionStatus);
                   final details = p.connectingDetails;
 
                   // Safely stringify peerId
@@ -251,24 +249,7 @@ class NodePeersScreen extends StatelessWidget {
                         ],
                       ),
                     ),
-                    trailing: Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: statusColor.withValues(alpha: 0.15),
-                        borderRadius: BorderRadius.circular(6),
-                        border: Border.all(color: statusColor, width: 1),
-                      ),
-                      child: Text(
-                        status.toUpperCase(),
-                        style: TextStyle(
-                          color: statusColor,
-                          fontWeight: FontWeight.w400,
-                          fontSize: 10,
-                          letterSpacing: 0.5,
-                        ),
-                      ),
-                    ),
+                    trailing: null,
                     dense: true,
                     visualDensity: VisualDensity.compact,
                   );
@@ -281,19 +262,6 @@ class NodePeersScreen extends StatelessWidget {
     );
   }
 
-  Color _statusColor(ThemeData theme, PeerConnectionStatus s) {
-    final colorScheme = theme.colorScheme;
-    switch (s) {
-      case PeerConnectionStatus.connected:
-        return colorScheme.tertiary; // Green
-      case PeerConnectionStatus.connecting:
-        return MaterialTheme.warningColor; // Orange
-      case PeerConnectionStatus.disconnected:
-        return colorScheme.error; // Red
-      case PeerConnectionStatus.disconnecting:
-        return MaterialTheme.accentYellow; // Amber
-    }
-  }
 
   String? _peerIpOnly(RpcPeerInfo p) {
     final addr = _extractIpOnly(p.address);

--- a/lib/features/node/screens/node_peers_screen.dart
+++ b/lib/features/node/screens/node_peers_screen.dart
@@ -64,6 +64,7 @@ class NodePeersScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppAppBar(
         title: l10n.nodePeersTitle,
+        showNodeStatus: false,
       ),
       body: SafeArea(
         child: Column(

--- a/lib/features/node/screens/node_peers_screen.dart
+++ b/lib/features/node/screens/node_peers_screen.dart
@@ -105,6 +105,8 @@ class NodePeersScreen extends StatelessWidget {
                 ),
                 itemBuilder: (_, i) {
                   final p = sortedPeers[i];
+                  final status = p.connectionStatus.toString().split('.').last;
+                  final statusColor = _statusColor(theme, p.connectionStatus);
                   final details = p.connectingDetails;
 
                   // Safely stringify peerId
@@ -249,7 +251,24 @@ class NodePeersScreen extends StatelessWidget {
                         ],
                       ),
                     ),
-                    trailing: null,
+                    trailing: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: statusColor.withValues(alpha: 0.15),
+                        borderRadius: BorderRadius.circular(6),
+                        border: Border.all(color: statusColor, width: 1),
+                      ),
+                      child: Text(
+                        status.toUpperCase(),
+                        style: TextStyle(
+                          color: statusColor,
+                          fontWeight: FontWeight.w400,
+                          fontSize: 10,
+                          letterSpacing: 0.5,
+                        ),
+                      ),
+                    ),
                     dense: true,
                     visualDensity: VisualDensity.compact,
                   );
@@ -262,6 +281,19 @@ class NodePeersScreen extends StatelessWidget {
     );
   }
 
+  Color _statusColor(ThemeData theme, PeerConnectionStatus s) {
+    final colorScheme = theme.colorScheme;
+    switch (s) {
+      case PeerConnectionStatus.connected:
+        return colorScheme.tertiary; // Green
+      case PeerConnectionStatus.connecting:
+        return MaterialTheme.warningColor; // Orange
+      case PeerConnectionStatus.disconnected:
+        return colorScheme.error; // Red
+      case PeerConnectionStatus.disconnecting:
+        return MaterialTheme.accentYellow; // Amber
+    }
+  }
 
   String? _peerIpOnly(RpcPeerInfo p) {
     final addr = _extractIpOnly(p.address);

--- a/lib/features/wallet/models/transaction_model.dart
+++ b/lib/features/wallet/models/transaction_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:crypto_mobile_app/core/services/explorer_service.dart';
 
 enum TransactionType {
   receive,
@@ -25,6 +26,7 @@ class TransactionModel {
   final DateTime timestamp;
   final IconData icon;
   final Color color;
+  final DataSource dataSource;
 
   TransactionModel({
     required this.id,
@@ -37,6 +39,7 @@ class TransactionModel {
     required this.timestamp,
     required this.icon,
     required this.color,
+    this.dataSource = DataSource.local,
   });
 
   bool get isPositive => amount > 0;
@@ -80,6 +83,104 @@ class TransactionModel {
     if (id.length <= 16) return id;
     return '${id.substring(0, 8)}...${id.substring(id.length - 8)}';
   }
+
+  /// Create TransactionModel from ExplorerTransaction
+  factory TransactionModel.fromExplorerTransaction(
+    ExplorerTransaction explorerTx, 
+    DataSource dataSource,
+    String userAddress,
+  ) {
+    // Determine transaction type based on addresses
+    TransactionType txType;
+    bool isOutgoing = false;
+    
+    if (explorerTx.type.toLowerCase().contains('reward') || 
+        explorerTx.type.toLowerCase().contains('mining') ||
+        explorerTx.type.toLowerCase().contains('coinbase')) {
+      txType = TransactionType.reward;
+    } else if (explorerTx.fromAddress == userAddress) {
+      txType = TransactionType.send;
+      isOutgoing = true;
+    } else {
+      txType = TransactionType.receive;
+    }
+
+    // Determine title and icon
+    String title;
+    IconData icon;
+    Color color;
+    
+    switch (txType) {
+      case TransactionType.reward:
+        title = explorerTx.amount == 20 ? 'Block Reward' : 'Mining Reward';
+        icon = Icons.star;
+        color = Colors.orange;
+        break;
+      case TransactionType.send:
+        title = 'Sent';
+        icon = Icons.north_east;
+        color = Colors.red;
+        break;
+      case TransactionType.receive:
+        title = 'Received';
+        icon = Icons.south_west;
+        color = Colors.green;
+        break;
+      case TransactionType.fee:
+        title = 'Fee';
+        icon = Icons.payment;
+        color = Colors.grey;
+        break;
+    }
+
+    // Create subtitle
+    String subtitle;
+    if (explorerTx.toAddress != null && explorerTx.fromAddress != null) {
+      if (isOutgoing) {
+        subtitle = 'To ${_shortenAddress(explorerTx.toAddress!)}';
+      } else {
+        subtitle = 'From ${_shortenAddress(explorerTx.fromAddress!)}';
+      }
+    } else {
+      subtitle = explorerTx.type.isNotEmpty ? explorerTx.type : 'Transaction';
+    }
+
+    return TransactionModel(
+      id: explorerTx.id,
+      title: title,
+      subtitle: subtitle,
+      amount: isOutgoing ? -explorerTx.amount.abs() : explorerTx.amount.abs(),
+      tokenSymbol: explorerTx.tokenSymbol,
+      type: txType,
+      status: _parseTransactionStatus(explorerTx.status),
+      timestamp: explorerTx.timestamp,
+      icon: icon,
+      color: color,
+      dataSource: dataSource,
+    );
+  }
+
+  static String _shortenAddress(String address) {
+    if (address.length <= 16) return address;
+    return '${address.substring(0, 8)}...${address.substring(address.length - 8)}';
+  }
+
+  static TransactionStatus _parseTransactionStatus(String status) {
+    switch (status.toLowerCase()) {
+      case 'confirmed':
+      case 'success':
+      case 'completed':
+        return TransactionStatus.completed;
+      case 'pending':
+      case 'unconfirmed':
+        return TransactionStatus.pending;
+      case 'failed':
+      case 'error':
+        return TransactionStatus.failed;
+      default:
+        return TransactionStatus.completed;
+    }
+  }
 }
 
 class WalletBalance {
@@ -87,12 +188,16 @@ class WalletBalance {
   final String tokenSymbol;
   final double usdValue;
   final BigInt totalBalance; // Total balance from all UTXOs
+  final DataSource dataSource;
+  final DateTime? lastUpdated;
 
   WalletBalance({
     required this.tokenAmount,
     required this.tokenSymbol,
     required this.usdValue,
     required this.totalBalance,
+    this.dataSource = DataSource.local,
+    this.lastUpdated,
   });
 
   String get formattedTokenAmount =>
@@ -137,12 +242,72 @@ class WalletBalance {
     String? tokenSymbol,
     double? usdValue,
     BigInt? totalBalance,
+    DataSource? dataSource,
+    DateTime? lastUpdated,
   }) {
     return WalletBalance(
       tokenAmount: tokenAmount ?? this.tokenAmount,
       tokenSymbol: tokenSymbol ?? this.tokenSymbol,
       usdValue: usdValue ?? this.usdValue,
       totalBalance: totalBalance ?? this.totalBalance,
+      dataSource: dataSource ?? this.dataSource,
+      lastUpdated: lastUpdated ?? this.lastUpdated,
     );
+  }
+
+  /// Create WalletBalance from ExplorerBalanceResponse
+  factory WalletBalance.fromExplorerBalance(ExplorerBalanceResponse response) {
+    return WalletBalance(
+      tokenAmount: response.balance,
+      tokenSymbol: response.tokenSymbol,
+      usdValue: 0.0, // TODO: Add USD conversion
+      totalBalance: BigInt.from(response.balance.toInt()),
+      dataSource: response.dataSource,
+      lastUpdated: response.fetchedAt,
+    );
+  }
+
+  /// Get data source display text
+  String get dataSourceText {
+    switch (dataSource) {
+      case DataSource.explorerPrimary:
+        return 'Live (Primary)';
+      case DataSource.explorerSecondary:
+        return 'Live (Secondary)';
+      case DataSource.cached:
+        return 'Cached';
+      case DataSource.local:
+        return 'Local';
+    }
+  }
+
+  /// Check if data is from a live explorer API
+  bool get isLiveData => 
+    dataSource == DataSource.explorerPrimary || 
+    dataSource == DataSource.explorerSecondary;
+
+  /// Get time ago text for last update
+  String get lastUpdatedText {
+    if (lastUpdated == null) return '';
+    
+    final now = DateTime.now();
+    final isToday = now.day == lastUpdated!.day && 
+                   now.month == lastUpdated!.month && 
+                   now.year == lastUpdated!.year;
+    
+    if (isToday) {
+      // Format as time with seconds: 14:32:45
+      final hour = lastUpdated!.hour;
+      final minute = lastUpdated!.minute.toString().padLeft(2, '0');
+      final second = lastUpdated!.second.toString().padLeft(2, '0');
+      
+      // Use 24-hour format with seconds
+      return '$hour:$minute:$second';
+    } else {
+      // For dates not today, show the date
+      final month = lastUpdated!.month.toString().padLeft(2, '0');
+      final day = lastUpdated!.day.toString().padLeft(2, '0');
+      return '$month/$day';
+    }
   }
 }

--- a/lib/features/wallet/screens/wallet_screen.dart
+++ b/lib/features/wallet/screens/wallet_screen.dart
@@ -8,6 +8,7 @@ import 'package:crypto_mobile_app/core/providers/accounts_provider.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/core/config/app_router.dart';
+import 'package:crypto_mobile_app/core/services/explorer_service.dart';
 
 class WalletScreen extends ConsumerStatefulWidget {
   const WalletScreen({super.key});
@@ -161,6 +162,27 @@ class _BalanceSection extends StatelessWidget {
                   ),
                 ),
               ),
+            // Data source indicator
+            walletState.when(
+              data: (state) {
+                final balance = state.balance;
+                if (balance.lastUpdated != null) {
+                  return Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      'Last checked: ${balance.lastUpdatedText}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                        fontSize: 11,
+                      ),
+                    ),
+                  );
+                }
+                return const SizedBox.shrink();
+              },
+              loading: () => const SizedBox.shrink(),
+              error: (_, __) => const SizedBox.shrink(),
+            ),
           ],
         ),
       ),
@@ -282,6 +304,47 @@ class _RecentActivityCard extends StatelessWidget {
                 ?.copyWith(fontWeight: FontWeight.w500),
           ),
           const SizedBox(height: 16),
+          // API status banner for transaction data
+          walletState.when(
+            data: (state) {
+              // Check if we have non-local transactions
+              final hasExplorerData = state.recent.any((tx) => 
+                tx.dataSource != DataSource.local);
+              final hasOnlyCachedData = state.recent.every((tx) => 
+                tx.dataSource == DataSource.cached || tx.dataSource == DataSource.local);
+              
+              if (hasExplorerData && hasOnlyCachedData && state.recent.isNotEmpty) {
+                return Container(
+                  margin: const EdgeInsets.only(bottom: 8),
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: Colors.orange.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.orange.withValues(alpha: 0.3)),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(Icons.warning_amber, 
+                           color: Colors.orange.shade700, size: 16),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          'Explorer API unavailable. Showing cached data.',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: Colors.orange.shade700,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }
+              return const SizedBox.shrink();
+            },
+            loading: () => const SizedBox.shrink(),
+            error: (_, __) => const SizedBox.shrink(),
+          ),
           walletState.when(
             data: (state) => state.recent.isEmpty
                 ? _EmptyState(message: l10n.walletNoRecentActivity)
@@ -437,3 +500,4 @@ class _TransactionTile extends StatelessWidget {
     );
   }
 }
+


### PR DESCRIPTION
- Integrate primary/secondary explorer APIs with caching fallback to UTXOs
- Enhance UI to show actual timestamps instead of relative time ("14:32:45")
- Implement graceful degradation when explorer APIs are unavailable
- Add warning banners for cached data usage
- Ensure UTXO transactions are always loaded as final fallback
- Configure explorer endpoints and timeouts via environment variables