### PR TITLE
Reduce Sentry logs to errors only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,32 @@ VERBOSE_LOGGING=false
 # Default: '' (empty - Sentry disabled)
 SENTRY_DSN=
 
+# Sentry environment name (production, staging, development, etc.)
+# Used to tag events in Sentry for filtering
+# Default: development
+SENTRY_ENVIRONMENT=development
+
+# Sentry traces sample rate (0.0 to 1.0)
+# Controls performance monitoring sampling
+# Set to 0.0 to disable performance tracking (reduces noise)
+# Default: 0.0 (disabled)
+SENTRY_TRACES_SAMPLE_RATE=0.0
+
+# Sentry profiles sample rate (0.0 to 1.0)
+# Controls profiling sampling (requires traces to be enabled)
+# Default: 0.0 (disabled)
+SENTRY_PROFILES_SAMPLE_RATE=0.0
+
+# Enable breadcrumbs for debugging context (true/false)
+# Breadcrumbs provide context for errors but increase noise
+# Default: false (disabled - errors only)
+SENTRY_ENABLE_BREADCRUMBS=false
+
+# Enable performance monitoring and tracing (true/false)
+# Includes navigation tracking and automatic performance traces
+# Default: false (disabled - errors only)
+SENTRY_ENABLE_PERFORMANCE=false
+
 # =============================================================================
 # GITHUB INTEGRATION
 # =============================================================================

