### PR TITLE
fix: Card zero-margin theme fix + ZK Identity layout bugs

### DIFF
--- a/lib/design_system/docs/CONSTRAINTS.md
+++ b/lib/design_system/docs/CONSTRAINTS.md
@@ -114,6 +114,14 @@ See [DECISIONS.md](DECISIONS.md) "Selective M3 Adoption" for a worked example.
 
 **Where:** `/verify-widget` checks all 10 items.
 
+## Card Zero-Margin Rule
+
+**Constraint:** `CardThemeData` sets `margin: EdgeInsets.zero`, overriding Flutter's hidden default `margin: EdgeInsets.all(4.0)`. Cards never own their external spacing — parent widgets (Padding, SizedBox, Column spacing) provide inter-card gaps following the Matryoshka model.
+
+**Why:** Flutter's `Card` has a built-in 4px margin that breaks token-based keyline alignment. When a screen applies `space16` horizontal padding and a Card adds 4px margin, the visual inset becomes 20px instead of 16px — an invisible off-grid drift. Zeroing at the theme level fixes every Card globally.
+
+**Where:** `theme/color_is_expensive_theme.dart` (CardThemeData); enforced by `avoid_card_margin` lint.
+
 ## Known Architecture Issues
 
 1. ~~**Dual theme.**~~ **Resolved (2026-03-02).** `ColorIsExpensiveTheme` is now the
@@ -171,6 +179,7 @@ cd packages/ds_lints && dart run bin/lint.dart /path/to/project/root
 | `avoid_padding_around_tiles` | WARNING | `Padding` with horizontal insets wrapping a ListTile-family widget (`ListTile`, `SwitchListTile`, `CheckboxListTile`, `RadioListTile`, `ExpansionTile`). These widgets get `contentPadding` from the theme — outer horizontal Padding causes double-indenting. |
 | `avoid_listtile_layout_overrides` | WARNING | Per-widget `visualDensity`, `minVerticalPadding`, `minTileHeight`, `titleAlignment`, or `contentPadding` on `ListTile`/`SwitchListTile`/`CheckboxListTile`/`RadioListTile`. These layout properties should come from the theme — per-widget overrides break M3's baseline alignment. |
 | `require_tile_card_vertical_inset` | WARNING | `AppCard(padding: EdgeInsets.zero)` whose child subtree contains tile widgets. Use `EdgeInsets.symmetric(vertical: spacing.space8)` for list surface inset. |
+| `avoid_card_margin` | WARNING | `Card(margin: ...)` with an explicit margin argument. CardThemeData zeroes the default 4px margin — use a parent `Padding` or `SizedBox` for spacing instead. |
 
 Excluded paths: `/widgetbook/`, `/test/`.
 

--- a/lib/design_system/docs/SCREEN_PATTERNS.md
+++ b/lib/design_system/docs/SCREEN_PATTERNS.md
@@ -463,7 +463,7 @@ radii.borderRadiusTopLargeIncreased
 
 ### AppCard Is the Canonical Meso Container
 
-`AppCard` provides the standard surface: `surfaceContainerLowest` background, `outlineVariant` border, `large` (16dp) radius, and configurable padding.
+`AppCard` provides the standard surface: `surfaceContainerLowest` background, `outlineVariant` border, `large` (16dp) radius, and configurable padding. Note: `CardThemeData` zeroes Flutter's hidden default 4px margin — Cards sit flush within screen margins with no invisible offset.
 
 | Constructor | Internal padding | Use for |
 |-------------|-----------------|---------|

--- a/lib/design_system/src/zk_identity_flow_page.dart
+++ b/lib/design_system/src/zk_identity_flow_page.dart
@@ -84,11 +84,19 @@ class ZkIdentityFlowPage extends StatelessWidget {
           ),
           if (centerActiveContent)
             Expanded(
-              child: Center(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: spacing.space16),
-                  child: activeStepContent ?? const SizedBox.shrink(),
-                ),
+              child: CustomScrollView(
+                slivers: [
+                  SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: Center(
+                      child: Padding(
+                        padding:
+                            EdgeInsets.symmetric(horizontal: spacing.space16),
+                        child: activeStepContent ?? const SizedBox.shrink(),
+                      ),
+                    ),
+                  ),
+                ],
               ),
             )
           else

--- a/lib/design_system/src/zk_identity_status_card.dart
+++ b/lib/design_system/src/zk_identity_status_card.dart
@@ -76,6 +76,7 @@ class _StepRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final colors = Theme.of(context).colorScheme;
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
     final sizing = Theme.of(context).extension<AppSizing>()!;
 
     final valueStyle = step.monospace
@@ -87,17 +88,38 @@ class _StepRow extends StatelessWidget {
             color: colors.onSurfaceVariant,
           );
 
