### PR TITLE
Usernode dapps tab

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -60,5 +60,18 @@
         <string>UIInterfaceOrientationPortrait</string>
         <string>UIInterfaceOrientationPortraitUpsideDown</string>
     </array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/lib/core/config/l10n/app_en.arb
+++ b/lib/core/config/l10n/app_en.arb
@@ -710,13 +710,17 @@
     "description": "Not available fallback text"
   },
 
-  "navProducedBlocks": "Produced Blocks",
+  "navProducedBlocks": "Blocks",
   "@navProducedBlocks": {
     "description": "Navigation bar label for produced blocks tab"
   },
   "navWallet": "Wallet",
   "@navWallet": {
     "description": "Navigation bar label for wallet tab"
+  },
+  "navDapps": "dApps",
+  "@navDapps": {
+    "description": "Navigation bar label for dapps tab"
   },
   "navNodeStatus": "Node Status",
   "@navNodeStatus": {

--- a/lib/core/config/l10n/app_localizations.dart
+++ b/lib/core/config/l10n/app_localizations.dart
@@ -1057,7 +1057,7 @@ abstract class AppLocalizations {
   /// Navigation bar label for produced blocks tab
   ///
   /// In en, this message translates to:
-  /// **'Produced Blocks'**
+  /// **'Blocks'**
   String get navProducedBlocks;
 
   /// Navigation bar label for wallet tab
@@ -1065,6 +1065,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Wallet'**
   String get navWallet;
+
+  /// Navigation bar label for dapps tab
+  ///
+  /// In en, this message translates to:
+  /// **'dApps'**
+  String get navDapps;
 
   /// Navigation bar label for node status tab
   ///

--- a/lib/core/config/l10n/app_localizations_en.dart
+++ b/lib/core/config/l10n/app_localizations_en.dart
@@ -544,10 +544,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get nodeNotAvailable => 'Not available';
 
   @override
-  String get navProducedBlocks => 'Produced Blocks';
+  String get navProducedBlocks => 'Blocks';
 
   @override
   String get navWallet => 'Wallet';
+
+  @override
+  String get navDapps => 'dApps';
 
   @override
   String get navNodeStatus => 'Node Status';

--- a/lib/dapps/dapps_screen.dart
+++ b/lib/dapps/dapps_screen.dart
@@ -1,0 +1,385 @@
+import 'dart:convert';
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:crypto_mobile_app/core/providers/accounts_provider.dart';
+import 'package:crypto_mobile_app/features/node/node_service.dart';
+import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
+
+class DappsScreen extends ConsumerStatefulWidget {
+  const DappsScreen({super.key});
+
+  @override
+  ConsumerState<DappsScreen> createState() => _DappsScreenState();
+}
+
+class _DappsScreenState extends ConsumerState<DappsScreen> {
+  late final WebViewController _controller;
+  bool _canGoBack = false;
+  int _progress = 0;
+
+  static const _jsChannelName = 'Usernode';
+
+  final TextEditingController _urlController = TextEditingController();
+  final FocusNode _urlFocusNode = FocusNode();
+  final List<DateTime> _secretTaps = <DateTime>[];
+  Timer? _secretTapResetTimer;
+  bool _showUrlEditor = false;
+
+  static Uri _defaultDappUri() {
+    // Note: "localhost" inside a mobile simulator/device refers to the device itself.
+    // - Android emulator: use 10.0.2.2 to reach the host machine's localhost.
+    // - iOS simulator / Flutter web: localhost usually works as expected.
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      return Uri.parse('http://10.0.2.2:8000');
+    }
+    return Uri.parse('http://localhost:8000');
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..addJavaScriptChannel(
+        _jsChannelName,
+        onMessageReceived: (message) async {
+          try {
+            final payload = jsonDecode(message.message) as Map<String, dynamic>;
+            final method = payload['method'] as String?;
+            final id = payload['id'] as String?;
+            if (method == null || id == null) return;
+
+            if (method == 'getNodeAddress') {
+              final address = await _getActiveNodeAddress();
+              if (address == null || address.isEmpty) {
+                await _resolveJsPromise(
+                  id: id,
+                  value: null,
+                  error: 'No active account/address available',
+                );
+              } else {
+                await _resolveJsPromise(id: id, value: address, error: null);
+              }
+            }
+
+            if (method == 'sendTransaction') {
+              final args = payload['args'];
+              if (args is! Map<String, dynamic>) {
+                await _resolveJsPromise(
+                  id: id,
+                  value: null,
+                  error: 'Missing args',
+                );
+                return;
+              }
+
+              final destinationPubkey =
+                  (args['destination_pubkey'] as String?)?.trim();
+              final amountRaw = args['amount'];
+              final memo = (args['memo'] as String?)?.trim();
+
+              if (destinationPubkey == null || destinationPubkey.isEmpty) {
+                await _resolveJsPromise(
+                  id: id,
+                  value: null,
+                  error: 'destination_pubkey is required',
+                );
+                return;
+              }
+
+              final amount = _parseAmountToBigInt(amountRaw);
+              if (amount == null) {
+                await _resolveJsPromise(
+                  id: id,
+                  value: null,
+                  error: 'Invalid amount',
+                );
+                return;
+              }
+
+              final fromAddress = await _getActiveNodeAddress();
+              if (fromAddress == null || fromAddress.isEmpty) {
+                await _resolveJsPromise(
+                  id: id,
+                  value: null,
+                  error: 'No active account/address available',
+                );
+                return;
+              }
+
+              // NOTE: memo is accepted for API compatibility, but not yet
+              // supported by the underlying transfer RPC.
+              // TODO: plumb memo through once Rust RPC supports it.
+              final _ = memo;
+
+              final fromPkHash =
+                  frb_types.publicKeyHashFromString(s: fromAddress);
+              final toPkHash =
+                  frb_types.publicKeyHashFromString(s: destinationPubkey);
+
+              final resp = await RustBackendService.instance.transferFunds(
+                fromPkHash: fromPkHash,
+                amount: amount,
+                toPkHash: toPkHash,
+              );
+
+              await _resolveJsPromise(
+                id: id,
+                value: <String, dynamic>{
+                  'queued': resp?.queued ?? false,
+                  'error': resp?.error,
+                },
+                error: null,
+              );
+            }
+          } catch (_) {
+            // Ignore malformed messages.
+          }
+        },
+      )
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageStarted: (_) async {
+            if (!mounted) return;
+            setState(() => _progress = 0);
+            await _syncNavState();
+          },
+          onProgress: (progress) {
+            if (!mounted) return;
+            // progress is 0..100
+            if (progress != _progress) {
+              setState(() => _progress = progress);
+            }
+          },
+          onPageFinished: (_) async {
+            if (!mounted) return;
+            setState(() => _progress = 100);
+            await _syncNavState();
+          },
+          onNavigationRequest: (_) async {
+            // Keep the back button state in sync even while navigating.
+            await _syncNavState();
+            return NavigationDecision.navigate;
+          },
+          onWebResourceError: (_) {
+            if (!mounted) return;
+            // Ensure the progress bar doesn't get stuck forever on load failures.
+            setState(() => _progress = 100);
+          },
+        ),
+      )
+      ..loadRequest(_defaultDappUri());
+  }
+
+  @override
+  void dispose() {
+    _secretTapResetTimer?.cancel();
+    _urlController.dispose();
+    _urlFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _onSecretTap() {
+    final now = DateTime.now();
+    _secretTaps.add(now);
+    // Keep only last 3 taps
+    if (_secretTaps.length > 3) {
+      _secretTaps.removeAt(0);
+    }
+
+    // Reset window after a short delay so taps must be "fast"
+    _secretTapResetTimer?.cancel();
+    _secretTapResetTimer = Timer(const Duration(milliseconds: 900), () {
+      _secretTaps.clear();
+    });
+
+    if (_secretTaps.length == 3) {
+      final first = _secretTaps.first;
+      final last = _secretTaps.last;
+      final delta = last.difference(first);
+      if (delta <= const Duration(milliseconds: 800)) {
+        setState(() {
+          _showUrlEditor = !_showUrlEditor;
+        });
+
+        if (_showUrlEditor) {
+          // Prefill with current URL (best-effort).
+          () async {
+            try {
+              final current = await _controller.currentUrl();
+              if (!mounted) return;
+              if (!_showUrlEditor) return;
+              if (_urlController.text.trim().isNotEmpty) return;
+              _urlController.text = current ?? '';
+            } catch (_) {
+              // Ignore.
+            }
+          }();
+
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            _urlFocusNode.requestFocus();
+          });
+        }
+      }
+      _secretTaps.clear();
+    }
+  }
+
+  Uri? _normalizeUserUrl(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return null;
+
+    // If user entered without scheme, assume http.
+    final withScheme = trimmed.contains('://') ? trimmed : 'http://$trimmed';
+    final parsed = Uri.tryParse(withScheme);
+    if (parsed == null || parsed.host.isEmpty) return null;
+
+    // Android emulator: map localhost -> host machine.
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      if (parsed.host == 'localhost') {
+        return parsed.replace(host: '10.0.2.2');
+      }
+    }
+    return parsed;
+  }
+
+  Future<void> _loadUrlFromInput() async {
+    final uri = _normalizeUserUrl(_urlController.text);
+    if (uri == null) return;
+    await _controller.loadRequest(uri);
+  }
+
+  Future<String?> _getActiveNodeAddress() async {
+    final repo = await ref.read(accountsProvider.future);
+    final active = await repo.getActive();
+    return active?.address;
+  }
+
+  Future<void> _resolveJsPromise({
+    required String id,
+    required Object? value,
+    required String? error,
+  }) async {
+    // Uses JSON encoding so values are safely escaped for JS.
+    final js = 'window.__usernodeResolve(${jsonEncode(id)},'
+        ' ${jsonEncode(value)}, ${jsonEncode(error)});';
+    try {
+      await _controller.runJavaScript(js);
+    } catch (_) {
+      // Ignore callback failures.
+    }
+  }
+
+  BigInt? _parseAmountToBigInt(Object? amountRaw) {
+    if (amountRaw is num) {
+      return BigInt.from(amountRaw.round());
+    }
+    if (amountRaw is String) {
+      final trimmed = amountRaw.trim();
+      if (trimmed.isEmpty) return null;
+      final parsed = double.tryParse(trimmed);
+      if (parsed == null) return null;
+      return BigInt.from(parsed.round());
+    }
+    return null;
+  }
+
+  Future<void> _syncNavState() async {
+    final canGoBack = await _controller.canGoBack();
+    if (!mounted) return;
+    if (canGoBack != _canGoBack) {
+      setState(() => _canGoBack = canGoBack);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showLoading = _progress < 100;
+    final theme = Theme.of(context);
+
+    final bottomWidgets = <Widget>[
+      if (showLoading)
+        LinearProgressIndicator(
+          minHeight: 2,
+          value: _progress <= 0 ? null : _progress / 100,
+        ),
+      if (_showUrlEditor)
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _urlController,
+                  focusNode: _urlFocusNode,
+                  keyboardType: TextInputType.url,
+                  textInputAction: TextInputAction.go,
+                  onSubmitted: (_) => _loadUrlFromInput(),
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    hintText: 'Enter URL (e.g. localhost:8000)',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              FilledButton(
+                onPressed: _loadUrlFromInput,
+                child: const Text('Go'),
+              ),
+              const SizedBox(width: 8),
+              IconButton(
+                tooltip: 'Refresh',
+                onPressed: () => _controller.reload(),
+                icon: const Icon(Icons.refresh),
+              ),
+            ],
+          ),
+        ),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          tooltip: 'Back',
+          onPressed: _canGoBack ? () => _controller.goBack() : null,
+          icon: const Icon(Icons.arrow_back),
+        ),
+        titleSpacing: 0,
+        actions: [
+          // Hidden "triple-tap" button. Tap 3x quickly to reveal URL editor.
+          Opacity(
+            opacity: 0,
+            child: IconButton(
+              tooltip: 'Hidden',
+              onPressed: _onSecretTap,
+              icon: const Icon(Icons.more_horiz),
+            ),
+          ),
+        ],
+        bottom: bottomWidgets.isEmpty
+            ? null
+            : PreferredSize(
+                preferredSize: Size.fromHeight(
+                  (showLoading ? 2 : 0) + (_showUrlEditor ? 62 : 0),
+                ),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(color: theme.colorScheme.surface),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: bottomWidgets,
+                  ),
+                ),
+              ),
+      ),
+      body: WebViewWidget(controller: _controller),
+    );
+  }
+}
+

