### PR TITLE
feat: slot assignments DS widget + wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ All new design system work lives in `lib/design_system/`. Existing code is untou
 - **New widgets**: When M3 doesn't cover the need, build from core primitives with M3 alignment in mind.
 - **Composing existing `lib/core/widgets/`** (AppButton, AppCard, etc.) is allowed.
 - **Tokens**: Access via `Theme.of(context).extension<T>()!` (e.g., `AppSpacing`, `AppRadii`, `AppElevation`)
-- **Colors**: `Theme.of(context).colorScheme`
+- **Colors**: `Theme.of(context).colorScheme` — **all structural roles are achromatic grey** (primary, secondary, tertiary, containers). Only `error*` has hue. To introduce chromatic color, use `Theme.of(context).extension<AppSemanticColors>()!` (technical/flash/community/success/warning). Never assume a `ColorScheme` role carries color.
 - **Typography**: `Theme.of(context).textTheme`
 - **Presentation-only**: Design system widgets take all state via constructor params (data + callbacks). No providers, no `ConsumerWidget`, no services. No FRB-generated types in constructor params (they transitively import native FFI). Screens in `lib/features/` wire state to widgets.
 - **Widgetbook rule**: Every new design system widget gets a use case that imports the **real widget** with mock data via knobs — never hand-built replicas.

--- a/lib/design_system/design_system.dart
+++ b/lib/design_system/design_system.dart
@@ -47,6 +47,7 @@ export 'src/sheet_layout.dart';
 export 'src/shimmer_block.dart';
 export 'src/shimmer_card_skeleton.dart';
 export 'src/shimmer_list_tile.dart';
+export 'src/slot_assignments_page.dart';
 export 'src/status_badge.dart';
 export 'src/status_text_trailing.dart';
 export 'src/tabs.dart';

--- a/lib/design_system/docs/CONSTRAINTS.md
+++ b/lib/design_system/docs/CONSTRAINTS.md
@@ -33,9 +33,22 @@ Rules enforced by convention (and eventually by lint). Each constraint has: WHAT
 
 ## Color Budget Rule
 
-**Constraint:** Chromatic color only via `AppSemanticColors`. The `ColorScheme` is achromatic. The tertiary role is a "ghost" that forces semantic color usage.
+**Constraint:** Chromatic color only via `AppSemanticColors`. Every `ColorScheme` structural role — primary, secondary, tertiary, and all their containers — is **achromatic grey**. Only `error*` retains hue.
 
-**Why:** An achromatic base ensures color has meaning — every chromatic pixel earns its place through a semantic role. **Where:** [COLOR.md](COLOR.md).
+**Critical implication:** Widgets using `ColorScheme` defaults render grey automatically. For example, `IconBadge` defaults to `secondaryContainer` / `onSecondaryContainer` which are grey (`#E1E2E8` / `#44474D`) — no explicit override needed to make them neutral. Do not add color params to "neutralize" something that is already achromatic.
+
+**To introduce hue**, reach for `AppSemanticColors`:
+```dart
+final semantic = Theme.of(context).extension<AppSemanticColors>()!;
+// semantic.technical  — blue (infrastructure, upcoming slots)
+// semantic.flash      — amber (challenge category)
+// semantic.community  — green (challenge category)
+// semantic.success    — green (positive outcomes)
+// semantic.warning    — amber (syncing, permissions)
+// Each group: .color, .onColor, .colorContainer, .onColorContainer, .colorSurface, .onColorSurface
+```
+
+**Why:** An achromatic base ensures color has meaning — every chromatic pixel earns its place through a semantic role. **Where:** [COLOR.md](COLOR.md); `theme/color_is_expensive_theme.dart`.
 
 ## Two-Tier Surface Rule
 

--- a/lib/design_system/src/block_production_status_card.dart
+++ b/lib/design_system/src/block_production_status_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
 
 import 'package:crypto_mobile_app/core/widgets/app_card.dart';
 
@@ -35,29 +36,38 @@ class PipelineStepStatus {
     required this.label,
     required this.icon,
     required this.trailing,
+    this.onTap,
   });
 
   final String label;
   final IconData icon;
   final StepTrailing trailing;
+  final VoidCallback? onTap;
 }
 
-/// Data for the four pipeline steps in [BlockProductionStatusCard].
+/// Data for the pipeline steps in [BlockProductionStatusCard].
 class BlockProductionStatusData {
   const BlockProductionStatusData({
     required this.network,
     required this.vrf,
     required this.nextBlock,
     required this.lastProduced,
+    this.missedBlocks,
   });
 
   final PipelineStepStatus network;
   final PipelineStepStatus vrf;
   final PipelineStepStatus nextBlock;
   final PipelineStepStatus lastProduced;
+  final PipelineStepStatus? missedBlocks;
 
-  List<PipelineStepStatus> get _steps =>
-      [network, vrf, nextBlock, lastProduced];
+  List<PipelineStepStatus> get _steps => [
+        network,
+        vrf,
+        nextBlock,
+        lastProduced,
+        if (missedBlocks != null) missedBlocks!,
+      ];
 }
 
 /// A card showing 4 [ListTile] rows for block production pipeline readiness.
@@ -102,7 +112,7 @@ class _StepRow extends StatelessWidget {
     final colors = Theme.of(context).colorScheme;
     final sizing = Theme.of(context).extension<AppSizing>()!;
 
-    final trailing = switch (step.trailing) {
+    final trailingWidget = switch (step.trailing) {
       StepTrailingBadge(:final label, :final variant) => StatusTextTrailing(
           text: label,
           variant: variant,
@@ -115,6 +125,23 @@ class _StepRow extends StatelessWidget {
         ),
     };
 
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+
+    final trailing = step.onTap != null
+        ? Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              trailingWidget,
+              SizedBox(width: spacing.space4),
+              Icon(
+                Symbols.chevron_right_sharp,
+                size: sizing.iconSmall,
+                color: colors.onSurfaceVariant,
+              ),
+            ],
+          )
+        : trailingWidget;
+
     return ListTile(
       leading: IconBadge(
         icon: step.icon,
@@ -125,6 +152,7 @@ class _StepRow extends StatelessWidget {
         style: textTheme.bodyMedium?.copyWith(color: colors.onSurface),
       ),
       trailing: trailing,
+      onTap: step.onTap,
     );
   }
 }

