### PR TITLE
fix: add token decimal conversion (8 decimals) for transfer amounts

### DIFF
--- a/lib/core/config/token_config.dart
+++ b/lib/core/config/token_config.dart
@@ -1,0 +1,25 @@
+/// Token configuration constants
+class TokenConfig {
+  /// Number of decimal places for the token
+  /// Similar to Bitcoin (8 decimals) or Ethereum (18 decimals)
+  /// 1 TOKEN = 10^8 smallest units
+  static const int decimals = 8;
+  
+  /// Conversion factor: 10^decimals
+  /// Used to convert user-friendly amounts to smallest units
+  static final BigInt conversionFactor = BigInt.from(100000000); // 10^8
+  
+  /// Convert user input amount (with decimals) to smallest units (BigInt)
+  /// Example: 0.1 TOKEN -> 10000000 smallest units
+  static BigInt toSmallestUnit(double amount) {
+    // Multiply by conversion factor and round to nearest integer
+    final scaled = amount * conversionFactor.toInt();
+    return BigInt.from(scaled.round());
+  }
+  
+  /// Convert smallest units (BigInt) to user-friendly amount (double)
+  /// Example: 10000000 smallest units -> 0.1 TOKEN
+  static double fromSmallestUnit(BigInt smallestUnits) {
+    return smallestUnits.toDouble() / conversionFactor.toInt();
+  }
+}

--- a/lib/core/providers/wallet_provider.dart
+++ b/lib/core/providers/wallet_provider.dart
@@ -11,6 +11,7 @@ import 'package:crypto_mobile_app/core/providers/mempool_provider.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/services/explorer_service.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
+import 'package:crypto_mobile_app/core/config/token_config.dart';
 
 final _log = LoggingService.instance.withTag('usernode/WalletProvider');
 
