### PR TITLE
fix(android): prevent ANR by skipping VRF poll in foreground

### DIFF
--- a/android/app/src/main/kotlin/com/example/mobile_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mobile_app/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.usernode_labs.usernode
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmMethodChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmMethodChannelHandler.kt
@@ -2,7 +2,6 @@ package com.usernode_labs.usernode.alarm
 
 import android.Manifest
 import android.app.Activity
-import android.app.ActivityManager
 import android.app.AlarmManager
 import android.content.Context
 import android.content.Intent
@@ -460,14 +459,7 @@ class AlarmMethodChannelHandler(context: Context) {
     }
 
     private fun isForegroundServiceRunning(): Boolean {
-        val activityManager = appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        @Suppress("DEPRECATION")
-        for (service in activityManager.getRunningServices(Int.MAX_VALUE)) {
-            if (SlotMonitoringService::class.java.name == service.service.className) {
-                return true
-            }
-        }
-        return false
+        return SlotMonitoringService.isForegroundServiceActive
     }
 
     private fun isWakelockHeld(): Boolean {

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -25,6 +25,7 @@ class AndroidForegroundTaskController {
   Timer? _pollTimer;
   bool _initialized = false;
   bool _wakelockHeld = false;
+  bool _isPolling = false;
   AccountPublicKey? _cachedOurPubKey;
   ({int height, DateTime since})? _awaitingOtherProducerState;
 
@@ -142,6 +143,18 @@ class AndroidForegroundTaskController {
   }
 
   Future<void> _pollVrf() async {
+    if (_isPolling) {
+      _log.warn('_pollVrf overlap detected, skipping');
+      return;
+    }
+
+    final lifecycleState = WidgetsBinding.instance.lifecycleState;
+    if (lifecycleState == AppLifecycleState.resumed) {
+      _log.debug('Skipping VRF poll: app is in foreground');
+      return;
+    }
+
+    _isPolling = true;
     try {
       final info = await RustBackendService.instance.getEpochInfo();
       if (info == null) {
@@ -193,6 +206,8 @@ class AndroidForegroundTaskController {
       }
     } catch (e, st) {
       _log.error('VRF poll failed', error: e, stackTrace: st);
+    } finally {
+      _isPolling = false;
     }
   }
 

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -26,6 +26,7 @@ class AndroidForegroundTaskController {
   bool _initialized = false;
   bool _wakelockHeld = false;
   bool _isPolling = false;
+  bool _isStartingMonitoring = false;
   AccountPublicKey? _cachedOurPubKey;
   ({int height, DateTime since})? _awaitingOtherProducerState;
 
@@ -75,29 +76,45 @@ class AndroidForegroundTaskController {
 
   Future<void> startMonitoring({String reason = 'manual'}) async {
     if (!Platform.isAndroid) return;
-    await initialize();
 
-    // Ensure the Rust node is running before polling VRF or scheduling alarms.
-    final nodeOk = await _ensureNodeRunning();
-    if (!nodeOk) {
-      _log.error('Cannot start monitoring: node failed to start');
+    // Guard against the ANR cascade: each ANR-dismiss triggers a resume →
+    // startMonitoring → heavy FRB work → another ANR. Skip if either:
+    // - poll timer is already running (monitoring fully set up), or
+    // - a previous startMonitoring call is still executing (mid-bootstrap)
+    if (_pollTimer != null || _isStartingMonitoring) {
+      _log.info(
+          'startMonitoring($reason) skipped: already active');
       return;
     }
+    _isStartingMonitoring = true;
+    try {
+      await initialize();
 
-    await _acquireWakelock();
+      // Ensure the Rust node is running before polling VRF or scheduling alarms.
+      final nodeOk = await _ensureNodeRunning();
+      if (!nodeOk) {
+        _log.error('Cannot start monitoring: node failed to start');
+        return;
+      }
 
-    final running =
-        await PlatformAlarmService.instance.isForegroundServiceRunning();
-    if (!running) {
-      final result = await PlatformAlarmService.instance.startForegroundService(
-        title: 'Usernode',
-        message: 'Evaluating VRF slots',
-        slotNumber: 0,
-      );
-      _log.info('Foreground service start result: $result');
+      await _acquireWakelock();
+
+      final running =
+          await PlatformAlarmService.instance.isForegroundServiceRunning();
+
+      if (!running) {
+        await PlatformAlarmService.instance.startForegroundService(
+          title: 'Usernode',
+          message: 'Evaluating VRF slots',
+          slotNumber: 0,
+        );
+      }
+
+      _startPollTimer();
+      _log.info('startMonitoring($reason) complete');
+    } finally {
+      _isStartingMonitoring = false;
     }
-
-    _startPollTimer();
   }
 
   Future<void> stopMonitoring({String reason = 'stopped'}) async {

--- a/lib/core/utils/lifecycle.dart
+++ b/lib/core/utils/lifecycle.dart
@@ -1,8 +1,6 @@
-import 'dart:async';
 import 'dart:io';
 import 'package:flutter/widgets.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
-import '../../features/node/node_service.dart';
 import '../../features/metrics/metrics_collector_service.dart';
 import '../services/android_foreground_task_controller.dart';
 
@@ -66,18 +64,7 @@ class AppLifecycleLogger with WidgetsBindingObserver {
 
     try {
       _log.info('Handling app resume...');
-
-      // 1. Check and restart node if needed (Android only)
-      if (Platform.isAndroid) {
-        await _ensureNodeRunning();
-      }
-
-      // 2. Check for epoch transition and reschedule if needed
       await _checkEpochTransition();
-
-      // 3. Verify scheduled alarms still exist
-      await _verifyScheduledAlarms();
-
       _log.info('App resume handling complete');
     } catch (e) {
       _log.error('Error handling app resume: $e');
@@ -89,24 +76,6 @@ class AppLifecycleLogger with WidgetsBindingObserver {
   /// Handle app paused
   Future<void> _handleAppPaused() async {
     // Rust Node will be paused by the foreground service or MainActivity destructor.
-  }
-
-  /// Ensure node is running (Android only)
-  Future<void> _ensureNodeRunning() async {
-    try {
-      final rustBackend = RustBackendService.instance;
-
-      await rustBackend.startNode();
-      await rustBackend.resumeNode();
-
-      if (rustBackend.isRunning) {
-        _log.info('✓ Node successfully ensured running');
-      } else {
-        _log.error('✗ Failed to start and resume node');
-      }
-    } catch (e) {
-      _log.error('Error ensuring node running: $e');
-    }
   }
 
   /// Check if epoch has changed and reschedule slots if needed
@@ -123,14 +92,4 @@ class AppLifecycleLogger with WidgetsBindingObserver {
     }
   }
 
-  /// Verify that scheduled alarms still exist (could be cleared by system)
-  ///
-  Future<void> _verifyScheduledAlarms() async {
-    try {
-      _log.debug(
-          'Alarm verification no-op (handled by AlarmManager scheduling)');
-    } catch (e) {
-      _log.error('Error verifying scheduled alarms: $e');
-    }
-  }
 }


### PR DESCRIPTION
## Summary

Fixes confirmed ANR ("Application Not Responding") crashes on Android by preventing VRF polling while the app is in the foreground and guarding against ANR cascade on resume.

- Skip `_pollVrf()` when `AppLifecycleState == resumed` — the primary ANR fix
- Add `_isPolling` overlap guard to prevent concurrent poll executions
- Guard `startMonitoring()` against ANR cascade (re-entrancy + already-active checks)
- Remove redundant `_ensureNodeRunning()` from lifecycle resume path (saves 2 FRB calls)
- Replace deprecated `getRunningServices(MAX_VALUE)` with static boolean

## Problem discovery

During real-device testing on a Samsung Seeker (Android 15), we observed **confirmed ANR dialogs**:

> "Input dispatching timed out (MainActivity is not responding. Waited 5000ms for MotionEvent)"

The ANRs appeared when switching tabs or tapping the screen during routine background work. They were reproducible but timing-dependent — they occurred when a 30-second VRF poll timer happened to fire while the user was interacting with the UI.

## Root cause analysis

We instrumented the codebase with `Stopwatch` timers and `[ANR-DIAG]` log tags to measure every call in the hot paths. The findings:

**`_pollVrf()` chains 8-10 sequential FRB/RPC calls** (getEpochInfo, getBlockProducerStatus, listBlockchain, getStatus, getSlotTime, etc.) every 30 seconds. Each round takes **2-7 seconds** on real hardware, all executing on the main Dart isolate.

Android's ANR threshold is **5 seconds** — if the main thread can't dispatch an input event within that window, the system shows the ANR dialog. When a multi-second VRF poll coincides with user interaction (which only happens when the app is **foregrounded** and the user is **touching the screen**), the main thread is blocked processing RPC responses and can't service the touch event in time.

**Contributing factors discovered during investigation:**

1. **Redundant `_ensureNodeRunning()` calls**: `_handleAppResumed()` in `lifecycle.dart` called `_ensureNodeRunning()` (2 FRB calls: `startNode()` + `resumeNode()`), then immediately called `_checkEpochTransition()` → `startMonitoring()` which called `_ensureNodeRunning()` again — **4 unnecessary FRB calls** on every app resume.

2. **`getRunningServices(Int.MAX_VALUE)` blocking the main thread**: `AlarmMethodChannelHandler.isForegroundServiceRunning()` called the deprecated `ActivityManager.getRunningServices()` on every poll cycle and every `startMonitoring()` call. This API enumerates **all running services system-wide**, and our instrumentation showed it taking **50-200ms per call** on some devices.

3. **Poll overlap**: Without a guard, if a poll took >30 seconds (rare but possible under memory pressure), the next timer tick would start a second concurrent poll, doubling the main-thread load.

4. **ANR cascade feedback loop**: Each ANR-dismiss triggers a `resumed` lifecycle event → `startMonitoring()` → heavy FRB/platform-channel work (2 FRB calls for node start + 3 platform channel calls) → another ANR. This positive feedback loop made a single ANR snowball into repeated ANR dialogs that persisted until the app was force-killed.

## Solution rationale

### VRF poll skip (commit 1)

The key insight: **"Input dispatching timed out" ANR can ONLY happen when the app is in foreground AND the user is interacting.** VRF polling exists to manage the background lifecycle — scheduling alarms, acquiring/releasing wakelocks, starting/stopping the foreground service. None of this is needed while the user is actively using the app:

- **In foreground**: Node is running, foreground service is running, block production is automatic
- **On background transition**: The poll timer keeps ticking. The next tick (≤30 seconds) runs the full poll
- **On resume**: `startMonitoring()` ensures the foreground service and node are running

### Cascade guard (commit 2)

`startMonitoring()` is called on every app resume via the lifecycle observer. Without a guard, each call performs:
- `_ensureNodeRunning()` → 2 FRB calls (`startNode()` + `resumeNode()`)
- `isForegroundServiceRunning()` → platform channel call
- `startForegroundService()` → platform channel call
- `_acquireWakelock()` → platform channel call

If monitoring is already active (poll timer running), all this work is redundant. Two guards break the cascade:
- `_pollTimer != null` → monitoring fully set up, skip entirely
- `_isStartingMonitoring` → previous call still in-flight, skip to prevent re-entrancy

## Changes

| File | Change | Why |
|------|--------|-----|
| `android_foreground_task_controller.dart` | Skip `_pollVrf()` body when `AppLifecycleState.resumed` | **Primary ANR fix** — eliminates 2-7s main-thread blocking during user interaction |
| `android_foreground_task_controller.dart` | Add `_isPolling` boolean guard | Prevents concurrent polls under memory pressure |
| `android_foreground_task_controller.dart` | Add `_isStartingMonitoring` + `_pollTimer` guards on `startMonitoring()` | **Cascade fix** — breaks ANR feedback loop on resume |
| `lifecycle.dart` | Remove `_ensureNodeRunning()` call from `_handleAppResumed()` | Redundant — `startMonitoring()` already calls it. Saves 2 FRB calls per resume |
| `lifecycle.dart` | Remove `_verifyScheduledAlarms()` call and method | Was a no-op (just a debug log statement) |
| `AlarmMethodChannelHandler.kt` | Replace `getRunningServices(MAX_VALUE)` with `SlotMonitoringService.isForegroundServiceActive` | Eliminates deprecated API call that enumerated all system services |
| `MainActivity.kt` | Remove unused `android.os.Build` import | Cleanup |

## Test results

Tested on Samsung Seeker (Android 15, SM02E4072810190):

- ✅ Background app → VRF polls run every 30s with full RPC evaluation
- ✅ Foreground app → logs "Skipping VRF poll: app is in foreground"
- ✅ On resume → logs "startMonitoring(app_resumed) skipped: already active" (cascade guard working)
- ✅ Rapid tab switching after first round — no ANR
- ⚠️ ANR still possible from **separate vector**: wallet tab parses 6,980 UTXOs on main thread (~14,000 FFI calls). Tracked in separate issue.

## Known limitation

A separate ANR vector exists in `WalletProvider._calculateBalanceFromUtxos()` which iterates through all UTXOs (6,980+) calling `utxoToJson()` (FFI) + `json.decode()` for each one, twice (balance + transactions). This is tracked separately and is outside the scope of VRF polling fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)