-    return ListTile(
-      leading: IconBadge(
-        icon: step.icon,
-        size: sizing.iconContainerSmall,
+    final content = Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: spacing.space16,
+        vertical: spacing.space12,
       ),
-      title: Text(
-        step.label,
-        style: textTheme.bodyMedium?.copyWith(color: colors.onSurface),
+      child: Row(
+        children: [
+          IconBadge(
+            icon: step.icon,
+            size: sizing.iconContainerSmall,
+          ),
+          SizedBox(width: spacing.space12),
+          Text(
+            step.label,
+            style: textTheme.bodyMedium?.copyWith(color: colors.onSurface),
+          ),
+          SizedBox(width: spacing.space16),
+          Expanded(
+            child: Text(
+              step.value,
+              style: valueStyle,
+              textAlign: TextAlign.end,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
       ),
-      trailing: Text(step.value, style: valueStyle),
-      onTap: step.onTap,
     );
+
+    return step.onTap != null
+        ? InkWell(onTap: step.onTap, child: content)
+        : content;
   }
 }

--- a/lib/design_system/src/zk_identity_status_card.dart
+++ b/lib/design_system/src/zk_identity_status_card.dart
@@ -76,6 +76,7 @@ class _StepRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final colors = Theme.of(context).colorScheme;
+    final radii = Theme.of(context).extension<AppRadii>()!;
     final spacing = Theme.of(context).extension<AppSpacing>()!;
     final sizing = Theme.of(context).extension<AppSizing>()!;
 
@@ -119,7 +120,11 @@ class _StepRow extends StatelessWidget {
     );
 
     return step.onTap != null
-        ? InkWell(onTap: step.onTap, child: content)
+        ? InkWell(
+            onTap: step.onTap,
+            borderRadius: radii.borderRadiusMedium,
+            child: content,
+          )
         : content;
   }
 }

