### PR TITLE
refactor: extract shared HH:MM:SS time formatting utility

### DIFF
--- a/lib/core/utils/time_format.dart
+++ b/lib/core/utils/time_format.dart
@@ -1,0 +1,14 @@
+/// Formats [dt] as `"HH:MM:SS"` (24-hour, zero-padded).
+String formatHHMMSS(DateTime dt) {
+  final hh = dt.hour.toString().padLeft(2, '0');
+  final mm = dt.minute.toString().padLeft(2, '0');
+  final ss = dt.second.toString().padLeft(2, '0');
+  return '$hh:$mm:$ss';
+}
+
+/// Formats [dt] as `"HH:MM"` (24-hour, zero-padded, no seconds).
+String formatHHMM(DateTime dt) {
+  final hh = dt.hour.toString().padLeft(2, '0');
+  final mm = dt.minute.toString().padLeft(2, '0');
+  return '$hh:$mm';
+}

--- a/lib/core/widgets/produced_block_card.dart
+++ b/lib/core/widgets/produced_block_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:crypto_mobile_app/core/config/app_router.dart';
+import 'package:crypto_mobile_app/core/utils/time_format.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_radii.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_spacing.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_typography.dart';
@@ -351,10 +352,7 @@ class ProducedBlockCard extends StatelessWidget {
       final millis = timestampMs.toInt();
       final blockTime =
           DateTime.fromMillisecondsSinceEpoch(millis, isUtc: true).toLocal();
-      final hour = blockTime.hour.toString().padLeft(2, '0');
-      final minute = blockTime.minute.toString().padLeft(2, '0');
-      final second = blockTime.second.toString().padLeft(2, '0');
-      return '$hour:$minute:$second';
+      return formatHHMMSS(blockTime);
     } catch (e) {
       return 'Invalid time';
     }
@@ -385,11 +383,7 @@ class ProducedBlockCard extends StatelessWidget {
             '${(diff.inDays / 7).floor()} week${(diff.inDays / 7).floor() == 1 ? '' : 's'} ago';
       }
 