@@ -147,7 +148,7 @@ class WalletController extends AsyncNotifier<WalletState> {
     _log.debug('Calculated balance from UTXOs: ${totalBalance.toString()}');
 
     return WalletBalance(
-      tokenAmount: totalBalance.toDouble(),
+      tokenAmount: TokenConfig.fromSmallestUnit(totalBalance),
       tokenSymbol: primaryTokenSymbol,
       usdValue: 0.0,
       totalBalance: totalBalance,
@@ -181,7 +182,7 @@ class WalletController extends AsyncNotifier<WalletState> {
             id: utxoData['id']?.toString() ?? 'utxo_$i',
             title: 'Received',
             subtitle: 'Token transfer',
-            amount: balance.toDouble(),
+            amount: TokenConfig.fromSmallestUnit(BigInt.from(balance)),
             tokenSymbol: tokenSymbol,
             type: TransactionType.receive,
             status: TransactionStatus.completed,
@@ -410,7 +411,7 @@ class WalletController extends AsyncNotifier<WalletState> {
     // Calculate total amount - check locally stored pending transactions first
     double amount = 0.0;
     if (txItem.amounts.isNotEmpty) {
-      amount = txItem.amounts.first.amount.toDouble();
+      amount = TokenConfig.fromSmallestUnit(txItem.amounts.first.amount);
     }
 
     // Ensure pending "send" amounts are displayed as negative in the UI.

--- a/lib/features/wallet/screens/send_screen.dart
+++ b/lib/features/wallet/screens/send_screen.dart
@@ -8,6 +8,7 @@ import 'package:crypto_mobile_app/core/providers/recipient_history_provider.dart
 import 'package:crypto_mobile_app/features/wallet/transaction_limits_service.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
 import 'package:crypto_mobile_app/core/config/app_router.dart';
+import 'package:crypto_mobile_app/core/config/token_config.dart';
 
 class SendScreen extends ConsumerStatefulWidget {
   const SendScreen({super.key});
@@ -84,9 +85,11 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       final recipientAddress = _addressController.text.trim();
       final toPkHash = frb_types.publicKeyHashFromString(s: recipientAddress);
 
-      // Parse amount (keep as entered, no multiplication)
+      // Parse amount and convert to smallest units
+      // Example: 0.1 TOKEN -> 10000000 smallest units
       final amountStr = _amountController.text.trim();
-      final amount = BigInt.from(double.parse(amountStr).round());
+      final userAmount = double.parse(amountStr);
+      final amount = TokenConfig.toSmallestUnit(userAmount);
 
       // Call the transfer funds RPC
       final response = await RustBackendService.instance.transferFunds(


### PR DESCRIPTION
## 🐛 Bug Fix: Implement Token Decimal Conversion for Transfer Amounts

### 📋 Problem Description

**Issue**: On iOS, users cannot transfer amounts between 0.1-0.4 tokens. The transaction fails with error: "amount must be greater than zero"

**Root Cause**: The code was converting user input directly to BigInt using `.toInt()`, which truncates decimal values:
- Input: 0.1 → Conversion: `0.1.toInt()` = 0 → Result: ❌ Rejected (amount = 0)
- Input: 0.5 → Conversion: `0.5.toInt()` = 0 → Result: ❌ Rejected (amount = 0)
- Input: 1.0 → Conversion: `1.0.toInt()` = 1 → Result: ✅ Accepted

### ✅ Solution

Implemented proper blockchain-style decimal handling similar to ETH/Cosmos:
- **1 TOKEN = 10^8 smallest units** (8 decimal places, like Bitcoin)
- User inputs decimal amounts (e.g., 0.1)
- System converts to smallest units (e.g., 0.1 → 10,000,000)
- Backend processes integer amounts (no precision loss)

### 📝 Changes Made

#### 1. **New File**: token_config.dart
- Defines token decimals (8 places)
- Provides conversion methods:
  - `toSmallestUnit()`: User amount → Blockchain units
  - `fromSmallestUnit()`: Blockchain units → User amount

#### 2. **Modified**: send_screen.dart
- Import `TokenConfig`
- Convert user input using `TokenConfig.toSmallestUnit(userAmount)`
- Maintains decimal input support (no integer-only restriction)

#### 3. **Modified**: wallet_provider.dart
- Import `TokenConfig`
- Convert balance display using `TokenConfig.fromSmallestUnit(totalBalance)`
- Convert transaction amounts for proper display

### 🧪 Testing Required (NOT YET TESTED)

**⚠️ This PR has not been tested. Please verify before merging:**

#### iOS Testing
- [ ] Can transfer 0.1 tokens successfully
- [ ] Can transfer 0.4 tokens successfully
- [ ] Can transfer 0.5 tokens successfully
- [ ] Can transfer 1.5 tokens successfully
- [ ] Decimal keyboard displays correctly
- [ ] No validation errors for valid decimal amounts

#### Balance Display
- [ ] Wallet balance displays correctly (e.g., 100,000,000 units → 1.0 TOKEN)
- [ ] Transaction history shows correct amounts
- [ ] Received transactions display proper decimal values

#### Edge Cases
- [ ] Very small amounts (0.00000001) work correctly
- [ ] Large amounts with decimals work (999.12345678)
- [ ] Precision is maintained (no rounding errors)

#### Android Testing
- [ ] All above tests pass on Android
- [ ] No regression in transfer functionality

### 🔍 Conversion Examples

```dart
// User Input → Smallest Units
0.1        → 10,000,000
0.5        → 50,000,000
1.0        → 100,000,000
1.23456789 → 123,456,789 (rounded to 8 decimals)

// Smallest Units → Display
10,000,000   → 0.1 TOKEN
100,000,000  → 1.0 TOKEN
```

### ⚠️ Potential Risks

1. **Decimal Places Assumption**: Assumes 8 decimals. If backend uses different precision, this needs adjustment.
2. **Existing Balances**: If existing UTXO amounts are already in user-friendly format (not smallest units), this will display incorrectly.
3. **Floating Point Precision**: Very large amounts may have precision issues.
4. **Explorer API**: Assumes explorer API returns amounts in smallest units. If not, may need conversion there too.

### 🔄 Rollback Plan

If issues arise, revert these commits:
```bash
git revert HEAD
```

Then restore original logic:
```dart
final amount = BigInt.from(double.parse(amountStr).round());
```

### 📌 Related

- Fixes iOS transfer validation issue
- Aligns with blockchain standard practices (BTC, ETH, ATOM)
- Improves UX by supporting decimal amounts

---

**Reviewer Notes**: Please test thoroughly on both iOS and Android before merging. Verify with backend team that amounts are indeed stored in smallest units (10^8).