--- a/lib/design_system/src/slot_assignments_page.dart
+++ b/lib/design_system/src/slot_assignments_page.dart
@@ -280,6 +280,7 @@ IconData _statusIcon(SlotStatus status) => switch (status) {
 ) =>
     switch (status) {
       SlotStatus.missed => (colors.errorContainer, colors.onErrorContainer),
+      SlotStatus.orphaned => (colors.errorContainer, colors.onErrorContainer),
       SlotStatus.upcoming => (
           semantic.technical.colorContainer,
           semantic.technical.onColorContainer,

--- a/lib/design_system/src/slot_assignments_page.dart
+++ b/lib/design_system/src/slot_assignments_page.dart
@@ -1,8 +1,11 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../tokens/app_semantic_colors.dart';
 import '../tokens/app_sizing.dart';
+import '../tokens/app_radii.dart';
 import '../tokens/app_spacing.dart';
 import 'icon_badge.dart';
 
@@ -46,7 +49,7 @@ class SlotFilterData {
 ///
 /// Presentation-only: all data comes through constructor parameters.
 /// The feature screen in `lib/features/` wires state to this widget.
-class SlotAssignmentsPage extends StatelessWidget {
+class SlotAssignmentsPage extends StatefulWidget {
   const SlotAssignmentsPage({
     super.key,
     required this.title,
@@ -59,6 +62,7 @@ class SlotAssignmentsPage extends StatelessWidget {
     this.slotProgressRightLabel,
     this.onItemTap,
     this.onBackTap,
+    this.highlightIndex,
   });
 
   /// AppBar title, e.g. "Slot Assignments".
@@ -91,6 +95,34 @@ class SlotAssignmentsPage extends StatelessWidget {
   /// Called when the back button is tapped.
   final VoidCallback? onBackTap;
 
+  /// Index of the item to highlight with a heartbeat pulse animation.
+  final int? highlightIndex;
+
+  @override
+  State<SlotAssignmentsPage> createState() => _SlotAssignmentsPageState();
+}
+
+class _SlotAssignmentsPageState extends State<SlotAssignmentsPage> {
+  int? _activeHighlightIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _activeHighlightIndex = widget.highlightIndex;
+  }
+
+  @override
+  void didUpdateWidget(SlotAssignmentsPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.highlightIndex != oldWidget.highlightIndex) {
+      _activeHighlightIndex = widget.highlightIndex;
+    }
+  }
+
+  void _onHighlightComplete() {
+    setState(() => _activeHighlightIndex = null);
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -98,13 +130,13 @@ class SlotAssignmentsPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        leading: onBackTap != null
+        leading: widget.onBackTap != null
             ? IconButton(
                 icon: const Icon(Symbols.arrow_back_sharp),
-                onPressed: onBackTap,
+                onPressed: widget.onBackTap,
               )
             : null,
-        title: Text(title),
+        title: Text(widget.title),
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -116,23 +148,23 @@ class SlotAssignmentsPage extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(epochLabel, style: theme.textTheme.titleMedium),
+                Text(widget.epochLabel, style: theme.textTheme.titleMedium),
                 SizedBox(height: spacing.space8),
-                LinearProgressIndicator(value: slotProgress),
+                LinearProgressIndicator(value: widget.slotProgress),
                 SizedBox(height: spacing.space4),
                 Row(
                   children: [
                     Expanded(
                       child: Text(
-                        slotProgressLeftLabel,
+                        widget.slotProgressLeftLabel,
                         style: theme.textTheme.bodySmall?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ),
-                    if (slotProgressRightLabel != null)
+                    if (widget.slotProgressRightLabel != null)
                       Text(
-                        slotProgressRightLabel!,
+                        widget.slotProgressRightLabel!,
                         style: theme.textTheme.bodySmall?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
@@ -145,16 +177,16 @@ class SlotAssignmentsPage extends StatelessWidget {
           SizedBox(height: spacing.space12),
           // Filter row
           _FilterRow(
-            filters: filters,
-            onFilterTap: onFilterTap,
+            filters: widget.filters,
+            onFilterTap: widget.onFilterTap,
           ),
           SizedBox(height: spacing.space8),
           // Item list
           Expanded(
             child: ListView.builder(
-              itemCount: items.length,
+              itemCount: widget.items.length,
               itemBuilder: (context, index) {
-                final item = items[index];
+                final item = widget.items[index];
                 return _buildItemTile(context, item, index);
               },
             ),
@@ -198,7 +230,7 @@ class SlotAssignmentsPage extends StatelessWidget {
           )
         : trailingText;
 
-    return ListTile(
+    Widget tile = ListTile(
       leading: IconBadge(
         icon: _statusIcon(item.status),
         size: sizing.iconContainerSmall,
@@ -208,14 +240,104 @@ class SlotAssignmentsPage extends StatelessWidget {
       title: Text('Slot ${item.slot}'),
       subtitle: item.timeLabel != null ? Text(item.timeLabel!) : null,
       trailing: trailing,
-      onTap: item.isTappable ? () => onItemTap?.call(index) : null,
+      onTap: item.isTappable ? () => widget.onItemTap?.call(index) : null,
     );
+
+    if (index == _activeHighlightIndex) {
+      tile = _HeartbeatHighlight(
+        onComplete: _onHighlightComplete,
+        child: tile,
+      );
+    }
+
+    return tile;
   }
 }
 
 // ---------------------------------------------------------------------------
 // Private sub-widgets
 // ---------------------------------------------------------------------------
+
+class _HeartbeatHighlight extends StatefulWidget {
+  const _HeartbeatHighlight({
+    required this.onComplete,
+    required this.child,
+  });
+
+  final VoidCallback onComplete;
+  final Widget child;
+
+  @override
+  State<_HeartbeatHighlight> createState() => _HeartbeatHighlightState();
+}
+
+class _HeartbeatHighlightState extends State<_HeartbeatHighlight>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  bool _completed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1800),
+    )..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          widget.onComplete();
+        }
+      });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_completed) return;
+    if (MediaQuery.of(context).disableAnimations) {
+      _completed = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.onComplete();
+      });
+    } else if (!_controller.isAnimating) {
+      _controller.forward();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_completed) return widget.child;
+
+    final highlightColor = Theme.of(context)
+        .colorScheme
+        .surfaceContainerHighest
+        .withAlpha((255 * 0.35).round());
+
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        // 3 smooth sin pulses over the animation duration
+        final pulse = math.sin(_controller.value * math.pi * 3).clamp(0.0, 1.0);
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            color: Color.lerp(
+              Colors.transparent,
+              highlightColor,
+              pulse,
+            ),
+          ),
+          child: child,
+        );
+      },
+      child: widget.child,
+    );
+  }
+}
 
 class _FilterRow extends StatelessWidget {
   const _FilterRow({
@@ -231,6 +353,7 @@ class _FilterRow extends StatelessWidget {
     final spacing = Theme.of(context).extension<AppSpacing>()!;
     final colorScheme = Theme.of(context).colorScheme;
     final labelSmall = Theme.of(context).textTheme.labelSmall!;
+    final radii = Theme.of(context).extension<AppRadii>()!;
 
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
@@ -240,15 +363,28 @@ class _FilterRow extends StatelessWidget {
         children: [
           for (int i = 0; i < filters.length; i++)
             FilterChip(
-              avatar: CircleAvatar(
-                backgroundColor: colorScheme.onSurfaceVariant,
-                child: Text(
-                  '${filters[i].count}',
-                  style: labelSmall.copyWith(color: colorScheme.surface),
-                ),
-              ),
               showCheckmark: false,
-              label: Text(filters[i].label),
+              label: Row(
+                mainAxisSize: MainAxisSize.min,
+                spacing: spacing.space8,
+                children: [
+                  Container(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: spacing.space8,
+                      vertical: spacing.space4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: colorScheme.onSurfaceVariant,
+                      borderRadius: radii.borderRadiusFull,
+                    ),
+                    child: Text(
+                      '${filters[i].count}',
+                      style: labelSmall.copyWith(color: colorScheme.surface),
+                    ),
+                  ),
+                  Text(filters[i].label),
+                ],
+              ),
               selected: filters[i].selected,
               onSelected: (_) => onFilterTap(i),
             ),

--- a/lib/design_system/src/slot_assignments_page.dart
+++ b/lib/design_system/src/slot_assignments_page.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import '../tokens/app_semantic_colors.dart';
+import '../tokens/app_sizing.dart';
+import '../tokens/app_spacing.dart';
+import 'icon_badge.dart';
+
+/// Status of a single slot assignment.
+enum SlotStatus { produced, orphaned, missed, upcoming, notCalculated, notWon }
+
+/// Data for a single slot assignment list item.
+class SlotAssignmentItemData {
+  final int slot;
+  final SlotStatus status;
+
+  /// Pre-formatted time label, e.g. "Today, 08:21" or "Mar 14, 08:21".
+  final String? timeLabel;
+
+  /// Whether the item can be tapped (typically produced/orphaned).
+  final bool isTappable;
+
+  const SlotAssignmentItemData({
+    required this.slot,
+    required this.status,
+    this.timeLabel,
+    this.isTappable = false,
+  });
+}
+
+/// Data for a single filter chip in the filter row.
+class SlotFilterData {
+  final String label;
+  final int count;
+  final bool selected;
+
+  const SlotFilterData({
+    required this.label,
+    required this.count,
+    this.selected = false,
+  });
+}
+
+/// A full-page slot assignments view with epoch progress header, filter chips,
+/// and a scrollable list of slot items.
+///
+/// Presentation-only: all data comes through constructor parameters.
+/// The feature screen in `lib/features/` wires state to this widget.
+class SlotAssignmentsPage extends StatelessWidget {
+  const SlotAssignmentsPage({
+    super.key,
+    required this.title,
+    required this.epochLabel,
+    required this.slotProgressLeftLabel,
+    required this.slotProgress,
+    required this.filters,
+    required this.onFilterTap,
+    required this.items,
+    this.slotProgressRightLabel,
+    this.onItemTap,
+    this.onBackTap,
+  });
+
+  /// AppBar title, e.g. "Slot Assignments".
+  final String title;
+
+  /// Epoch label shown above the progress bar, e.g. "Epoch 176".
+  final String epochLabel;
+
+  /// Left label under the progress bar, e.g. "5000 / 7140 slots".
+  final String slotProgressLeftLabel;
+
+  /// Optional right label under the progress bar, e.g. "7h 14min left".
+  final String? slotProgressRightLabel;
+
+  /// Progress fraction (0.0–1.0) for the slot progress bar.
+  final double slotProgress;
+
+  /// Filter chips shown in the horizontal scroll row.
+  final List<SlotFilterData> filters;
+
+  /// Called with the index of the tapped filter chip.
+  final ValueChanged<int> onFilterTap;
+
+  /// Slot assignment items, pre-filtered by the caller.
+  final List<SlotAssignmentItemData> items;
+
+  /// Called with the index of the tapped item.
+  final ValueChanged<int>? onItemTap;
+
+  /// Called when the back button is tapped.
+  final VoidCallback? onBackTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final spacing = theme.extension<AppSpacing>()!;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: onBackTap != null
+            ? IconButton(
+                icon: const Icon(Symbols.arrow_back_sharp),
+                onPressed: onBackTap,
+              )
+            : null,
+        title: Text(title),
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(height: spacing.space16),
+          // Inline progress — epoch label + bar + left/right labels
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: spacing.space16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(epochLabel, style: theme.textTheme.titleMedium),
+                SizedBox(height: spacing.space8),
+                LinearProgressIndicator(value: slotProgress),
+                SizedBox(height: spacing.space4),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        slotProgressLeftLabel,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    if (slotProgressRightLabel != null)
+                      Text(
+                        slotProgressRightLabel!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          SizedBox(height: spacing.space12),
+          // Filter row
+          _FilterRow(
+            filters: filters,
+            onFilterTap: onFilterTap,
+          ),
+          SizedBox(height: spacing.space8),
+          // Item list
+          Expanded(
+            child: ListView.builder(
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                final item = items[index];
+                return _buildItemTile(context, item, index);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildItemTile(
+    BuildContext context,
+    SlotAssignmentItemData item,
+    int index,
+  ) {
+    final colors = Theme.of(context).colorScheme;
+    final semantic = Theme.of(context).extension<AppSemanticColors>()!;
+    final sizing = Theme.of(context).extension<AppSizing>()!;
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+
+    final badgeColors = _statusBadgeColors(item.status, colors, semantic);
+
+    final trailingText = Text(
+      _statusLabel(item.status),
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: colors.onSurfaceVariant,
+          ),
+    );
+
+    final trailing = item.isTappable
+        ? Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              trailingText,
+              SizedBox(width: spacing.space4),
+              Icon(
+                Symbols.chevron_right_sharp,
+                size: sizing.iconSmall,
+                color: colors.onSurfaceVariant,
+              ),
+            ],
+          )
+        : trailingText;
+
+    return ListTile(
+      leading: IconBadge(
+        icon: _statusIcon(item.status),
+        size: sizing.iconContainerSmall,
+        backgroundColor: badgeColors?.$1,
+        iconColor: badgeColors?.$2,
+      ),
+      title: Text('Slot ${item.slot}'),
+      subtitle: item.timeLabel != null ? Text(item.timeLabel!) : null,
+      trailing: trailing,
+      onTap: item.isTappable ? () => onItemTap?.call(index) : null,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private sub-widgets
+// ---------------------------------------------------------------------------
+
+class _FilterRow extends StatelessWidget {
+  const _FilterRow({
+    required this.filters,
+    required this.onFilterTap,
+  });
+
+  final List<SlotFilterData> filters;
+  final ValueChanged<int> onFilterTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final colorScheme = Theme.of(context).colorScheme;
+    final labelSmall = Theme.of(context).textTheme.labelSmall!;
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: EdgeInsets.symmetric(horizontal: spacing.space16),
+      child: Row(
+        spacing: spacing.space8,
+        children: [
+          for (int i = 0; i < filters.length; i++)
+            FilterChip(
+              avatar: CircleAvatar(
+                backgroundColor: colorScheme.onSurfaceVariant,
+                child: Text(
+                  '${filters[i].count}',
+                  style: labelSmall.copyWith(color: colorScheme.surface),
+                ),
+              ),
+              showCheckmark: false,
+              label: Text(filters[i].label),
+              selected: filters[i].selected,
+              onSelected: (_) => onFilterTap(i),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Status mapping helpers
+// ---------------------------------------------------------------------------
+
+IconData _statusIcon(SlotStatus status) => switch (status) {
+      SlotStatus.produced => Symbols.check_circle_sharp,
+      SlotStatus.orphaned => Symbols.error_sharp,
+      SlotStatus.missed => Symbols.cancel_sharp,
+      SlotStatus.upcoming => Symbols.schedule_sharp,
+      SlotStatus.notCalculated => Symbols.help_sharp,
+      SlotStatus.notWon => Symbols.remove_circle_sharp,
+    };
+
+/// Returns `(backgroundColor, iconColor)` for the leading [IconBadge].
+/// `null` → use IconBadge defaults (achromatic secondaryContainer).
+(Color, Color)? _statusBadgeColors(
+  SlotStatus status,
+  ColorScheme colors,
+  AppSemanticColors semantic,
+) =>
+    switch (status) {
+      SlotStatus.missed => (colors.errorContainer, colors.onErrorContainer),
+      SlotStatus.upcoming => (
+          semantic.technical.colorContainer,
+          semantic.technical.onColorContainer,
+        ),
+      _ => null,
+    };
+
+String _statusLabel(SlotStatus status) => switch (status) {
+      SlotStatus.produced => 'Produced',
+      SlotStatus.orphaned => 'Orphaned',
+      SlotStatus.missed => 'Missed',
+      SlotStatus.upcoming => 'Upcoming',
+      SlotStatus.notCalculated => 'Not Calculated',
+      SlotStatus.notWon => 'Not Won',
+    };

--- a/lib/design_system/theme/color_is_expensive_theme.dart
+++ b/lib/design_system/theme/color_is_expensive_theme.dart
@@ -341,11 +341,17 @@ class ColorIsExpensiveTheme {
   // ThemeData builders
   // ---------------------------------------------------------------------------
 
-  ThemeData theme(ColorScheme colorScheme) => ThemeData(
+  ThemeData theme(ColorScheme colorScheme) {
+    // Platform text themes (blackRedwoodCity, etc.) only carry font-family
+    // and color — no geometry. Pre-merge M3 geometry so that explicit style
+    // references (listTileTheme, etc.) get concrete font sizes.
+    final resolved = Typography.englishLike2021.merge(textTheme);
+
+    return ThemeData(
         useMaterial3: true,
         brightness: colorScheme.brightness,
         colorScheme: colorScheme,
-        textTheme: textTheme.apply(
+        textTheme: resolved.apply(
           bodyColor: colorScheme.onSurface,
           displayColor: colorScheme.onSurface,
         ),
@@ -364,6 +370,7 @@ class ColorIsExpensiveTheme {
         // --- Surface architecture: two-tier grey scaffold / white content ---
 
         appBarTheme: AppBarTheme(
+          centerTitle: false,
           backgroundColor: colorScheme.surface,
           foregroundColor: colorScheme.onSurface,
           elevation: 0,
@@ -502,18 +509,19 @@ class ColorIsExpensiveTheme {
           shape: RoundedRectangleBorder(
             borderRadius: _radii.borderRadiusMedium,
           ),
-          titleTextStyle: textTheme.bodyMedium?.copyWith(
+          titleTextStyle: resolved.bodyMedium?.copyWith(
             color: colorScheme.onSurface,
           ),
-          subtitleTextStyle: textTheme.bodySmall?.copyWith(
+          subtitleTextStyle: resolved.bodySmall?.copyWith(
             color: colorScheme.onSurfaceVariant,
           ),
-          leadingAndTrailingTextStyle: textTheme.bodyMedium?.copyWith(
+          leadingAndTrailingTextStyle: resolved.bodyMedium?.copyWith(
             color: colorScheme.onSurface,
             fontWeight: FontWeight.w500,
           ),
         ),
       );
+  }
 
   ThemeData light() => theme(lightScheme());
   ThemeData lightMediumContrast() => theme(lightMediumContrastScheme());

--- a/lib/design_system/widgetbook/block_production_status_card_use_case.dart
+++ b/lib/design_system/widgetbook/block_production_status_card_use_case.dart
@@ -12,6 +12,7 @@ WidgetbookComponent blockProductionStatusCardComponent() {
     useCases: [
       _allGreen(),
       _disconnected(),
+      _tappableRows(),
     ],
   );
 }
@@ -100,6 +101,59 @@ WidgetbookUseCase _disconnected() {
                 label: 'None yet',
                 variant: StatusBadgeVariant.neutral,
               ),
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}
+
+WidgetbookUseCase _tappableRows() {
+  return WidgetbookUseCase(
+    name: 'Tappable Rows',
+    builder: (context) {
+      final spacing = Theme.of(context).extension<AppSpacing>()!;
+
+      return Padding(
+        padding: EdgeInsets.all(spacing.space16),
+        child: BlockProductionStatusCard(
+          data: BlockProductionStatusData(
+            network: PipelineStepStatus(
+              label: 'Network',
+              icon: Symbols.wifi_sharp,
+              trailing: const StepTrailingBadge(
+                label: 'Connected',
+                variant: StatusBadgeVariant.success,
+              ),
+              onTap: () {},
+            ),
+            vrf: PipelineStepStatus(
+              label: 'VRF Calculation',
+              icon: Symbols.casino_sharp,
+              trailing: const StepTrailingBadge(
+                label: 'Complete',
+                variant: StatusBadgeVariant.success,
+              ),
+              onTap: () {},
+            ),
+            nextBlock: PipelineStepStatus(
+              label: 'Next Block',
+              icon: Symbols.schedule_sharp,
+              trailing: const StepTrailingText(text: 'in ~12 min'),
+              onTap: () {},
+            ),
+            lastProduced: PipelineStepStatus(
+              label: 'Last Produced',
+              icon: Symbols.check_circle_sharp,
+              trailing: const StepTrailingText(text: '2 min ago'),
+              onTap: () {},
+            ),
+            missedBlocks: PipelineStepStatus(
+              label: 'Missed Blocks',
+              icon: Symbols.disabled_by_default_sharp,
+              trailing: const StepTrailingText(text: '3 blocks'),
+              onTap: () {},
             ),
           ),
         ),

--- a/lib/design_system/widgetbook/slot_assignments_page_use_case.dart
+++ b/lib/design_system/widgetbook/slot_assignments_page_use_case.dart
@@ -144,6 +144,61 @@ WidgetbookComponent slotAssignmentsPageComponent() {
         },
       ),
       WidgetbookUseCase(
+        name: 'Heartbeat Highlight',
+        builder: (context) {
+          final items = [
+            const SlotAssignmentItemData(
+              slot: 5012,
+              status: SlotStatus.produced,
+              timeLabel: 'Today, 14:21',
+              isTappable: true,
+            ),
+            const SlotAssignmentItemData(
+              slot: 5011,
+              status: SlotStatus.produced,
+              timeLabel: 'Today, 13:05',
+              isTappable: true,
+            ),
+            const SlotAssignmentItemData(
+              slot: 5010,
+              status: SlotStatus.missed,
+              timeLabel: 'Today, 12:42',
+            ),
+            const SlotAssignmentItemData(
+              slot: 5009,
+              status: SlotStatus.orphaned,
+              timeLabel: 'Today, 11:18',
+              isTappable: true,
+            ),
+            const SlotAssignmentItemData(
+              slot: 5008,
+              status: SlotStatus.produced,
+              timeLabel: 'Yesterday, 23:55',
+              isTappable: true,
+            ),
+          ];
+
+          return SlotAssignmentsPage(
+            title: 'Slot Assignments',
+            epochLabel: 'Epoch 176',
+            slotProgressLeftLabel: '5012 / 7140 slots',
+            slotProgressRightLabel: '7h 14min left',
+            slotProgress: 0.70,
+            filters: const [
+              SlotFilterData(label: 'Won Slots', count: 5, selected: false),
+              SlotFilterData(label: 'Produced', count: 4, selected: true),
+              SlotFilterData(label: 'Missed', count: 1),
+              SlotFilterData(label: 'Upcoming', count: 0),
+            ],
+            highlightIndex: 0,
+            onFilterTap: (_) {},
+            items: items,
+            onItemTap: (_) {},
+            onBackTap: () {},
+          );
+        },
+      ),
+      WidgetbookUseCase(
         name: 'Empty State',
         builder: (context) {
           return SlotAssignmentsPage(

--- a/lib/design_system/widgetbook/slot_assignments_page_use_case.dart
+++ b/lib/design_system/widgetbook/slot_assignments_page_use_case.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+import '../src/slot_assignments_page.dart';
+
+WidgetbookComponent slotAssignmentsPageComponent() {
+  return WidgetbookComponent(
+    name: 'SlotAssignments',
+    useCases: [
+      WidgetbookUseCase(
+        name: 'Playground',
+        builder: (context) {
+          final epochNumber = context.knobs.int.slider(
+            label: 'Epoch',
+            initialValue: 176,
+            min: 0,
+            max: 200,
+          );
+
+          final progress = context.knobs.double.slider(
+            label: 'Progress',
+            initialValue: 0.70,
+            min: 0,
+            max: 1,
+          );
+
+          final itemCount = context.knobs.int.slider(
+            label: 'Item Count',
+            initialValue: 20,
+            min: 0,
+            max: 50,
+          );
+
+          return _PlaygroundBuilder(
+            epochNumber: epochNumber,
+            progress: progress,
+            itemCount: itemCount,
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'All Produced',
+        builder: (context) {
+          final items = List.generate(
+            12,
+            (i) => SlotAssignmentItemData(
+              slot: 5000 + i,
+              status: SlotStatus.produced,
+              timeLabel: 'Today, ${(8 + i).toString().padLeft(2, '0')}:21',
+              isTappable: true,
+            ),
+          );
+
+          return SlotAssignmentsPage(
+            title: 'Slot Assignments',
+            epochLabel: 'Epoch 176',
+            slotProgressLeftLabel: '5000 / 7140 slots',
+            slotProgressRightLabel: '3h 12min left',
+            slotProgress: 0.70,
+            filters: const [
+              SlotFilterData(label: 'Won Slots', count: 12, selected: true),
+              SlotFilterData(label: 'Produced', count: 12),
+              SlotFilterData(label: 'Missed', count: 0),
+              SlotFilterData(label: 'Upcoming', count: 0),
+            ],
+            onFilterTap: (_) {},
+            items: items,
+            onItemTap: (_) {},
+            onBackTap: () {},
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Mixed Results',
+        builder: (context) {
+          final items = [
+            const SlotAssignmentItemData(
+              slot: 5012,
+              status: SlotStatus.produced,
+              timeLabel: 'Today, 14:21',
+              isTappable: true,
+            ),
+            const SlotAssignmentItemData(
+              slot: 5011,
+              status: SlotStatus.produced,
+              timeLabel: 'Today, 13:05',
+              isTappable: true,
+            ),
+            const SlotAssignmentItemData(
+              slot: 5010,
+              status: SlotStatus.missed,
+              timeLabel: 'Today, 12:42',
+            ),
+            const SlotAssignmentItemData(
+              slot: 5009,
+              status: SlotStatus.orphaned,
+              timeLabel: 'Today, 11:18',
+              isTappable: true,
+            ),
+            const SlotAssignmentItemData(
+              slot: 5008,
+              status: SlotStatus.produced,
+              timeLabel: 'Yesterday, 23:55',
+              isTappable: true,
+            ),
+            const SlotAssignmentItemData(
+              slot: 5007,
+              status: SlotStatus.upcoming,
+              timeLabel: 'Today, 15:30',
+            ),
+            const SlotAssignmentItemData(
+              slot: 5006,
+              status: SlotStatus.upcoming,
+              timeLabel: 'Today, 16:45',
+            ),
+            const SlotAssignmentItemData(
+              slot: 5005,
+              status: SlotStatus.notCalculated,
+            ),
+            const SlotAssignmentItemData(
+              slot: 5004,
+              status: SlotStatus.notWon,
+            ),
+          ];
+
+          return SlotAssignmentsPage(
+            title: 'Slot Assignments',
+            epochLabel: 'Epoch 176',
+            slotProgressLeftLabel: '5012 / 7140 slots',
+            slotProgressRightLabel: '7h 14min left',
+            slotProgress: 0.70,
+            filters: const [
+              SlotFilterData(label: 'Won Slots', count: 9, selected: true),
+              SlotFilterData(label: 'Produced', count: 4),
+              SlotFilterData(label: 'Missed', count: 1),
+              SlotFilterData(label: 'Orphaned', count: 1),
+              SlotFilterData(label: 'Upcoming', count: 2),
+            ],
+            onFilterTap: (_) {},
+            items: items,
+            onItemTap: (_) {},
+            onBackTap: () {},
+          );
+        },
+      ),
+      WidgetbookUseCase(
+        name: 'Empty State',
+        builder: (context) {
+          return SlotAssignmentsPage(
+            title: 'Slot Assignments',
+            epochLabel: 'Epoch 176',
+            slotProgressLeftLabel: '5000 / 7140 slots',
+            slotProgressRightLabel: '4h 30min left',
+            slotProgress: 0.70,
+            filters: const [
+              SlotFilterData(label: 'Won Slots', count: 21),
+              SlotFilterData(label: 'Produced', count: 0, selected: true),
+              SlotFilterData(label: 'Missed', count: 0),
+              SlotFilterData(label: 'Upcoming', count: 0),
+            ],
+            onFilterTap: (_) {},
+            items: const [],
+            onItemTap: (_) {},
+            onBackTap: () {},
+          );
+        },
+      ),
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stateful wrapper for the Playground use case (manages filter toggle state)
+// ---------------------------------------------------------------------------
+
+class _PlaygroundBuilder extends StatefulWidget {
+  const _PlaygroundBuilder({
+    required this.epochNumber,
+    required this.progress,
+    required this.itemCount,
+  });
+
+  final int epochNumber;
+  final double progress;
+  final int itemCount;
+
+  @override
+  State<_PlaygroundBuilder> createState() => _PlaygroundBuilderState();
+}
+
+class _PlaygroundBuilderState extends State<_PlaygroundBuilder> {
+  int _selectedFilter = 0;
+
+  static const _statuses = SlotStatus.values;
+
+  List<SlotAssignmentItemData> _generateItems(int count) {
+    return List.generate(count, (i) {
+      final status = _statuses[i % _statuses.length];
+      final hour = (8 + i) % 24;
+      final minute = (i * 7) % 60;
+      final timeLabel = status == SlotStatus.notCalculated ||
+              status == SlotStatus.notWon
+          ? null
+          : '${i < 12 ? "Today" : "Mar 14"}, ${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
+      return SlotAssignmentItemData(
+        slot: 5000 + count - i,
+        status: status,
+        timeLabel: timeLabel,
+        isTappable:
+            status == SlotStatus.produced || status == SlotStatus.orphaned,
+      );
+    });
+  }
+
+  List<SlotAssignmentItemData> _filterItems(
+    List<SlotAssignmentItemData> all,
+  ) {
+    if (_selectedFilter == 0) return all;
+    final targetStatuses = switch (_selectedFilter) {
+      1 => [SlotStatus.produced],
+      2 => [SlotStatus.missed],
+      3 => [SlotStatus.orphaned],
+      4 => [SlotStatus.upcoming],
+      _ => SlotStatus.values.toList(),
+    };
+    return all.where((item) => targetStatuses.contains(item.status)).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final allItems = _generateItems(widget.itemCount);
+    final filteredItems = _filterItems(allItems);
+
+    int countByStatus(List<SlotStatus> statuses) =>
+        allItems.where((i) => statuses.contains(i.status)).length;
+
+    final filters = [
+      SlotFilterData(
+        label: 'Won Slots',
+        count: allItems.length,
+        selected: _selectedFilter == 0,
+      ),
+      SlotFilterData(
+        label: 'Produced',
+        count: countByStatus([SlotStatus.produced]),
+        selected: _selectedFilter == 1,
+      ),
+      SlotFilterData(
+        label: 'Missed',
+        count: countByStatus([SlotStatus.missed]),
+        selected: _selectedFilter == 2,
+      ),
+      SlotFilterData(
+        label: 'Orphaned',
+        count: countByStatus([SlotStatus.orphaned]),
+        selected: _selectedFilter == 3,
+      ),
+      SlotFilterData(
+        label: 'Upcoming',
+        count: countByStatus([SlotStatus.upcoming]),
+        selected: _selectedFilter == 4,
+      ),
+    ];
+
+    final totalSlots = (widget.itemCount * 1.4).round();
+
+    return SlotAssignmentsPage(
+      title: 'Slot Assignments',
+      epochLabel: 'Epoch ${widget.epochNumber}',
+      slotProgressLeftLabel: '${widget.itemCount} / $totalSlots slots',
+      slotProgressRightLabel: '3h 45min left',
+      slotProgress: widget.progress,
+      filters: filters,
+      onFilterTap: (index) => setState(() => _selectedFilter = index),
+      items: filteredItems,
+      onItemTap: (_) {},
+      onBackTap: () {},
+    );
+  }
+}

--- a/lib/design_system/widgetbook/widgetbook.dart
+++ b/lib/design_system/widgetbook/widgetbook.dart
@@ -38,6 +38,7 @@ import 'result_page_use_case.dart';
 import 'score_header_use_case.dart';
 import 'settings_page_use_case.dart';
 import 'sheet_layout_use_case.dart';
+import 'slot_assignments_page_use_case.dart';
 import 'shimmer_use_case.dart';
 import 'status_badge_use_case.dart';
 import 'status_text_trailing_use_case.dart';
@@ -274,6 +275,7 @@ class WidgetbookApp extends StatelessWidget {
               children: [
                 epochPerformancePageComponent(),
                 leaderboardPageComponent(),
+                slotAssignmentsPageComponent(),
               ],
             ),
             WidgetbookFolder(

--- a/lib/features/challenges/screens/challenge_detail_screen.dart
+++ b/lib/features/challenges/screens/challenge_detail_screen.dart
@@ -290,11 +290,8 @@ class ChallengeDetailScreen extends ConsumerWidget {
             variant: StatusBadgeVariant.neutral,
           ),
       },
-      onTap: currentEpoch != null
-          ? () => context.push(
-                AppRoutes.epochPerformance,
-                extra: {'initialEpoch': currentEpoch},
-              )
+      onTap: currentEpoch != null && summary != null
+          ? () => _navigateToSlots(context, summary, currentEpoch, ['all'])
           : null,
     );
 
@@ -402,10 +399,10 @@ class ChallengeDetailScreen extends ConsumerWidget {
     // Missed Blocks step — count from current epoch
     final PipelineStepStatus? missedBlocksStep;
     if (summary != null && currentEpoch != null) {
-      final currentScore = summary.epochScores.cast<EpochScore?>().firstWhere(
-            (s) => s!.epochData.slotData != null,
-            orElse: () => null,
-          );
+      final currentScore =
+          (currentEpoch >= 0 && currentEpoch < summary.epochScores.length)
+              ? summary.epochScores[currentEpoch]
+              : null;
       final missed = currentScore?.missed ?? 0;
       missedBlocksStep = PipelineStepStatus(
         label: 'Missed Blocks',
@@ -466,10 +463,9 @@ class ChallengeDetailScreen extends ConsumerWidget {
     List<String> filters,
   ) {
     if (currentEpoch == null) return;
-    final score = data.epochScores.cast<EpochScore?>().firstWhere(
-          (s) => s!.epochData.slotData != null,
-          orElse: () => null,
-        );
+    final score = (currentEpoch >= 0 && currentEpoch < data.epochScores.length)
+        ? data.epochScores[currentEpoch]
+        : null;
     final epochData = score?.epochData.slotData;
     final results = epochData == null
         ? <int>[]

--- a/lib/features/challenges/screens/challenge_detail_screen.dart
+++ b/lib/features/challenges/screens/challenge_detail_screen.dart
@@ -5,7 +5,6 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import 'package:crypto_mobile_app/core/config/app_router.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
-import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/core/models/leaderboard_api_models.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 import 'package:crypto_mobile_app/core/providers/points_breakdown_provider.dart';
@@ -17,6 +16,7 @@ import 'package:crypto_mobile_app/design_system/src/challenge_detail_page.dart';
 import 'package:crypto_mobile_app/design_system/src/challenge_reward_card.dart';
 import 'package:crypto_mobile_app/design_system/src/status_badge.dart';
 import 'package:crypto_mobile_app/features/challenges/challenge_mappers.dart';
+import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/epoch_slots.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
 

--- a/lib/features/challenges/screens/challenge_detail_screen.dart
+++ b/lib/features/challenges/screens/challenge_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import 'package:crypto_mobile_app/core/config/app_router.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
+import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/core/models/leaderboard_api_models.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 import 'package:crypto_mobile_app/core/providers/points_breakdown_provider.dart';
@@ -52,6 +53,7 @@ class ChallengeDetailScreen extends ConsumerWidget {
         builder: (context, diffSnapshot) {
           return _buildPage(
             context,
+            ref,
             eb,
             diffSnapshot.data,
             latestEpoch,
@@ -65,6 +67,7 @@ class ChallengeDetailScreen extends ConsumerWidget {
 
   Widget _buildPage(
     BuildContext context,
+    WidgetRef ref,
     EventBreakdown? eb,
     PointDiff? diff,
     int? latestEpoch,
@@ -101,7 +104,7 @@ class ChallengeDetailScreen extends ConsumerWidget {
           : null,
       statusSection: isProduceBlocks
           ? _buildStatusSection(
-              context, nodeStatus, blocksSummaryData, latestEpoch)
+              context, ref, nodeStatus, blocksSummaryData, latestEpoch)
           : null,
       sections: _buildSections(context, dto),
       totalRewardHeading: showRewardCard
@@ -220,12 +223,16 @@ class ChallengeDetailScreen extends ConsumerWidget {
 
   Widget _buildStatusSection(
     BuildContext context,
+    WidgetRef ref,
     NodeStatusState? nodeStatus,
     ProducedBlocksSummary? summary,
     int? currentEpoch,
   ) {
-    // Network step — always tappable, navigates to Node Status
-    void networkOnTap() => context.push(AppRoutes.mainNode);
+    // Network step — always tappable, navigates to Node Status tab
+    void networkOnTap() {
+      ref.read(currentHomeTabProvider.notifier).state = HomeTab.nodeStatus;
+      context.go(AppRoutes.home);
+    }
     final PipelineStepStatus networkStep;
     if (nodeStatus == null) {
       networkStep = PipelineStepStatus(

--- a/lib/features/challenges/screens/challenge_detail_screen.dart
+++ b/lib/features/challenges/screens/challenge_detail_screen.dart
@@ -100,7 +100,8 @@ class ChallengeDetailScreen extends ConsumerWidget {
           ? _buildRewardCard(context, category, eb, diff, latestEpoch)
           : null,
       statusSection: isProduceBlocks
-          ? _buildStatusSection(nodeStatus, blocksSummaryData)
+          ? _buildStatusSection(
+              context, nodeStatus, blocksSummaryData, latestEpoch)
           : null,
       sections: _buildSections(context, dto),
       totalRewardHeading: showRewardCard
@@ -218,41 +219,47 @@ class ChallengeDetailScreen extends ConsumerWidget {
   }
 
   Widget _buildStatusSection(
+    BuildContext context,
     NodeStatusState? nodeStatus,
     ProducedBlocksSummary? summary,
+    int? currentEpoch,
   ) {
-    // Network step
+    // Network step — always tappable, navigates to Node Status
+    void networkOnTap() => context.push(AppRoutes.mainNode);
     final PipelineStepStatus networkStep;
     if (nodeStatus == null) {
-      networkStep = const PipelineStepStatus(
+      networkStep = PipelineStepStatus(
         label: 'Network',
         icon: Symbols.wifi_sharp,
-        trailing: StepTrailingBadge(
+        trailing: const StepTrailingBadge(
           label: 'Loading',
           variant: StatusBadgeVariant.neutral,
         ),
+        onTap: networkOnTap,
       );
     } else if (nodeStatus.connectedPeers > 0) {
-      networkStep = const PipelineStepStatus(
+      networkStep = PipelineStepStatus(
         label: 'Network',
         icon: Symbols.wifi_sharp,
-        trailing: StepTrailingBadge(
+        trailing: const StepTrailingBadge(
           label: 'Connected',
           variant: StatusBadgeVariant.success,
         ),
+        onTap: networkOnTap,
       );
     } else {
-      networkStep = const PipelineStepStatus(
+      networkStep = PipelineStepStatus(
         label: 'Network',
         icon: Symbols.wifi_sharp,
-        trailing: StepTrailingBadge(
+        trailing: const StepTrailingBadge(
           label: 'Disconnected',
           variant: StatusBadgeVariant.error,
         ),
+        onTap: networkOnTap,
       );
     }
 
-    // VRF step
+    // VRF step — tappable when currentEpoch is known
     final PipelineStepStatus vrfStep;
     final vrfStatus = nodeStatus?.vrfEvaluator?.currentEpochVrfEvaluationStatus;
     vrfStep = PipelineStepStatus(
@@ -276,6 +283,12 @@ class ChallengeDetailScreen extends ConsumerWidget {
             variant: StatusBadgeVariant.neutral,
           ),
       },
+      onTap: currentEpoch != null
+          ? () => context.push(
+                AppRoutes.epochPerformance,
+                extra: {'initialEpoch': currentEpoch},
+              )
+          : null,
     );
 
     // Next Block step — find first scheduled slot with future time
@@ -301,11 +314,17 @@ class ChallengeDetailScreen extends ConsumerWidget {
       }
     }
 
-    if (nextBlockText != null) {
+    // Next Block — tappable when there are upcoming slots
+    final hasUpcoming = nextBlockText != null;
+    if (hasUpcoming) {
       nextBlockStep = PipelineStepStatus(
         label: 'Next Block',
         icon: Symbols.schedule_sharp,
         trailing: StepTrailingText(text: nextBlockText),
+        onTap: summary != null
+            ? () =>
+                _navigateToSlots(context, summary, currentEpoch, ['upcoming'])
+            : null,
       );
     } else if (vrfStatus == RpcStatusVrfEvaluationStatus.completed) {
       nextBlockStep = const PipelineStepStatus(
@@ -349,12 +368,18 @@ class ChallengeDetailScreen extends ConsumerWidget {
       }
     }
 
-    if (lastProducedTimeMs != null) {
+    // Last Produced — tappable when there are produced blocks
+    final hasProduced = lastProducedTimeMs != null;
+    if (hasProduced) {
       final agoMs = nowMs - lastProducedTimeMs.toInt();
       lastProducedStep = PipelineStepStatus(
         label: 'Last Produced',
         icon: Symbols.check_circle_sharp,
         trailing: StepTrailingText(text: _formatTimeAgo(agoMs)),
+        onTap: summary != null
+            ? () =>
+                _navigateToSlots(context, summary, currentEpoch, ['produced'])
+            : null,
       );
     } else {
       lastProducedStep = const PipelineStepStatus(
@@ -367,12 +392,39 @@ class ChallengeDetailScreen extends ConsumerWidget {
       );
     }
 
+    // Missed Blocks step — count from current epoch
+    final PipelineStepStatus? missedBlocksStep;
+    if (summary != null && currentEpoch != null) {
+      final currentScore = summary.epochScores.cast<EpochScore?>().firstWhere(
+            (s) => s!.epochData.slotData != null,
+            orElse: () => null,
+          );
+      final missed = currentScore?.missed ?? 0;
+      missedBlocksStep = PipelineStepStatus(
+        label: 'Missed Blocks',
+        icon: Symbols.disabled_by_default_sharp,
+        trailing: missed > 0
+            ? StepTrailingText(
+                text: '$missed ${missed == 1 ? 'block' : 'blocks'}')
+            : const StepTrailingBadge(
+                label: 'None',
+                variant: StatusBadgeVariant.success,
+              ),
+        onTap: missed > 0
+            ? () => _navigateToSlots(context, summary, currentEpoch, ['missed'])
+            : null,
+      );
+    } else {
+      missedBlocksStep = null;
+    }
+
     return BlockProductionStatusCard(
       data: BlockProductionStatusData(
         network: networkStep,
         vrf: vrfStep,
         nextBlock: nextBlockStep,
         lastProduced: lastProducedStep,
+        missedBlocks: missedBlocksStep,
       ),
     );
   }
@@ -397,6 +449,52 @@ class ChallengeDetailScreen extends ConsumerWidget {
     if (hours < 24) return '$hours h ago';
     final days = hours ~/ 24;
     return '$days d ago';
+  }
+
+  /// Navigate to slot assignments with extracted slot data.
+  static void _navigateToSlots(
+    BuildContext context,
+    ProducedBlocksSummary data,
+    int? currentEpoch,
+    List<String> filters,
+  ) {
+    if (currentEpoch == null) return;
+    final score = data.epochScores.cast<EpochScore?>().firstWhere(
+          (s) => s!.epochData.slotData != null,
+          orElse: () => null,
+        );
+    final epochData = score?.epochData.slotData;
+    final results = epochData == null
+        ? <int>[]
+        : epochData.map((s) => s.result.index).toList();
+    final slotTimesMs = epochData == null
+        ? <int?>[]
+        : epochData.map((s) => s.slotTimeMs?.toInt()).toList();
+    final producedMeta = epochData == null
+        ? const <Map<String, dynamic>?>[]
+        : epochData
+            .map((s) => s.producedBlockMetadata == null
+                ? null
+                : <String, dynamic>{
+                    'blockHash': s.producedBlockMetadata!.blockHash.toString(),
+                    'canonical': s.producedBlockMetadata!.canonical,
+                    'timestampMs':
+                        s.producedBlockMetadata!.timestampMs.toString(),
+                    'tokensWon': s.producedBlockMetadata!.tokensWon.toString(),
+                  })
+            .toList();
+
+    context.push(
+      AppRoutes.slotAssignments,
+      extra: {
+        'epoch': currentEpoch,
+        'slotsInEpoch': data.slotsInEpoch,
+        'results': results,
+        'slotTimesMs': slotTimesMs,
+        'producedMeta': producedMeta,
+        'filters': filters,
+      },
+    );
   }
 
   String _categoryDisplayName(ChallengeCategory category) {

--- a/lib/features/node/screens/slot_assignments_screen.dart
+++ b/lib/features/node/screens/slot_assignments_screen.dart
@@ -39,7 +39,7 @@ class _ParsedItem {
 }
 
 class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
-  _Filter? _selected;
+  _Filter _selected = _Filter.wonSlots;
   late final List<_ParsedItem> _items =
       _buildItemsFromArgs(widget.args) ?? const <_ParsedItem>[];
 
@@ -105,7 +105,8 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
           producedMeta: i < producedMeta.length ? producedMeta[i] : null,
         );
       }).toList();
-    } catch (_) {
+    } catch (e, st) {
+      debugPrint('SlotAssignmentsScreen: failed to parse args: $e\n$st');
       return null;
     }
   }
@@ -144,8 +145,7 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
   // ---------------------------------------------------------------------------
 
   bool _matchesFilter(_ParsedItem item) {
-    if (_selected == null) return true;
-    return switch (_selected!) {
+    return switch (_selected) {
       _Filter.wonSlots => item.result == RpcSlotResult.produced ||
           item.result == RpcSlotResult.orphaned ||
           item.result == RpcSlotResult.missed ||
@@ -160,7 +160,7 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
   void _onFilterTap(int index) {
     final tapped = _chipOrder[index];
     setState(() {
-      _selected = _selected == tapped ? null : tapped;
+      _selected = _selected == tapped ? _Filter.wonSlots : tapped;
     });
   }
 
@@ -219,8 +219,6 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
     final List<_ParsedItem> filtered;
     if (_selected == _Filter.upcoming) {
       filtered = _items.where(_matchesFilter).toList(growable: false);
-    } else if (_selected == null) {
-      filtered = _items;
     } else {
       filtered = _items.reversed.where(_matchesFilter).toList(growable: false);
     }

--- a/lib/features/node/screens/slot_assignments_screen.dart
+++ b/lib/features/node/screens/slot_assignments_screen.dart
@@ -1,29 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:material_symbols_icons/symbols.dart';
 import 'package:crypto_mobile_app/core/providers/produced_blocks_provider.dart';
 import 'package:crypto_mobile_app/core/config/app_router.dart';
-import 'package:crypto_mobile_app/core/widgets/app_card.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 import 'package:go_router/go_router.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/epoch_slots.dart';
 
-class SlotAssignmentsScreen extends StatefulWidget {
+class SlotAssignmentsScreen extends ConsumerStatefulWidget {
   const SlotAssignmentsScreen({super.key, this.args});
   final Map<String, dynamic>? args;
 
   @override
-  State<SlotAssignmentsScreen> createState() => _SlotAssignmentsScreenState();
+  ConsumerState<SlotAssignmentsScreen> createState() =>
+      _SlotAssignmentsScreenState();
 }
 
-enum _Filter { all, produced, missed, upcoming }
+enum _Filter { wonSlots, produced, missed, upcoming }
 
-class _AssignmentItem {
+/// Chip order — used for both building chips and resolving tap indices.
+const _chipOrder = [
+  _Filter.wonSlots,
+  _Filter.produced,
+  _Filter.missed,
+  _Filter.upcoming
+];
+
+class _ParsedItem {
   final int slot;
   final RpcSlotResult result;
   final int? slotTimeMs;
   final Map<String, dynamic>? producedMeta;
-  const _AssignmentItem({
+  const _ParsedItem({
     required this.slot,
     required this.result,
     this.slotTimeMs,
@@ -31,33 +38,37 @@ class _AssignmentItem {
   });
 }
 
-class _SlotAssignmentsScreenState extends State<SlotAssignmentsScreen> {
-  final Set<_Filter> _selected = {_Filter.all};
-  late final List<_AssignmentItem> _items =
-      _buildItemsFromArgs(widget.args) ?? const <_AssignmentItem>[];
+class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
+  _Filter? _selected;
+  late final List<_ParsedItem> _items =
+      _buildItemsFromArgs(widget.args) ?? const <_ParsedItem>[];
 
   @override
   void initState() {
     super.initState();
-    // Initialize selected filters from args if provided
     final filters = (widget.args?['filters'] as List?)?.cast<String>();
     if (filters != null && filters.isNotEmpty) {
-      final Set<_Filter> initial = {};
       if (filters.contains('all')) {
-        initial.add(_Filter.all);
+        _selected = _Filter.wonSlots;
+      } else if (filters.contains('produced')) {
+        _selected = _Filter.produced;
+      } else if (filters.contains('missed')) {
+        _selected = _Filter.missed;
+      } else if (filters.contains('upcoming')) {
+        _selected = _Filter.upcoming;
       } else {
-        if (filters.contains('produced')) initial.add(_Filter.produced);
-        if (filters.contains('missed')) initial.add(_Filter.missed);
-        if (filters.contains('upcoming')) initial.add(_Filter.upcoming);
-        if (initial.isEmpty) initial.add(_Filter.all);
+        _selected = _Filter.wonSlots;
       }
-      _selected
-        ..clear()
-        ..addAll(initial);
+    } else {
+      _selected = _Filter.wonSlots;
     }
   }
 
-  List<_AssignmentItem>? _buildItemsFromArgs(Map<String, dynamic>? args) {
+  // ---------------------------------------------------------------------------
+  // Args parsing (reused from old screen)
+  // ---------------------------------------------------------------------------
+
+  List<_ParsedItem>? _buildItemsFromArgs(Map<String, dynamic>? args) {
     if (args == null) return null;
     try {
       final epoch = args['epoch'] as int?;
@@ -80,14 +91,14 @@ class _SlotAssignmentsScreenState extends State<SlotAssignmentsScreen> {
               .map((e) => e == null ? null : (e as Map).cast<String, dynamic>())
               .toList();
       if (epoch == null || slotsInEpoch == null || results == null) return null;
-      return List<_AssignmentItem>.generate(slotsInEpoch, (i) {
+      return List<_ParsedItem>.generate(slotsInEpoch, (i) {
         RpcSlotResult r;
         if (i < results.length) {
           r = RpcSlotResult.values[results[i]];
         } else {
           r = RpcSlotResult.notCalculated;
         }
-        return _AssignmentItem(
+        return _ParsedItem(
           slot: i,
           result: r,
           slotTimeMs: i < slotTimesMs.length ? slotTimesMs[i] : null,
@@ -99,65 +110,100 @@ class _SlotAssignmentsScreenState extends State<SlotAssignmentsScreen> {
     }
   }
 
-  bool _matchesFilters(_AssignmentItem item) {
-    // When no filters are selected, show everything.
-    if (_selected.isEmpty) {
-      return true;
-    }
+  // ---------------------------------------------------------------------------
+  // Data mapping helpers
+  // ---------------------------------------------------------------------------
 
-    final wantsWonSlots = _selected.contains(_Filter.all) &&
-        (item.result == RpcSlotResult.produced ||
-            item.result == RpcSlotResult.orphaned ||
-            item.result == RpcSlotResult.missed ||
-            item.result == RpcSlotResult.scheduled);
-    final wantsProduced = _selected.contains(_Filter.produced) &&
-        (item.result == RpcSlotResult.produced ||
-            item.result == RpcSlotResult.orphaned);
-    final wantsMissed = _selected.contains(_Filter.missed) &&
-        item.result == RpcSlotResult.missed;
-    final wantsUpcoming = _selected.contains(_Filter.upcoming) &&
-        item.result == RpcSlotResult.scheduled;
-    return wantsWonSlots || wantsProduced || wantsMissed || wantsUpcoming;
+  static SlotStatus _mapStatus(RpcSlotResult r) => switch (r) {
+        RpcSlotResult.produced => SlotStatus.produced,
+        RpcSlotResult.orphaned => SlotStatus.orphaned,
+        RpcSlotResult.missed => SlotStatus.missed,
+        RpcSlotResult.scheduled => SlotStatus.upcoming,
+        RpcSlotResult.notCalculated => SlotStatus.notCalculated,
+        RpcSlotResult.notWon => SlotStatus.notWon,
+      };
+
+  static String? _formatTimeLabel(RpcSlotResult result, int? slotTimeMs) {
+    if (slotTimeMs == null) return null;
+    final dt = DateTime.fromMillisecondsSinceEpoch(slotTimeMs);
+    final hh = dt.hour.toString().padLeft(2, '0');
+    final mm = dt.minute.toString().padLeft(2, '0');
+    final ss = dt.second.toString().padLeft(2, '0');
+    final timeStr = '$hh:$mm:$ss';
+    return switch (result) {
+      RpcSlotResult.scheduled => 'Scheduled for $timeStr',
+      RpcSlotResult.produced => 'Produced at $timeStr',
+      RpcSlotResult.missed => 'Missed at $timeStr',
+      RpcSlotResult.orphaned => 'Orphaned at $timeStr',
+      _ => null,
+    };
   }
 
-  void _toggleFilter(_Filter filter) {
+  // ---------------------------------------------------------------------------
+  // Filter logic
+  // ---------------------------------------------------------------------------
+
+  bool _matchesFilter(_ParsedItem item) {
+    if (_selected == null) return true;
+    return switch (_selected!) {
+      _Filter.wonSlots => item.result == RpcSlotResult.produced ||
+          item.result == RpcSlotResult.orphaned ||
+          item.result == RpcSlotResult.missed ||
+          item.result == RpcSlotResult.scheduled,
+      _Filter.produced => item.result == RpcSlotResult.produced ||
+          item.result == RpcSlotResult.orphaned,
+      _Filter.missed => item.result == RpcSlotResult.missed,
+      _Filter.upcoming => item.result == RpcSlotResult.scheduled,
+    };
+  }
+
+  void _onFilterTap(int index) {
+    final tapped = _chipOrder[index];
     setState(() {
-      // Single-select behavior:
-      // - Tapping an already-selected filter clears all (shows everything).
-      // - Tapping a different filter selects only that one.
-      if (_selected.contains(filter)) {
-        _selected.clear();
-      } else {
-        _selected
-          ..clear()
-          ..add(filter);
-      }
+      _selected = _selected == tapped ? null : tapped;
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // Slot progress from live provider
+  // ---------------------------------------------------------------------------
+
+  (int current, int total, double fraction) _slotProgress(
+    ProducedBlocksSummary? data,
+    int epoch,
+    int fallbackSlotsInEpoch,
+  ) {
+    final total = data?.slotsInEpoch ?? fallbackSlotsInEpoch;
+    if (data == null || total <= 0) return (0, total, 0.0);
+
+    final currentEpoch = data.currentEpoch;
+    int curr;
+    if (currentEpoch == epoch) {
+      curr = data.currentEpochSlot;
+    } else if (epoch > currentEpoch) {
+      curr = 0;
+    } else {
+      curr = total; // past epoch
+    }
+    return (curr, total, curr / total);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
+
   @override
   Widget build(BuildContext context) {
-    final spacing = Theme.of(context).extension<AppSpacing>()!;
-    final radii = Theme.of(context).extension<AppRadii>()!;
-    final theme = Theme.of(context);
-    final secondary = theme.colorScheme.secondary;
-
-    // Build the filtered list
-    final List<_AssignmentItem> filtered;
-    if (_selected.contains(_Filter.upcoming)) {
-      // Sort upcoming slots ascending (chronological)
-      filtered = _items.where(_matchesFilters).toList(growable: false);
-    } else {
-      // Sort all, produced and missed views descending (newest first)
-      filtered = _items.reversed.where(_matchesFilters).toList(growable: false);
-    }
-
     final args = widget.args ?? const <String, dynamic>{};
     final epoch = (args['epoch'] as int?) ?? 0;
     final slotsInEpoch = (args['slotsInEpoch'] as int?) ?? 0;
-    // Progress now driven by live node status; results not needed here
 
-    // Precompute counts for each filter for display in chips.
+    // Live slot progress
+    final summary = ref.watch(producedBlocksSummaryProvider);
+    final data = summary.asData?.value;
+    final (curr, total, progress) = _slotProgress(data, epoch, slotsInEpoch);
+
+    // Filter counts
     final producedCount = _items
         .where((i) =>
             i.result == RpcSlotResult.produced ||
@@ -169,387 +215,69 @@ class _SlotAssignmentsScreenState extends State<SlotAssignmentsScreen> {
         _items.where((i) => i.result == RpcSlotResult.scheduled).length;
     final wonSlotsCount = producedCount + missedCount + upcomingCount;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Slot Assignments'),
-        centerTitle: true,
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.all(spacing.space16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Header KPI card
-              AppCard(
-                color: theme.colorScheme.surfaceBright,
-                borderRadius: radii.borderRadiusLargeIncreased,
-                padding: EdgeInsets.all(spacing.space16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          'Epoch $epoch',
-                          style: theme.textTheme.bodyLarge
-                              ?.copyWith(fontWeight: FontWeight.w600),
-                        ),
-                        Consumer(builder: (context, ref, _) {
-                          final summary =
-                              ref.watch(producedBlocksSummaryProvider);
-                          final data = summary.asData?.value;
-                          final total = data?.slotsInEpoch ?? slotsInEpoch;
-                          final currentEpoch = data?.currentEpoch;
-                          final isCurrentEpoch =
-                              currentEpoch != null && currentEpoch == epoch;
-                          final isFutureEpoch =
-                              currentEpoch != null && epoch > currentEpoch;
+    // Build filtered + sorted item list
+    final List<_ParsedItem> filtered;
+    if (_selected == _Filter.upcoming) {
+      filtered = _items.where(_matchesFilter).toList(growable: false);
+    } else if (_selected == null) {
+      filtered = _items;
+    } else {
+      filtered = _items.reversed.where(_matchesFilter).toList(growable: false);
+    }
 
-                          int curr;
-                          if (data == null || total <= 0) {
-                            curr = 0;
-                          } else if (isCurrentEpoch) {
-                            curr = data.currentEpochSlot;
-                          } else if (isFutureEpoch) {
-                            curr = 0;
-                          } else {
-                            // Past epoch: fully completed
-                            curr = total;
-                          }
+    final dsItems = filtered.map((item) {
+      final isTappable = item.result == RpcSlotResult.produced ||
+          item.result == RpcSlotResult.orphaned;
+      return SlotAssignmentItemData(
+        slot: item.slot,
+        status: _mapStatus(item.result),
+        timeLabel: _formatTimeLabel(item.result, item.slotTimeMs),
+        isTappable: isTappable,
+      );
+    }).toList(growable: false);
 
-                          return Text(
-                            'Slot Progress: $curr / $total',
-                            style: theme.textTheme.bodyMedium
-                                ?.copyWith(color: secondary),
-                          );
-                        }),
-                      ],
-                    ),
-                    SizedBox(height: spacing.space12),
-                    Consumer(builder: (context, ref, _) {
-                      final summary = ref.watch(producedBlocksSummaryProvider);
-                      final data = summary.asData?.value;
-                      final total = data?.slotsInEpoch ?? slotsInEpoch;
-                      final currentEpoch = data?.currentEpoch;
-                      final isCurrentEpoch =
-                          currentEpoch != null && currentEpoch == epoch;
-                      final isFutureEpoch =
-                          currentEpoch != null && epoch > currentEpoch;
-
-                      int curr;
-                      if (data == null || total <= 0) {
-                        curr = 0;
-                      } else if (isCurrentEpoch) {
-                        curr = data.currentEpochSlot;
-                      } else if (isFutureEpoch) {
-                        curr = 0;
-                      } else {
-                        // Past epoch: fully completed
-                        curr = total;
-                      }
-
-                      final p = total > 0 ? (curr / total) : 0.0;
-                      return _ProgressBar(progress: p);
-                    }),
-                  ],
-                ),
-              ),
-              SizedBox(height: spacing.space12),
-              // Filters row
-              SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: Row(
-                  spacing: spacing.space8,
-                  children: [
-                    _FilterChip(
-                      label: 'Won Slots',
-                      count: wonSlotsCount,
-                      selected: _selected.contains(_Filter.all),
-                      onTap: () => _toggleFilter(_Filter.all),
-                    ),
-                    _FilterChip(
-                      label: 'Produced',
-                      count: producedCount,
-                      selected: _selected.contains(_Filter.produced),
-                      onTap: () => _toggleFilter(_Filter.produced),
-                    ),
-                    _FilterChip(
-                      label: 'Missed',
-                      count: missedCount,
-                      selected: _selected.contains(_Filter.missed),
-                      onTap: () => _toggleFilter(_Filter.missed),
-                    ),
-                    _FilterChip(
-                      label: 'Upcoming',
-                      count: upcomingCount,
-                      selected: _selected.contains(_Filter.upcoming),
-                      onTap: () => _toggleFilter(_Filter.upcoming),
-                    ),
-                  ],
-                ),
-              ),
-              SizedBox(height: spacing.space12),
-              // List title
-              Text(
-                'Assignments',
-                style: theme.textTheme.titleMedium
-                    ?.copyWith(fontWeight: FontWeight.bold),
-              ),
-              SizedBox(height: spacing.space8),
-              // Filtered list of slots (demo data)
-              Expanded(
-                child: ListView.separated(
-                  padding: EdgeInsets.only(bottom: spacing.space32),
-                  itemBuilder: (context, index) {
-                    final item = filtered[index];
-                    final isScheduled = item.result == RpcSlotResult.scheduled;
-                    final isProduced = item.result == RpcSlotResult.produced;
-                    final isMissed = item.result == RpcSlotResult.missed;
-                    final isOrphaned = item.result == RpcSlotResult.orphaned;
-                    String subtitleText = '';
-                    if (item.slotTimeMs != null &&
-                        (isScheduled || isProduced || isMissed || isOrphaned)) {
-                      final dt =
-                          DateTime.fromMillisecondsSinceEpoch(item.slotTimeMs!);
-                      final hh = dt.hour.toString().padLeft(2, '0');
-                      final mm = dt.minute.toString().padLeft(2, '0');
-                      final ss = dt.second.toString().padLeft(2, '0');
-                      final timeStr = '$hh:$mm:$ss';
-                      if (isScheduled) {
-                        subtitleText = 'Scheduled for $timeStr';
-                      } else if (isProduced) {
-                        subtitleText = 'Produced at $timeStr';
-                      } else if (isMissed) {
-                        subtitleText = 'Missed at $timeStr';
-                      } else if (isOrphaned) {
-                        subtitleText = 'Orphaned at $timeStr';
-                      }
-                    }
-                    final VoidCallback? onTap = (isProduced || isOrphaned)
-                        ? () {
-                            context.push(
-                              AppRoutes.producedBlockDetails,
-                              extra: {
-                                'epoch': epoch,
-                                'slot': item.slot,
-                                'metadata': item.producedMeta,
-                                'slotsInEpoch': slotsInEpoch,
-                              },
-                            );
-                          }
-                        : null;
-                    // Calculate global slot: globalSlot = epoch * slotsInEpoch + slot
-                    final globalSlot = epoch * slotsInEpoch + item.slot;
-                    return _SlotRow(
-                      icon: Symbols.layers_sharp,
-                      title: 'Epoch Slot ${item.slot}',
-                      subtitle: subtitleText,
-                      result: item.result,
-                      globalSlot: globalSlot,
-                      onTap: onTap,
-                    );
-                  },
-                  separatorBuilder: (_, __) => const Divider(height: 1),
-                  itemCount: filtered.length,
-                ),
-              ),
-            ],
-          ),
+    return SlotAssignmentsPage(
+      title: 'Slot Assignments',
+      epochLabel: 'Epoch $epoch',
+      slotProgressLeftLabel: '$curr / $total slots',
+      slotProgress: progress,
+      filters: [
+        SlotFilterData(
+          label: 'Won Slots',
+          count: wonSlotsCount,
+          selected: _selected == _Filter.wonSlots,
         ),
-      ),
-    );
-  }
-}
-
-class _ProgressBar extends StatelessWidget {
-  const _ProgressBar({required this.progress});
-  final double progress;
-
-  @override
-  Widget build(BuildContext context) {
-    final radii = Theme.of(context).extension<AppRadii>()!;
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final isDark = colorScheme.brightness == Brightness.dark;
-
-    // Match ProducedBlocksScreen epoch panel colors:
-    // - Light: grey track + black active
-    // - Dark: surfaceVariant track + primary active
-    final trackColor = colorScheme.surfaceContainerHighest;
-    final activeColor = isDark ? colorScheme.primary : colorScheme.onSurface;
-
-    final p = progress.clamp(0.0, 1.0);
-    return SizedBox(
-      height: 12,
-      child: Stack(
-        alignment: Alignment.centerLeft,
-        children: [
-          Container(
-            height: 4,
-            decoration: BoxDecoration(
-              color: trackColor,
-              borderRadius: radii.borderRadiusXSmall,
-            ),
-          ),
-          FractionallySizedBox(
-            widthFactor: p,
-            child: Container(
-              height: 4,
-              decoration: BoxDecoration(
-                color: activeColor,
-                borderRadius: radii.borderRadiusXSmall,
-              ),
-            ),
-          ),
-          Align(
-            alignment: Alignment.centerRight,
-            child: Container(
-              width: 4,
-              height: 8,
-              decoration: BoxDecoration(
-                color: activeColor,
-                borderRadius: radii.borderRadiusXLarge,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _SlotRow extends StatelessWidget {
-  const _SlotRow({
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    required this.result,
-    required this.globalSlot,
-    this.onTap,
-  });
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final RpcSlotResult result;
-  final int globalSlot;
-  final VoidCallback? onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final spacing = Theme.of(context).extension<AppSpacing>()!;
-    final sizing = Theme.of(context).extension<AppSizing>()!;
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final resultLabel = switch (result) {
-      RpcSlotResult.produced => 'Produced',
-      RpcSlotResult.orphaned => 'Orphaned',
-      RpcSlotResult.missed => 'Missed',
-      RpcSlotResult.scheduled => 'Upcoming',
-      RpcSlotResult.notCalculated => 'Not Calculated',
-      RpcSlotResult.notWon => 'Not Won',
-    };
-    final showChevron =
-        result == RpcSlotResult.produced || result == RpcSlotResult.orphaned;
-    final resultColor = result == RpcSlotResult.orphaned
-        ? colorScheme.error
-        : colorScheme.onSurface;
-
-    return ListTile(
-      leading: IconBadge(icon: icon),
-      title: Text(title),
-      subtitle: Text('Global Slot $globalSlot · $subtitle'),
-      trailing: showChevron
-          ? Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  resultLabel,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: resultColor,
-                  ),
-                ),
-                SizedBox(width: spacing.space4),
-                Icon(Symbols.chevron_right_sharp,
-                    size: sizing.iconSmall,
-                    color: colorScheme.onSurfaceVariant),
-              ],
-            )
-          : Text(
-              resultLabel,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-                color: resultColor,
-              ),
-            ),
-      onTap: onTap,
-    );
-  }
-}
-
-class _FilterChip extends StatelessWidget {
-  const _FilterChip({
-    required this.label,
-    required this.count,
-    required this.selected,
-    required this.onTap,
-  });
-  final String label;
-  final int count;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final spacing = Theme.of(context).extension<AppSpacing>()!;
-    final radii = Theme.of(context).extension<AppRadii>()!;
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final bg = selected ? colorScheme.onSurface : colorScheme.surface;
-    final fg = selected ? colorScheme.surface : colorScheme.onSurface;
-    final border = selected ? colorScheme.onSurface : colorScheme.outline;
-    return InkWell(
-      onTap: onTap,
-      borderRadius: radii.borderRadiusLargeIncreased,
-      child: Container(
-        padding: EdgeInsets.symmetric(
-            horizontal: spacing.space8, vertical: spacing.space8),
-        decoration: BoxDecoration(
-          color: bg,
-          borderRadius: radii.borderRadiusLarge,
-          border: Border.all(color: border),
+        SlotFilterData(
+          label: 'Produced',
+          count: producedCount,
+          selected: _selected == _Filter.produced,
         ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              padding: EdgeInsets.symmetric(
-                  horizontal: spacing.space8, vertical: spacing.space4),
-              decoration: BoxDecoration(
-                color: colorScheme.onSurfaceVariant,
-                borderRadius: radii.borderRadiusFull,
-              ),
-              child: Text(
-                '$count',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: colorScheme.surface,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-            SizedBox(width: spacing.space8),
-            Text(
-              label,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: fg,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ],
+        SlotFilterData(
+          label: 'Missed',
+          count: missedCount,
+          selected: _selected == _Filter.missed,
         ),
-      ),
+        SlotFilterData(
+          label: 'Upcoming',
+          count: upcomingCount,
+          selected: _selected == _Filter.upcoming,
+        ),
+      ],
+      onFilterTap: _onFilterTap,
+      items: dsItems,
+      onItemTap: (index) {
+        final item = filtered[index];
+        context.push(
+          AppRoutes.producedBlockDetails,
+          extra: {
+            'epoch': epoch,
+            'slot': item.slot,
+            'metadata': item.producedMeta,
+            'slotsInEpoch': slotsInEpoch,
+          },
+        );
+      },
+      onBackTap: () => context.pop(),
     );
   }
 }

--- a/lib/features/node/screens/slot_assignments_screen.dart
+++ b/lib/features/node/screens/slot_assignments_screen.dart
@@ -40,6 +40,7 @@ class _ParsedItem {
 
 class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
   _Filter _selected = _Filter.wonSlots;
+  bool _isInitialFilter = true;
   late final List<_ParsedItem> _items =
       _buildItemsFromArgs(widget.args) ?? const <_ParsedItem>[];
 
@@ -159,6 +160,7 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
 
   void _onFilterTap(int index) {
     final tapped = _chipOrder[index];
+    _isInitialFilter = false;
     setState(() {
       _selected = _selected == tapped ? _Filter.wonSlots : tapped;
     });
@@ -234,11 +236,20 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
       );
     }).toList(growable: false);
 
+    final highlightIndex = _isInitialFilter &&
+            filtered.isNotEmpty &&
+            (_selected == _Filter.produced ||
+                _selected == _Filter.missed ||
+                _selected == _Filter.upcoming)
+        ? 0
+        : null;
+
     return SlotAssignmentsPage(
       title: 'Slot Assignments',
       epochLabel: 'Epoch $epoch',
       slotProgressLeftLabel: '$curr / $total slots',
       slotProgress: progress,
+      highlightIndex: highlightIndex,
       filters: [
         SlotFilterData(
           label: 'Won Slots',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -761,18 +761,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: "direct dev"
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_symbols_icons:
     dependency: "direct main"
     description:
@@ -1229,10 +1229,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timing:
     dependency: transitive
     description:

--- a/test/design_system/block_production_status_card_test.dart
+++ b/test/design_system/block_production_status_card_test.dart
@@ -1,0 +1,146 @@
+import 'package:crypto_mobile_app/design_system/design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import 'helpers/ds_test_helpers.dart';
+
+BlockProductionStatusData _baseData({
+  VoidCallback? networkOnTap,
+  VoidCallback? vrfOnTap,
+  VoidCallback? nextBlockOnTap,
+  VoidCallback? lastProducedOnTap,
+  PipelineStepStatus? missedBlocks,
+}) {
+  return BlockProductionStatusData(
+    network: PipelineStepStatus(
+      label: 'Network',
+      icon: Symbols.wifi_sharp,
+      trailing: const StepTrailingBadge(
+        label: 'Connected',
+        variant: StatusBadgeVariant.success,
+      ),
+      onTap: networkOnTap,
+    ),
+    vrf: PipelineStepStatus(
+      label: 'VRF Calculation',
+      icon: Symbols.casino_sharp,
+      trailing: const StepTrailingBadge(
+        label: 'Complete',
+        variant: StatusBadgeVariant.success,
+      ),
+      onTap: vrfOnTap,
+    ),
+    nextBlock: PipelineStepStatus(
+      label: 'Next Block',
+      icon: Symbols.schedule_sharp,
+      trailing: const StepTrailingText(text: 'in ~12 min'),
+      onTap: nextBlockOnTap,
+    ),
+    lastProduced: PipelineStepStatus(
+      label: 'Last Produced',
+      icon: Symbols.check_circle_sharp,
+      trailing: const StepTrailingText(text: '2 min ago'),
+      onTap: lastProducedOnTap,
+    ),
+    missedBlocks: missedBlocks,
+  );
+}
+
+void main() {
+  group('BlockProductionStatusCard', () {
+    testWidgets('renders 4 rows by default', (tester) async {
+      await tester.pumpWidget(wrap(
+        BlockProductionStatusCard(data: _baseData()),
+      ));
+
+      expect(find.byType(ListTile), findsNWidgets(4));
+      expect(find.text('Network'), findsOneWidget);
+      expect(find.text('VRF Calculation'), findsOneWidget);
+      expect(find.text('Next Block'), findsOneWidget);
+      expect(find.text('Last Produced'), findsOneWidget);
+    });
+
+    testWidgets('renders 5 rows when missedBlocks is provided', (tester) async {
+      await tester.pumpWidget(wrap(
+        BlockProductionStatusCard(
+          data: _baseData(
+            missedBlocks: const PipelineStepStatus(
+              label: 'Missed Blocks',
+              icon: Symbols.disabled_by_default_sharp,
+              trailing: StepTrailingText(text: '3 blocks'),
+            ),
+          ),
+        ),
+      ));
+
+      expect(find.byType(ListTile), findsNWidgets(5));
+      expect(find.text('Missed Blocks'), findsOneWidget);
+      expect(find.text('3 blocks'), findsOneWidget);
+    });
+
+    testWidgets('ListTile is tappable when onTap is provided', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(wrap(
+        BlockProductionStatusCard(
+          data: _baseData(networkOnTap: () => tapped = true),
+        ),
+      ));
+
+      await tester.tap(find.text('Network'));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('ListTile is not tappable when onTap is null', (tester) async {
+      await tester.pumpWidget(wrap(
+        BlockProductionStatusCard(data: _baseData()),
+      ));
+
+      // ListTile with null onTap should not have an InkWell with an onTap
+      final networkTile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Network'),
+      );
+      expect(networkTile.onTap, isNull);
+    });
+
+    testWidgets('shows chevron icon only for tappable rows', (tester) async {
+      await tester.pumpWidget(wrap(
+        BlockProductionStatusCard(
+          data: _baseData(networkOnTap: () {}),
+        ),
+      ));
+
+      // Only the Network row has onTap, so only 1 chevron
+      expect(find.byIcon(Symbols.chevron_right_sharp), findsOneWidget);
+    });
+
+    testWidgets('shows no chevron when no rows are tappable', (tester) async {
+      await tester.pumpWidget(wrap(
+        BlockProductionStatusCard(data: _baseData()),
+      ));
+
+      expect(find.byIcon(Symbols.chevron_right_sharp), findsNothing);
+    });
+
+    testWidgets('all rows tappable shows chevron on each', (tester) async {
+      await tester.pumpWidget(wrap(
+        BlockProductionStatusCard(
+          data: _baseData(
+            networkOnTap: () {},
+            vrfOnTap: () {},
+            nextBlockOnTap: () {},
+            lastProducedOnTap: () {},
+            missedBlocks: PipelineStepStatus(
+              label: 'Missed Blocks',
+              icon: Symbols.disabled_by_default_sharp,
+              trailing: const StepTrailingText(text: '3 blocks'),
+              onTap: () {},
+            ),
+          ),
+        ),
+      ));
+
+      expect(find.byIcon(Symbols.chevron_right_sharp), findsNWidgets(5));
+    });
+  });
+}

--- a/test/design_system/slot_assignments_page_test.dart
+++ b/test/design_system/slot_assignments_page_test.dart
@@ -1,0 +1,186 @@
+import 'package:crypto_mobile_app/design_system/design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import 'helpers/ds_test_helpers.dart';
+
+const _defaultFilters = [
+  SlotFilterData(label: 'Won Slots', count: 5, selected: true),
+  SlotFilterData(label: 'Produced', count: 3),
+  SlotFilterData(label: 'Missed', count: 1),
+  SlotFilterData(label: 'Upcoming', count: 1),
+];
+
+const _defaultItems = [
+  SlotAssignmentItemData(
+    slot: 100,
+    status: SlotStatus.produced,
+    timeLabel: 'Produced at 08:21:00',
+    isTappable: true,
+  ),
+  SlotAssignmentItemData(
+    slot: 101,
+    status: SlotStatus.missed,
+    timeLabel: 'Missed at 09:15:00',
+  ),
+  SlotAssignmentItemData(
+    slot: 102,
+    status: SlotStatus.upcoming,
+    timeLabel: 'Scheduled for 14:00:00',
+  ),
+];
+
+Widget _buildPage({
+  List<SlotFilterData> filters = _defaultFilters,
+  List<SlotAssignmentItemData> items = _defaultItems,
+  ValueChanged<int>? onFilterTap,
+  ValueChanged<int>? onItemTap,
+  VoidCallback? onBackTap,
+  String epochLabel = 'Epoch 176',
+  String slotProgressLeftLabel = '5000 / 7140 slots',
+  String? slotProgressRightLabel,
+  double slotProgress = 0.7,
+}) {
+  return wrap(
+    SlotAssignmentsPage(
+      title: 'Slot Assignments',
+      epochLabel: epochLabel,
+      slotProgressLeftLabel: slotProgressLeftLabel,
+      slotProgressRightLabel: slotProgressRightLabel,
+      slotProgress: slotProgress,
+      filters: filters,
+      onFilterTap: onFilterTap ?? (_) {},
+      items: items,
+      onItemTap: onItemTap,
+      onBackTap: onBackTap,
+    ),
+  );
+}
+
+void main() {
+  group('SlotAssignmentsPage', () {
+    testWidgets('renders epoch label and progress bar', (tester) async {
+      await tester.pumpWidget(_buildPage());
+
+      expect(find.text('Epoch 176'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      expect(find.text('5000 / 7140 slots'), findsOneWidget);
+    });
+
+    testWidgets('renders optional right progress label', (tester) async {
+      await tester.pumpWidget(
+        _buildPage(slotProgressRightLabel: '3h 12min left'),
+      );
+
+      expect(find.text('3h 12min left'), findsOneWidget);
+    });
+
+    testWidgets('renders filter chips with counts', (tester) async {
+      await tester.pumpWidget(_buildPage());
+
+      expect(find.byType(FilterChip), findsNWidgets(4));
+      expect(find.text('Won Slots'), findsOneWidget);
+      // "Produced", "Missed", "Upcoming" appear in both chips and item trailing
+      expect(find.byType(FilterChip), findsNWidgets(4));
+      // Count avatars
+      expect(find.text('5'), findsOneWidget);
+      expect(find.text('3'), findsOneWidget);
+      expect(find.text('1'), findsNWidgets(2));
+    });
+
+    testWidgets('onFilterTap fires with correct index', (tester) async {
+      int? tappedIndex;
+      await tester.pumpWidget(
+        _buildPage(
+          onFilterTap: (i) => tappedIndex = i,
+          items: const [], // empty to avoid label collision
+        ),
+      );
+
+      await tester.tap(find.text('Missed'));
+      expect(tappedIndex, 2);
+    });
+
+    testWidgets('renders item list tiles', (tester) async {
+      await tester.pumpWidget(_buildPage());
+
+      expect(find.byType(ListTile), findsNWidgets(3));
+      expect(find.text('Slot 100'), findsOneWidget);
+      expect(find.text('Slot 101'), findsOneWidget);
+      expect(find.text('Slot 102'), findsOneWidget);
+    });
+
+    testWidgets('shows subtitle time labels', (tester) async {
+      await tester.pumpWidget(_buildPage());
+
+      expect(find.text('Produced at 08:21:00'), findsOneWidget);
+      expect(find.text('Missed at 09:15:00'), findsOneWidget);
+      expect(find.text('Scheduled for 14:00:00'), findsOneWidget);
+    });
+
+    testWidgets('shows status labels in trailing', (tester) async {
+      await tester.pumpWidget(_buildPage());
+
+      expect(find.text('Produced'), findsNWidgets(2)); // filter chip + item
+      expect(find.text('Missed'), findsNWidgets(2));
+      expect(find.text('Upcoming'), findsNWidgets(2));
+    });
+
+    testWidgets('tappable items show chevron and fire onItemTap',
+        (tester) async {
+      int? tappedIndex;
+      await tester.pumpWidget(
+        _buildPage(onItemTap: (i) => tappedIndex = i),
+      );
+
+      // Only the produced item (index 0) is tappable
+      expect(find.byIcon(Symbols.chevron_right_sharp), findsOneWidget);
+
+      await tester.tap(find.text('Slot 100'));
+      expect(tappedIndex, 0);
+    });
+
+    testWidgets('non-tappable items do not fire onItemTap', (tester) async {
+      int? tappedIndex;
+      await tester.pumpWidget(
+        _buildPage(onItemTap: (i) => tappedIndex = i),
+      );
+
+      await tester.tap(find.text('Slot 101'));
+      expect(tappedIndex, isNull);
+    });
+
+    testWidgets('empty state renders no ListTiles', (tester) async {
+      await tester.pumpWidget(_buildPage(items: const []));
+
+      expect(find.byType(ListTile), findsNothing);
+    });
+
+    testWidgets('back button calls onBackTap', (tester) async {
+      var backTapped = false;
+      await tester.pumpWidget(
+        _buildPage(onBackTap: () => backTapped = true),
+      );
+
+      await tester.tap(find.byIcon(Symbols.arrow_back_sharp));
+      expect(backTapped, isTrue);
+    });
+
+    testWidgets('orphaned items get error badge colors', (tester) async {
+      await tester.pumpWidget(_buildPage(
+        items: const [
+          SlotAssignmentItemData(
+            slot: 50,
+            status: SlotStatus.orphaned,
+            isTappable: true,
+          ),
+        ],
+      ));
+
+      // Verify the IconBadge uses error colors (non-default)
+      final badge = tester.widget<IconBadge>(find.byType(IconBadge));
+      expect(badge.backgroundColor, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #308
Closes #303

## Summary
- **New DS widget**: `SlotAssignmentsPage` — presentation-only page with epoch progress header, M3 `FilterChip` row, and status-badged `ListTile` items
- **Rewired feature screen**: Replaced 555-line monolithic `SlotAssignmentsScreen` with a ~280-line thin `ConsumerStatefulWidget` that parses route args, manages filter state, watches `producedBlocksSummaryProvider` for live slot progress, and delegates all rendering to the DS widget
- **New DS widget**: `BlockProductionStatusCard` — pipeline step status display with semantic badges, tappable rows with chevron affordance, optional 5th missed-blocks row
- **Heartbeat highlight**: When navigating via "Last Produced", "Missed Blocks", or "Next Block", the first matching item pulses 3× with a smooth sine-wave background animation (1800ms, `surfaceContainerHighest` at 35% opacity). Respects reduced motion. Clears on manual filter change.
- **Theme fixes**: `centerTitle: false` in `AppBarTheme` so titles inherit left-alignment; resolved text geometry via `Typography.englishLike2021.merge()` so `ListTileTheme` styles get concrete font sizes
- **Bug fix**: Network shortcut in `BlockProductionStatusCard` now navigates to Node Status tab within HomeScreen (preserving bottom nav) instead of pushing a standalone screen
- **Orphaned badge colors**: Orphaned slots now use `errorContainer` colors for visual distinction from produced slots
- Widgetbook use cases and tests for both new DS widgets

## Test plan
- [x] `flutter analyze` passes
- [x] `dart format` clean
- [x] `SlotAssignmentsPage` test suite (11 cases: rendering, filters, taps, empty state, orphaned badge)
- [x] `BlockProductionStatusCard` test suite (7 cases: row count, tap callbacks, chevron visibility)
- [ ] Slot assignments screen shows left-aligned title
- [ ] Filter chips toggle correctly, item list filters
- [ ] Tapping produced/orphaned items navigates to block details
- [ ] Back button pops correctly
- [ ] Live slot progress bar updates from provider
- [ ] Challenge detail → tap "Last Produced" → slot assignments opens with produced filter, first item pulses 3×
- [ ] Challenge detail → tap "Missed Blocks" → same with missed filter
- [ ] Challenge detail → tap "Next Block" → same with upcoming filter
- [ ] On slot assignments, tap a different filter chip → no highlight on new list
- [ ] Widgetbook "Heartbeat Highlight" use case — confirm 3 pulses on first item, then stops
- [ ] Widgetbook use cases render correctly
- [ ] Challenge detail → Network step → Node Status shows with bottom nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)