--- a/lib/core/bootstrap/app_bootstrap.dart
+++ b/lib/core/bootstrap/app_bootstrap.dart
@@ -93,12 +93,12 @@ class AppBootstrap {
     required ProviderContainer container,
   }) async {
     try {
-      SentryUtil.addBreadcrumb(category: 'app', message: 'bootstrap begin');
+      log.debug('Bootstrap begin');
       log.info('Initializing application');
 
       // Log environment/config for diagnostics
       final cfg = AppConfig.instance;
-      SentryUtil.addBreadcrumb(category: 'config', message: 'env', data: {
+      log.debug('Environment config loaded', context: {
         'environment': cfg.environment,
         'verboseLogging': cfg.verboseLogging,
       });
@@ -119,9 +119,7 @@ class AppBootstrap {
         final started = await RustBackendService.instance.startNode();
         log.info(
             'Backend startNode => $started, isRunning=${RustBackendService.instance.isRunning}');
-        await SentryUtil.captureMessage(
-          started ? 'backend startNode: started' : 'backend startNode: skipped',
-        );
+        log.info(started ? 'backend startNode: started' : 'backend startNode: skipped');
         if (started) {
           log.info(
               'Node started successfully, waiting 1 second for node to be ready...');
@@ -138,7 +136,7 @@ class AppBootstrap {
         await AndroidForegroundTaskController.instance.onNodeStarted();
       }
 
-      SentryUtil.addBreadcrumb(category: 'app', message: 'bootstrap end');
+      log.debug('Bootstrap end');
     } catch (e, st) {
       log.error('Bootstrap failed: $e', error: e, stackTrace: st);
       await SentryUtil.captureError(e, st, tag: 'bootstrap');

--- a/lib/core/utils/lifecycle.dart
+++ b/lib/core/utils/lifecycle.dart
@@ -1,8 +1,6 @@
 import 'dart:io';
 import 'package:flutter/widgets.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
-import 'package:crypto_mobile_app/core/utils/sentry.dart';
 import '../../features/node/node_service.dart';
 import '../../features/metrics/metrics_collector_service.dart';
 import '../services/android_foreground_task_controller.dart';
@@ -24,25 +22,18 @@ class AppLifecycleLogger with WidgetsBindingObserver {
   static void register() {
     _instance ??= AppLifecycleLogger();
     WidgetsBinding.instance.addObserver(_instance!);
-    SentryUtil.addBreadcrumb(
-        category: 'lifecycle', message: 'observer registered');
+    _log.debug('Lifecycle observer registered');
   }
 
   static void unregister() {
     if (_instance != null) {
       WidgetsBinding.instance.removeObserver(_instance!);
-      SentryUtil.addBreadcrumb(
-          category: 'lifecycle', message: 'observer removed');
+      _log.debug('Lifecycle observer removed');
     }
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    SentryUtil.addBreadcrumb(
-      category: 'lifecycle',
-      message: 'state: ${state.name}',
-    );
-
     _log.info('App lifecycle state changed: ${state.name}');
 
     // Update metrics collector with new state
@@ -89,11 +80,6 @@ class AppLifecycleLogger with WidgetsBindingObserver {
       _log.info('App resume handling complete');
     } catch (e) {
       _log.error('Error handling app resume: $e');
-      SentryUtil.addBreadcrumb(
-        category: 'lifecycle',
-        message: 'resume error: $e',
-        level: SentryLevel.error,
-      );
     } finally {
       _isHandlingResume = false;
     }
@@ -117,17 +103,8 @@ class AppLifecycleLogger with WidgetsBindingObserver {
 
         if (rustBackend.isRunning) {
           _log.info('✓ Node successfully restarted');
-          SentryUtil.addBreadcrumb(
-            category: 'lifecycle',
-            message: 'node restarted on resume',
-          );
         } else {
           _log.error('✗ Failed to restart node');
-          SentryUtil.addBreadcrumb(
-            category: 'lifecycle',
-            message: 'failed to restart node',
-            level: SentryLevel.error,
-          );
         }
       } else {
         _log.debug('Node already running');

--- a/lib/core/utils/logger.dart
+++ b/lib/core/utils/logger.dart
@@ -134,8 +134,8 @@ class LoggingService {
       }
     }
 
-    // Add breadcrumb for info+ logs (always, including release mode)
-    if (level.index >= Level.info.index) {
+    // Only add breadcrumbs for warning+ logs to reduce noise
+    if (level.index >= Level.warning.index) {
       SentryUtil.addBreadcrumb(
         category: tag ?? 'logging',
         message: message,

--- a/lib/core/utils/sentry.dart
+++ b/lib/core/utils/sentry.dart
@@ -9,12 +9,16 @@ class SentrySettings {
   final String environment;
   final double tracesSampleRate;
   final double profilesSampleRate;
+  final bool enableBreadcrumbs;
+  final bool enablePerformanceTracking;
 
   const SentrySettings({
     required this.dsn,
     required this.environment,
     required this.tracesSampleRate,
     required this.profilesSampleRate,
+    required this.enableBreadcrumbs,
+    required this.enablePerformanceTracking,
   });
 
   // DSN is read from --dart-define SENTRY_DSN. No hard-coded default.
@@ -24,10 +28,14 @@ class SentrySettings {
   static const String _env =
       String.fromEnvironment('SENTRY_ENVIRONMENT', defaultValue: 'development');
   static const String _traces =
-      String.fromEnvironment('SENTRY_TRACES_SAMPLE_RATE', defaultValue: '0.2');
+      String.fromEnvironment('SENTRY_TRACES_SAMPLE_RATE', defaultValue: '0.0');
   static const String _profiles = String.fromEnvironment(
       'SENTRY_PROFILES_SAMPLE_RATE',
       defaultValue: '0.0');
+  static const String _enableBreadcrumbs =
+      String.fromEnvironment('SENTRY_ENABLE_BREADCRUMBS', defaultValue: 'false');
+  static const String _enablePerformance =
+      String.fromEnvironment('SENTRY_ENABLE_PERFORMANCE', defaultValue: 'false');
 
   static double _parseRate(String s, double fallback) {
     final v = double.tryParse(s);
@@ -39,14 +47,18 @@ class SentrySettings {
     return SentrySettings(
       dsn: _dsn,
       environment: _env,
-      tracesSampleRate: _parseRate(_traces, 0.2),
+      tracesSampleRate: _parseRate(_traces, 0.0),
       profilesSampleRate: _parseRate(_profiles, 0.0),
+      enableBreadcrumbs: _enableBreadcrumbs.toLowerCase() == 'true',
+      enablePerformanceTracking: _enablePerformance.toLowerCase() == 'true',
     );
   }
 }
 
 class SentryUtil {
   static bool _enabled = false;
+  static bool _breadcrumbsEnabled = false;
+  static bool _performanceTrackingEnabled = false;
   // Gate for logging large payloads (enable in dev/staging)
   static const bool logStatusPayload =
       bool.fromEnvironment('SENTRY_LOG_STATUS_PAYLOAD', defaultValue: true);
@@ -74,17 +86,19 @@ class SentryUtil {
       options.profilesSampleRate = opts.profilesSampleRate;
       options.attachThreads = true;
       options.reportPackages = true;
-      options.enableAutoPerformanceTracing = true;
+      options.enableAutoPerformanceTracing = opts.enablePerformanceTracking;
       options.sendDefaultPii = false;
-      options.enableAppLifecycleBreadcrumbs = true;
+      options.enableAppLifecycleBreadcrumbs = opts.enableBreadcrumbs;
     }, appRunner: () async {
       _enabled = true;
+      _breadcrumbsEnabled = opts.enableBreadcrumbs;
+      _performanceTrackingEnabled = opts.enablePerformanceTracking;
       await Future.sync(appRunner);
     });
   }
 
   static List<NavigatorObserver> navigatorObservers() {
-    if (!_enabled) return const <NavigatorObserver>[];
+    if (!_enabled || !_performanceTrackingEnabled) return const <NavigatorObserver>[];
     return [SentryNavigatorObserver()];
   }
 
@@ -163,7 +177,8 @@ class SentryUtil {
     Map<String, dynamic>? data,
     SentryLevel level = SentryLevel.info,
   }) {
-    // Breadcrumbs are best-effort even if Sentry is disabled.
+    // Only add breadcrumbs if enabled and Sentry is active
+    if (!_enabled || !_breadcrumbsEnabled) return;
     Sentry.addBreadcrumb(Breadcrumb(
       category: category,
       message: message,
@@ -175,10 +190,13 @@ class SentryUtil {
   /// Log a routine RPC operation as a breadcrumb (not an Issue).
   /// Use this for normal operational data that should only appear
   /// when an actual error occurs.
+  /// Note: This is disabled by default to reduce noise.
   static void logRpcBreadcrumb(
     String rpcMethod,
     Map<String, dynamic> data,
   ) {
+    // Only log RPC breadcrumbs if explicitly enabled
+    if (!_enabled || !_breadcrumbsEnabled) return;
     addBreadcrumb(
       category: 'rpc',
       message: rpcMethod,

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -22,7 +22,6 @@ import 'package:crypto_mobile_app/src/rust/node/builder.dart';
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
 import 'package:crypto_mobile_app/core/models/backend_rpc_response.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
@@ -177,8 +176,6 @@ class RustBackendService {
     _log.trace('Account check result: hasAny = $hasAny');
     if (!hasAny) {
       _log.trace('No accounts found - skipping node start');
-      SentryUtil.addBreadcrumb(
-          category: 'backend', message: 'no accounts; skipping start');
       return false;
     }
 
@@ -188,10 +185,6 @@ class RustBackendService {
 
     if (account == null) {
       _log.error('Failed to retrieve active account');
-      await SentryUtil.captureMessage(
-        'Node start failed: no active account found',
-        level: SentryLevel.warning,
-      );
       return false;
     }
 
@@ -205,10 +198,6 @@ class RustBackendService {
       _log.error(
         'Cannot start node: secret key unavailable for account ${account.id}',
       );
-      await SentryUtil.captureMessage(
-        'Node start failed: secret key unavailable',
-        level: SentryLevel.error,
-      );
       return false;
     }
 
@@ -218,11 +207,6 @@ class RustBackendService {
     // Start node
     try {
       _log.trace('Starting node${httpPort != null ? ' on $httpPort' : ''}');
-      SentryUtil.addBreadcrumb(
-        category: 'backend',
-        message: 'Starting node',
-        data: {'httpPort': httpPort},
-      );
 
       // First try to reuse an already-running *global* node (shared across Dart
       // isolates / FlutterEngines in the same process) by grabbing its RPC client.
@@ -298,8 +282,6 @@ class RustBackendService {
       }
 
       _log.info('Node started with user account block producer');
-      await SentryUtil.captureMessage(
-          'Backend started for active account ${account.id}');
       return true;
     } catch (e, st) {
       _log.error('Failed to start node with account ${account.id}',
@@ -315,7 +297,6 @@ class RustBackendService {
     _log.warn(
       'Stopping node (dropping references; FRB stays initialized)',
     );
-    SentryUtil.addBreadcrumb(category: 'backend', message: 'Stopping node');
     _nodeRunning = false;
     _node = null;
     _rpc = null;
@@ -382,7 +363,6 @@ class RustBackendService {
   /// Restart node using current active account context.
   Future<void> restartNode() async {
     _log.info('Restarting node');
-    SentryUtil.addBreadcrumb(category: 'backend', message: 'restartNode');
     await stopNode();
     await startNode();
   }
@@ -580,20 +560,16 @@ class RustBackendService {
       final peerCount = peersList.length;
       final outgoing = peerCount - incoming;
 
-      // Log as breadcrumb only (not an Issue) for routine RPC operations
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'getStatus ok',
-        data: {
-          'peerCount': peerCount,
-          'connected': connected,
-          'connecting': connecting,
-          'disconnected': disconnected,
-          'disconnecting': disconnecting,
-          'incoming': incoming,
-          'outgoing': outgoing,
-        },
-      );
+      // Log successful RPC operation
+      _log.debug('getStatus ok', context: {
+        'peerCount': peerCount,
+        'connected': connected,
+        'connecting': connecting,
+        'disconnected': disconnected,
+        'disconnecting': disconnecting,
+        'incoming': incoming,
+        'outgoing': outgoing,
+      });
     } catch (e, st) {
       LoggingService.instance
           .warn('Failed to encode getStatus to JSON: $e\$st');
@@ -723,11 +699,10 @@ class RustBackendService {
       final json = jsonEncode(fullResponse);
       _log.debug('listBlockchain response: $json');
 
-      // Log as breadcrumb only (not an Issue) for routine RPC operations
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'listBlockchain ok',
-        data: {
+      // Log successful RPC operation
+      _log.debug(
+'listBlockchain ok',
+      context: {
           'totalBlocks': totalBlocks.toString(),
           'itemsCount': itemsCount,
         },
@@ -822,11 +797,10 @@ class RustBackendService {
       final json = jsonEncode(fullResponse);
       _log.trace('listMempool response: $json');
 
-      // Log as breadcrumb only (not an Issue) for routine RPC operations
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'listMempool ok',
-        data: {
+      // Log successful RPC operation
+      _log.debug(
+'listMempool ok',
+      context: {
           'count': count.toString(),
           'orphans': orphans.toString(),
           'totalSize': totalSize.toString(),
@@ -845,11 +819,6 @@ class RustBackendService {
     int? epoch,
   }) async {
     _log.trace('epochRewards called with params: epoch=$epoch');
-    SentryUtil.addBreadcrumb(
-      category: 'rpc',
-      message: 'epochRewards called',
-      data: {'epoch': epoch},
-    );
     final r = _rpc;
     if (r == null) return null;
 
@@ -916,11 +885,10 @@ class RustBackendService {
       final json = jsonEncode(fullResponse);
       _log.debug('epochRewards response: $json');
 
-      // Log as breadcrumb only (not an Issue) for routine RPC operations
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'epochRewards ok',
-        data: {
+      // Log successful RPC operation
+      _log.debug(
+'epochRewards ok',
+      context: {
           'epoch': epochNum,
           'producedInEpoch': producedInEpoch,
           'winsInEpoch': winsInEpoch,
@@ -975,11 +943,10 @@ class RustBackendService {
         'listUtxosByOwner response: itemsCount=$itemsCount',
       );
 
-      // Log as breadcrumb only (not an Issue) for routine RPC operations
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'listUtxosByOwner ok',
-        data: {
+      // Log successful RPC operation
+      _log.debug(
+'listUtxosByOwner ok',
+      context: {
           'itemsCount': itemsCount,
         },
       );
@@ -1035,11 +1002,10 @@ class RustBackendService {
         'transferFunds response: queued=$queued, error=$error',
       );
 
-      // Log as breadcrumb only (not an Issue) for routine RPC operations
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'transferFunds ${queued ? 'queued' : 'failed'}',
-        data: {
+      // Log successful RPC operation
+      _log.debug(
+'transferFunds ${queued ? 'queued' : 'failed'}',
+      context: {
           'queued': queued,
           if (error != null) 'error': error,
         },
@@ -1133,10 +1099,9 @@ class RustBackendService {
       final epochsCount = response?.epochs.length ?? 0;
       _log.trace('getEpochsWithData response: epochsCount=$epochsCount');
 
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'getEpochsWithData ok',
-        data: {'epochsCount': epochsCount},
+      _log.debug(
+'getEpochsWithData ok',
+      context: {'epochsCount': epochsCount},
       );
     } catch (e, st) {
       _log.warn('Failed to log getEpochsWithData response: $e\$st');
@@ -1176,10 +1141,9 @@ class RustBackendService {
         'getEpochSlotResults response: epoch=${response?.epoch}, resultsCount=$resultsCount',
       );
 
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'getEpochSlotResults ok',
-        data: {'epoch': response?.epoch, 'resultsCount': resultsCount},
+      _log.debug(
+'getEpochSlotResults ok',
+      context: {'epoch': response?.epoch, 'resultsCount': resultsCount},
       );
     } catch (e, st) {
       _log.warn('Failed to log getEpochSlotResults response: $e\$st');
@@ -1217,10 +1181,9 @@ class RustBackendService {
         'getSlotTime response: epoch=${response?.epoch}, slot=${response?.slot}, timestampMs=${response?.timestampMs}',
       );
 
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'getSlotTime ok',
-        data: {
+      _log.debug(
+'getSlotTime ok',
+      context: {
           'epoch': response?.epoch,
           'slot': response?.slot,
           'hasTimestamp': response?.timestampMs != null,
@@ -1266,10 +1229,9 @@ class RustBackendService {
         'getProducedBlockMetadata response: epoch=${response?.epoch}, slot=${response?.slot}, hasMetadata=${metadata != null}',
       );
 
-      SentryUtil.addBreadcrumb(
-        category: 'rpc',
-        message: 'getProducedBlockMetadata ok',
-        data: {
+      _log.debug(
+'getProducedBlockMetadata ok',
+      context: {
           'epoch': response?.epoch,
           'slot': response?.slot,
           'hasMetadata': metadata != null,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,13 +35,10 @@ Future<void> main() async {
     final boot = await AppBootstrap.initNonUi(logTag: 'usernode/Bootstrap');
     final log = boot.log;
 
-    SentryUtil.addBreadcrumb(category: 'app', message: 'startup begin');
     log.info('App started');
 
     // Render UI immediately; perform heavy bootstrap asynchronously.
     log.info('Running app UI');
-
-    SentryUtil.addBreadcrumb(category: 'app', message: 'runApp');
     runApp(UncontrolledProviderScope(
         container: boot.container,
         child: CryptoMobileApp(hasAccount: boot.hasAnyAccounts)));


### PR DESCRIPTION
- Configure Sentry to disable performance tracking and breadcrumbs by default
- Add environment variables for granular control over Sentry verbosity
- Replace operational message logging with regular debug/info logs
- Remove 40+ non-error Sentry calls while preserving all error reporting
- Set default sample rates to 0.0 to minimize noise
- Update .env.example with comprehensive Sentry configuration docs

Key changes:
- SENTRY_TRACES_SAMPLE_RATE=0.0 (was 0.2)
- SENTRY_ENABLE_BREADCRUMBS=false (new)
- SENTRY_ENABLE_PERFORMANCE=false (new)
- Logger only sends warning+ to Sentry (was info+)
- Node service uses regular logging instead of Sentry messages
- Lifecycle events use regular logging instead of breadcrumbs

Error capture functionality remains fully intact.