--- a/lib/design_system/theme/color_is_expensive_theme.dart
+++ b/lib/design_system/theme/color_is_expensive_theme.dart
@@ -391,6 +391,7 @@ class ColorIsExpensiveTheme {
         cardTheme: CardThemeData(
           color: colorScheme.surfaceContainerLowest,
           elevation: 0,
+          margin: EdgeInsets.zero,
           surfaceTintColor: Colors.transparent,
           shape: RoundedRectangleBorder(
             borderRadius: _radii.borderRadiusLarge,

--- a/lib/design_system/widgetbook/unified_theme_catalog.dart
+++ b/lib/design_system/widgetbook/unified_theme_catalog.dart
@@ -2436,6 +2436,7 @@ class _ThemeSwitchingDemo extends StatelessWidget {
       cardTheme: CardThemeData(
         color: comparisonScheme.surfaceContainerLowest,
         elevation: 0,
+        margin: EdgeInsets.zero,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(16),
           side: BorderSide(color: comparisonScheme.outlineVariant),

--- a/lib/features/node/screens/slot_production_stats_screen.dart
+++ b/lib/features/node/screens/slot_production_stats_screen.dart
@@ -375,23 +375,26 @@ class _SlotProductionStatsScreenState
     AppLocalizations l10n,
     AppSpacing spacing,
   ) {
-    return Card(
-      margin: EdgeInsets.only(bottom: spacing.space12),
-      child: ExpansionTile(
-        leading: Icon(Symbols.calendar_today_sharp, color: colorScheme.primary),
-        title: Text(
-          l10n.statsEpoch(epoch),
-          style: theme.textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.bold,
+    return Padding(
+      padding: EdgeInsets.only(bottom: spacing.space12),
+      child: Card(
+        child: ExpansionTile(
+          leading:
+              Icon(Symbols.calendar_today_sharp, color: colorScheme.primary),
+          title: Text(
+            l10n.statsEpoch(epoch),
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
           ),
+          subtitle: Text(
+            '${records.length} slot${records.length != 1 ? 's' : ''}',
+            style: theme.textTheme.bodySmall,
+          ),
+          children: records.map((record) {
+            return _buildRecordTile(record, theme, colorScheme, l10n);
+          }).toList(),
         ),
-        subtitle: Text(
-          '${records.length} slot${records.length != 1 ? 's' : ''}',
-          style: theme.textTheme.bodySmall,
-        ),
-        children: records.map((record) {
-          return _buildRecordTile(record, theme, colorScheme, l10n);
-        }).toList(),
       ),
     );
   }

--- a/packages/ds_lints/lib/src/lint_visitor.dart
+++ b/packages/ds_lints/lib/src/lint_visitor.dart
@@ -90,6 +90,7 @@ class DsLintVisitor extends RecursiveAstVisitor<void> {
     'SizedBox',
     'Icon',
     'Padding',
+    'Card',
     'ListTile',
     'SwitchListTile',
     'CheckboxListTile',
@@ -124,6 +125,8 @@ class DsLintVisitor extends RecursiveAstVisitor<void> {
       case 'CheckboxListTile':
       case 'RadioListTile':
         _checkListTileLayoutOverrides(node, typeName, args);
+      case 'Card':
+        _checkCardMargin(node, args);
       case 'AppCard':
         _checkTileCardVerticalInset(node, args);
       case 'FilledButton':
@@ -549,6 +552,26 @@ class DsLintVisitor extends RecursiveAstVisitor<void> {
       if (_containsTileWidget(value)) return true;
     }
     return false;
+  }
+
+  // ── Rule 9: avoid_card_margin ──────────────────────────────────────
+
+  void _checkCardMargin(AstNode node, ArgumentList args) {
+    if (isExcludedPath(filePath)) return;
+
+    for (final arg in args.arguments) {
+      if (arg is NamedExpression && arg.name.label.name == 'margin') {
+        _report(
+          node,
+          'avoid_card_margin',
+          'Card margin is zeroed by CardThemeData. '
+              'Use a parent Padding or SizedBox for spacing '
+              'instead of Card(margin:).',
+          'WARNING',
+        );
+        return;
+      }
+    }
   }
 
   // ── Rule 8: require_tile_card_vertical_inset ────────────────────────

--- a/packages/ds_lints/lib/src/lint_visitor.dart
+++ b/packages/ds_lints/lib/src/lint_visitor.dart
@@ -554,7 +554,7 @@ class DsLintVisitor extends RecursiveAstVisitor<void> {
     return false;
   }
 
-  // ── Rule 9: avoid_card_margin ──────────────────────────────────────
+  // ── Rule 10: avoid_card_margin ─────────────────────────────────────
 
   void _checkCardMargin(AstNode node, ArgumentList args) {
     if (isExcludedPath(filePath)) return;
@@ -574,7 +574,7 @@ class DsLintVisitor extends RecursiveAstVisitor<void> {
     }
   }
 
-  // ── Rule 8: require_tile_card_vertical_inset ────────────────────────
+  // ── Rule 9: require_tile_card_vertical_inset ────────────────────────
 
   void _checkTileCardVerticalInset(AstNode node, ArgumentList args) {
     // Find padding: named argument.
@@ -664,7 +664,7 @@ class DsLintVisitor extends RecursiveAstVisitor<void> {
     }
   }
 
-  // ── Rule 8: require_ds_button ──────────────────────────────────────
+  // ── Rule 11: require_ds_button ─────────────────────────────────────
 
   void _checkPreferDsButton(AstNode node, String typeName) {
     if (isExcludedPath(filePath)) return;

--- a/test/design_system/zk_identity_flow_page_test.dart
+++ b/test/design_system/zk_identity_flow_page_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:crypto_mobile_app/design_system/design_system.dart';
+
+void main() {
+  const steps = [
+    ZkIdentityStepData(
+      label: 'Check App',
+      description: 'Checking app version',
+      status: ZkIdentityStepVisualStatus.completed,
+    ),
+    ZkIdentityStepData(
+      label: 'Scan',
+      description: 'Scan your passport',
+      status: ZkIdentityStepVisualStatus.active,
+    ),
+    ZkIdentityStepData(
+      label: 'Verify',
+      description: 'Verifying identity',
+      status: ZkIdentityStepVisualStatus.pending,
+    ),
+  ];
+
+  Widget buildApp({
+    required List<ZkIdentityStepData> steps,
+    int currentStepIndex = 0,
+    bool centerActiveContent = false,
+    Widget? activeStepContent,
+    Widget? bottomAction,
+    VoidCallback? onBack,
+  }) {
+    final textTheme = ThemeData.light().textTheme;
+    final cieTheme = ColorIsExpensiveTheme(textTheme);
+    final themeData = cieTheme.light().copyWith(
+          extensions: DesignSystemTheme.standardExtensions(
+            semanticColors: AppSemanticColors.light(),
+          ),
+        );
+
+    return MaterialApp(
+      theme: themeData,
+      home: ZkIdentityFlowPage(
+        steps: steps,
+        currentStepIndex: currentStepIndex,
+        centerActiveContent: centerActiveContent,
+        activeStepContent: activeStepContent,
+        bottomAction: bottomAction,
+        onBack: onBack,
+      ),
+    );
+  }
+
+  // Uses pump() instead of pumpAndSettle() throughout — the
+  // ZkIdentityStepIllustration has a looping AnimationController
+  // that never settles.
+  group('ZkIdentityFlowPage', () {
+    testWidgets('renders step label and description', (tester) async {
+      await tester.pumpWidget(buildApp(steps: steps, currentStepIndex: 1));
+      await tester.pump();
+
+      expect(find.text('Scan'), findsOneWidget);
+      expect(find.text('Scan your passport'), findsOneWidget);
+    });
+
+    testWidgets('renders progress bar with decorated segments', (tester) async {
+      await tester.pumpWidget(buildApp(steps: steps));
+      await tester.pump();
+
+      // Each step gets a decorated Container with color in the progress bar.
+      final segments = find.byWidgetPredicate(
+        (w) =>
+            w is Container &&
+            w.decoration is BoxDecoration &&
+            (w.decoration as BoxDecoration).color != null,
+      );
+      expect(segments.evaluate().length, greaterThanOrEqualTo(3));
+    });
+
+    testWidgets('back button fires onBack callback', (tester) async {
+      var backPressed = false;
+
+      await tester.pumpWidget(
+        buildApp(steps: steps, onBack: () => backPressed = true),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byType(IconButton));
+      expect(backPressed, true);
+    });
+
+    testWidgets('renders bottom action in bottomNavigationBar', (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          steps: steps,
+          bottomAction: const Text('Continue'),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Continue'), findsOneWidget);
+    });
+
+    testWidgets('renders activeStepContent in normal mode', (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          steps: steps,
+          currentStepIndex: 1,
+          activeStepContent: const Text('Custom content'),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Scan'), findsOneWidget);
+      expect(find.text('Custom content'), findsOneWidget);
+    });
+
+    testWidgets('centered mode shows activeStepContent and hides label',
+        (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          steps: steps,
+          currentStepIndex: 1,
+          centerActiveContent: true,
+          activeStepContent: const Text('Centered widget'),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Centered widget'), findsOneWidget);
+      // Label/description hidden in centered mode.
+      expect(find.text('Scan'), findsNothing);
+      expect(find.text('Scan your passport'), findsNothing);
+    });
+
+    testWidgets('centered mode uses CustomScrollView for overflow scroll',
+        (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          steps: steps,
+          currentStepIndex: 1,
+          centerActiveContent: true,
+          activeStepContent: const Text('Content'),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CustomScrollView), findsOneWidget);
+      expect(find.byType(SliverFillRemaining), findsOneWidget);
+    });
+
+    testWidgets('centered mode scrolls when content overflows', (tester) async {
+      final tallContent = Column(
+        children: List.generate(
+          30,
+          (i) => SizedBox(height: 50, child: Text('Row $i')),
+        ),
+      );
+
+      await tester.pumpWidget(
+        buildApp(
+          steps: steps,
+          currentStepIndex: 1,
+          centerActiveContent: true,
+          activeStepContent: tallContent,
+        ),
+      );
+      await tester.pump();
+
+      // All rows exist in the widget tree (SliverFillRemaining lays out fully).
+      expect(find.text('Row 0'), findsOneWidget);
+      expect(find.text('Row 29'), findsOneWidget);
+
+      // Verify we can scroll without error (content exceeds viewport).
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -500));
+      await tester.pump();
+    });
+
+    testWidgets('handles out-of-bounds step index gracefully', (tester) async {
+      await tester.pumpWidget(
+        buildApp(steps: steps, currentStepIndex: 99),
+      );
+      await tester.pump();
+
+      expect(find.byType(ZkIdentityFlowPage), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Card zero-margin theme fix**: `CardThemeData` now sets `margin: EdgeInsets.zero`, eliminating Flutter's hidden 4px default that breaks token-based keyline alignment. Added `avoid_card_margin` ds_lint rule to enforce the convention. Migrated the only explicit `Card(margin:)` site to parent `Padding`.
- **ZkIdentityStatusCard**: Replaced `ListTile` with `Row`-based layout (following `InfoRow` pattern) to fix text wrapping caused by `ListTile` giving `trailing` priority over `title` in narrow contexts. `InkWell` uses `borderRadiusMedium` for rounded ink splash.
- **ZkIdentityFlowPage**: Wrapped centered mode in `CustomScrollView` + `SliverFillRemaining(hasScrollBody: false)` to enable scroll when content overflows while preserving centering.
- Updated CONSTRAINTS.md and SCREEN_PATTERNS.md docs.

Closes #305
Closes #304

## Test plan

- [x] `dart format` clean
- [x] `flutter analyze` — no new issues
- [x] `flutter test` — 597 tests pass (9 new `ZkIdentityFlowPage` tests)
- [x] `ds_lints` — no new issues, `avoid_card_margin` rule working
- [ ] Visual smoke test: verify Card alignment in slot production stats screen
- [ ] Visual smoke test: verify ZkIdentityStatusCard text no longer wraps
- [ ] Visual smoke test: verify ZkIdentityFlowPage centered mode scrolls on overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)