--- a/lib/features/dapps/dapps_screen.dart
+++ b/lib/features/dapps/dapps_screen.dart
@@ -1,14 +1,13 @@
-import 'dart:convert';
 import 'dart:async';
-
-import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
-import 'package:webview_flutter/webview_flutter.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'dart:convert';
 
 import 'package:crypto_mobile_app/core/providers/accounts_provider.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart' as frb_types;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 class DappsScreen extends ConsumerStatefulWidget {
   const DappsScreen({super.key});

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:crypto_mobile_app/features/wallet/screens/wallet_screen.dart';
 import 'package:crypto_mobile_app/features/node/screens/produced_blocks_screen.dart';
 import 'package:crypto_mobile_app/features/node/screens/node_status_screen.dart';
 import 'package:crypto_mobile_app/features/settings/screens/background_production_settings_screen.dart';
+import 'package:crypto_mobile_app/dapps/dapps_screen.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/core/providers/providers.dart';
@@ -52,8 +53,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         index: _index,
         children: const [
           ProducedBlocksScreen(),
-          NodeStatusScreen(),
           WalletScreen(),
+          DappsScreen(),
+          NodeStatusScreen(),
           BackgroundProductionSettingsScreen(),
         ],
       ),
@@ -93,14 +95,19 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 label: l10n.navProducedBlocks,
               ),
               NavigationDestination(
-                icon: const Icon(Icons.check_circle_outline),
-                selectedIcon: const Icon(Icons.check_circle),
-                label: l10n.navNodeStatus,
-              ),
-              NavigationDestination(
                 icon: const Icon(Icons.account_balance_wallet_outlined),
                 selectedIcon: const Icon(Icons.account_balance_wallet),
                 label: l10n.navWallet,
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.apps_outlined),
+                selectedIcon: const Icon(Icons.apps),
+                label: l10n.navDapps,
+              ),
+              NavigationDestination(
+                icon: const Icon(Icons.check_circle_outline),
+                selectedIcon: const Icon(Icons.check_circle),
+                label: l10n.navNodeStatus,
               ),
               NavigationDestination(
                 icon: const Icon(Icons.settings_outlined),

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -4,7 +4,7 @@ import 'package:crypto_mobile_app/features/wallet/screens/wallet_screen.dart';
 import 'package:crypto_mobile_app/features/node/screens/produced_blocks_screen.dart';
 import 'package:crypto_mobile_app/features/node/screens/node_status_screen.dart';
 import 'package:crypto_mobile_app/features/settings/screens/background_production_settings_screen.dart';
-import 'package:crypto_mobile_app/dapps/dapps_screen.dart';
+import 'package:crypto_mobile_app/features/dapps/dapps_screen.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/core/providers/providers.dart';

--- a/lib/features/node/screens/node_status_screen.dart
+++ b/lib/features/node/screens/node_status_screen.dart
@@ -314,7 +314,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen>
   Widget build(BuildContext context) {
     // React to tab changes
     final currentTab = ref.watch(currentHomeTabProvider);
-    final shouldBeActive = currentTab == 1;
+    final shouldBeActive = currentTab == 3;
     if (shouldBeActive != _active) {
       _log.debug(
           'Tab change detected: currentTab=$currentTab, shouldBeActive=$shouldBeActive, _active=$_active');

--- a/lib/features/settings/screens/background_production_settings_screen.dart
+++ b/lib/features/settings/screens/background_production_settings_screen.dart
@@ -36,7 +36,7 @@ class _BackgroundProductionSettingsScreenState
   bool _iosKeepAliveActive = false;
   Timer? _autoTimer;
   bool _refreshing = false;
-  bool _active = false; // active when Settings tab is selected (index 2)
+  bool _active = false; // active when Settings tab is selected (index 4)
 
   // Package info (app version)
   PackageInfo? _packageInfo;
@@ -69,7 +69,7 @@ class _BackgroundProductionSettingsScreenState
 
   bool _isActiveTab() {
     try {
-      return ref.read(currentHomeTabProvider) == 2;
+      return ref.read(currentHomeTabProvider) == 4;
     } catch (_) {
       return false;
     }

--- a/lib/features/wallet/screens/wallet_screen.dart
+++ b/lib/features/wallet/screens/wallet_screen.dart
@@ -48,9 +48,9 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
   void _startAutoRefresh() {
     _refreshTimer?.cancel();
     _refreshTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
-      // Only refresh if currently on wallet tab (index 2)
+      // Only refresh if currently on wallet tab (index 1)
       final currentTab = ref.read(currentHomeTabProvider);
-      if (currentTab == 2) {
+      if (currentTab == 1) {
         await ref.read(walletProvider.notifier).silentRefresh();
         await ref.read(nodeStatusProvider.notifier).silentRefresh();
 
@@ -93,8 +93,8 @@ class _WalletScreenState extends ConsumerState<WalletScreen> {
     // Listen for tab changes to refresh when wallet tab becomes active
     ref.listen<int>(currentHomeTabProvider, (previous, next) {
       _log.debug('Tab changed from $previous to $next');
-      // Refresh wallet data when switching to wallet tab (index 2)
-      if (next == 2 && previous != 2) {
+      // Refresh wallet data when switching to wallet tab (index 1)
+      if (next == 1 && previous != 1) {
         _log.debug('Switching to wallet tab - triggering refresh');
         _onRefresh();
       }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -16,6 +16,7 @@ import sentry_flutter
 import shared_preferences_foundation
 import url_launcher_macos
 import wakelock_plus
+import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   BatteryPlusMacosPlugin.register(with: registry.registrar(forPlugin: "BatteryPlusMacosPlugin"))
@@ -29,4 +30,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
+  WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1297,6 +1297,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.1"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: eeeb3fcd5f0ff9f8446c9f4bbc18a99b809e40297528a3395597d03aafb9f510
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.11"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: e49f378ed066efb13fc36186bbe0bd2425630d4ea0dbc71a18fdd0e4d8ed8ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.23.5"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   permission_handler: "^11.0.0"
   crypto: "^3.0.3"
   url_launcher: "^6.2.0"
+  webview_flutter: "^4.10.0"
 dev_dependencies:
   flutter_lints: "^5.0.0"
   flutter_test:

--- a/rust_builder/cargokit/build_tool/lib/src/target.dart
+++ b/rust_builder/cargokit/build_tool/lib/src/target.dart
@@ -22,19 +22,19 @@ class Target {
       rust: 'aarch64-linux-android',
       flutter: 'android-arm64',
       android: 'arm64-v8a',
-      androidMinSdkVersion: 21,
+      androidMinSdkVersion: 28,
     ),
     Target(
       rust: 'i686-linux-android',
       flutter: 'android-x86',
       android: 'x86',
-      androidMinSdkVersion: 16,
+      androidMinSdkVersion: 28,
     ),
     Target(
       rust: 'x86_64-linux-android',
       flutter: 'android-x64',
       android: 'x86_64',
-      androidMinSdkVersion: 21,
+      androidMinSdkVersion: 28,
     ),
     Target(
       rust: 'x86_64-pc-windows-msvc',


### PR DESCRIPTION
Added a tab for dapps (see usernode-dapp-starter for the other half of this).

Still missing:
- memo / data field in sendTransaction
- deciding how the start page list dapps for now (is this a remote HTML? An XML with dapp urls?)