-      // Format absolute time
-      final hour = blockTime.hour.toString().padLeft(2, '0');
-      final minute = blockTime.minute.toString().padLeft(2, '0');
-      final second = blockTime.second.toString().padLeft(2, '0');
-      final absoluteTime = '$hour:$minute:$second';
+      final absoluteTime = formatHHMMSS(blockTime);
 
       return '$relativeTime • $absoluteTime';
     } catch (e) {

--- a/lib/core/widgets/won_slot_item.dart
+++ b/lib/core/widgets/won_slot_item.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_radii.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_semantic_colors.dart';
+import 'package:crypto_mobile_app/core/utils/time_format.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_sizing.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_spacing.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/epoch_rewards.dart';
@@ -283,10 +284,7 @@ class WonSlotItem extends StatelessWidget {
 
       // If it's today, show time only
       if (now.year == dt.year && now.month == dt.month && now.day == dt.day) {
-        final hour = dt.hour.toString().padLeft(2, '0');
-        final minute = dt.minute.toString().padLeft(2, '0');
-        final second = dt.second.toString().padLeft(2, '0');
-        return 'Today at $hour:$minute:$second';
+        return 'Today at ${formatHHMMSS(dt)}';
       }
 
       // If it's tomorrow
@@ -294,17 +292,13 @@ class WonSlotItem extends StatelessWidget {
       if (tomorrow.year == dt.year &&
           tomorrow.month == dt.month &&
           tomorrow.day == dt.day) {
-        final hour = dt.hour.toString().padLeft(2, '0');
-        final minute = dt.minute.toString().padLeft(2, '0');
-        return 'Tomorrow at $hour:$minute';
+        return 'Tomorrow at ${formatHHMM(dt)}';
       }
 
       // Otherwise show full date
       final month = dt.month.toString().padLeft(2, '0');
       final day = dt.day.toString().padLeft(2, '0');
-      final hour = dt.hour.toString().padLeft(2, '0');
-      final minute = dt.minute.toString().padLeft(2, '0');
-      return '${dt.year}-$month-$day $hour:$minute';
+      return '${dt.year}-$month-$day ${formatHHMM(dt)}';
     } catch (e) {
       return 'Invalid time';
     }

--- a/lib/features/node/screens/node_status_screen.dart
+++ b/lib/features/node/screens/node_status_screen.dart
@@ -8,6 +8,7 @@ import 'package:crypto_mobile_app/core/config/app_router.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/core/utils/time_format.dart';
 import 'package:crypto_mobile_app/core/utils/utils.dart';
 import 'package:crypto_mobile_app/core/widgets/app_drawer.dart';
 import 'package:crypto_mobile_app/core/widgets/app_progress_bar.dart';
@@ -695,8 +696,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
     final now = DateTime.now();
     final checked = _lastChecked;
     final l10n = AppLocalizations.of(context);
-    final timeStr =
-        '${checked.hour.toString().padLeft(2, '0')}:${checked.minute.toString().padLeft(2, '0')}:${checked.second.toString().padLeft(2, '0')}';
+    final timeStr = formatHHMMSS(checked);
 
     final isToday = now.year == checked.year &&
         now.month == checked.month &&

--- a/lib/features/node/screens/slot_assignments_screen.dart
+++ b/lib/features/node/screens/slot_assignments_screen.dart
@@ -6,6 +6,7 @@ import 'package:crypto_mobile_app/core/config/app_router.dart';
 import 'package:crypto_mobile_app/core/widgets/app_card.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 import 'package:go_router/go_router.dart';
+import 'package:crypto_mobile_app/core/utils/time_format.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/epoch_slots.dart';
 
 class SlotAssignmentsScreen extends StatefulWidget {
@@ -313,10 +314,7 @@ class _SlotAssignmentsScreenState extends State<SlotAssignmentsScreen> {
                         (isScheduled || isProduced || isMissed || isOrphaned)) {
                       final dt =
                           DateTime.fromMillisecondsSinceEpoch(item.slotTimeMs!);
-                      final hh = dt.hour.toString().padLeft(2, '0');
-                      final mm = dt.minute.toString().padLeft(2, '0');
-                      final ss = dt.second.toString().padLeft(2, '0');
-                      final timeStr = '$hh:$mm:$ss';
+                      final timeStr = formatHHMMSS(dt);
                       if (isScheduled) {
                         subtitleText = 'Scheduled for $timeStr';
                       } else if (isProduced) {

--- a/lib/features/wallet/models/transaction_model.dart
+++ b/lib/features/wallet/models/transaction_model.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:crypto_mobile_app/core/services/explorer_service.dart';
+import 'package:crypto_mobile_app/core/utils/time_format.dart';
 import 'package:crypto_mobile_app/core/utils/utils.dart';
 
 enum TransactionType {
@@ -84,11 +85,8 @@ class TransactionModel {
     final year = timestamp.year.toString();
     final month = timestamp.month.toString().padLeft(2, '0');
     final day = timestamp.day.toString().padLeft(2, '0');
-    final hour = timestamp.hour.toString().padLeft(2, '0');
-    final minute = timestamp.minute.toString().padLeft(2, '0');
-    final second = timestamp.second.toString().padLeft(2, '0');
 
-    return '$year-$month-$day $hour:$minute:$second';
+    return '$year-$month-$day ${formatHHMMSS(timestamp)}';
   }
 
   String get fullSubtitle => shortHash;


### PR DESCRIPTION
## Summary

Closes #312.

- **Problem**: The `padLeft(2, '0')` HH:MM:SS time formatting pattern was duplicated across 5 files (`slot_assignments_screen.dart`, `produced_block_card.dart`, `won_slot_item.dart`, `node_status_screen.dart`, `transaction_model.dart`), making it easy for formatting to drift and harder to maintain.
- **Solution**: Extracted two shared utilities — `formatHHMMSS(DateTime)` and `formatHHMM(DateTime)` — into `lib/core/utils/time_format.dart` and replaced all inline occurrences.
- Net result: **+27 lines, −29 lines** (fewer lines overall, single source of truth for time formatting).

## Files changed

| File | Change |
|------|--------|
| `lib/core/utils/time_format.dart` | **New** — `formatHHMMSS()` and `formatHHMM()` |
| `lib/features/node/screens/slot_assignments_screen.dart` | Uses `formatHHMMSS()` in time label builder |
| `lib/core/widgets/produced_block_card.dart` | Uses `formatHHMMSS()` in `_formatTimestamp` and `_formatTimestampDetailed` |
| `lib/core/widgets/won_slot_item.dart` | Uses `formatHHMMSS()` for "Today" and `formatHHMM()` for "Tomorrow"/full-date branches |
| `lib/features/node/screens/node_status_screen.dart` | Uses `formatHHMMSS()` in `_formatLastChecked` |
| `lib/features/wallet/models/transaction_model.dart` | Uses `formatHHMMSS()` in `formattedTimestamp` getter |

## Test plan

- [x] `flutter analyze` passes on all changed files (pre-existing `mainNodeBlockDetails` error in `produced_block_card.dart` is unrelated)
- [ ] `flutter test` passes
- [ ] Grep for `padLeft(2, '0')` in changed files confirms no remaining inline HH:MM:SS duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)