### PR TITLE
Gate dApps behind leaderboard challenge

### DIFF
--- a/lib/design_system/src/dapp_card.dart
+++ b/lib/design_system/src/dapp_card.dart
@@ -6,6 +6,7 @@ import '../tokens/app_borders.dart';
 import '../tokens/app_radii.dart';
 import '../tokens/app_sizing.dart';
 import '../tokens/app_spacing.dart';
+import 'status_badge.dart';
 
 class DappCard extends StatelessWidget {
   static const kDefaultDescription =
@@ -19,6 +20,8 @@ class DappCard extends StatelessWidget {
     this.users,
     this.txns,
     this.onTap,
+    this.enabled = true,
+    this.disabledLabel,
   });
 
   final String name;
@@ -27,6 +30,8 @@ class DappCard extends StatelessWidget {
   final int? users;
   final int? txns;
   final VoidCallback? onTap;
+  final bool enabled;
+  final String? disabledLabel;
 
   static final _compactFormat = NumberFormat.compact();
 
@@ -42,8 +47,12 @@ class DappCard extends StatelessWidget {
 
     final borderRadius = BorderRadius.circular(radii.largeIncreased);
 
+    final cardBg =
+        enabled ? colors.surfaceContainerLowest : colors.surfaceContainerLow;
+    final titleColor = enabled ? null : colors.onSurfaceVariant;
+
     return Card(
-      color: colors.surfaceContainerLowest,
+      color: cardBg,
       elevation: 0,
       clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(
@@ -54,7 +63,7 @@ class DappCard extends StatelessWidget {
         ),
       ),
       child: InkWell(
-        onTap: onTap,
+        onTap: enabled ? onTap : null,
         borderRadius: borderRadius,
         child: Padding(
           padding: EdgeInsets.all(spacing.space16),
@@ -72,7 +81,7 @@ class DappCard extends StatelessWidget {
               SizedBox(height: spacing.space16),
               Text(
                 name,
-                style: textTheme.titleMedium,
+                style: textTheme.titleMedium?.copyWith(color: titleColor),
                 overflow: TextOverflow.ellipsis,
                 maxLines: 2,
               ),
@@ -86,26 +95,32 @@ class DappCard extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
               SizedBox(height: spacing.space8),
-              Row(
-                children: [
-                  if (users != null || txns != null)
-                    _StatsRow(
-                      users: users,
-                      txns: txns,
-                      style: textTheme.labelSmall!
-                          .copyWith(color: colors.onSurfaceVariant),
-                      iconSize: sizing.iconSmall,
-                      iconColor: colors.onSurfaceVariant,
-                      gap: spacing.space8,
+              if (enabled)
+                Row(
+                  children: [
+                    if (users != null || txns != null)
+                      _StatsRow(
+                        users: users,
+                        txns: txns,
+                        style: textTheme.labelSmall!
+                            .copyWith(color: colors.onSurfaceVariant),
+                        iconSize: sizing.iconSmall,
+                        iconColor: colors.onSurfaceVariant,
+                        gap: spacing.space8,
+                      ),
+                    const Spacer(),
+                    Icon(
+                      Symbols.arrow_forward_sharp,
+                      size: sizing.iconSmall,
+                      color: colors.primary,
                     ),
-                  const Spacer(),
-                  Icon(
-                    Symbols.arrow_forward_sharp,
-                    size: sizing.iconSmall,
-                    color: colors.primary,
-                  ),
-                ],
-              ),
+                  ],
+                )
+              else if (disabledLabel != null)
+                StatusBadge(
+                  label: disabledLabel!,
+                  variant: StatusBadgeVariant.neutral,
+                ),
             ],
           ),
         ),

--- a/lib/design_system/widgetbook/dapp_card_use_case.dart
+++ b/lib/design_system/widgetbook/dapp_card_use_case.dart
@@ -36,6 +36,11 @@ WidgetbookComponent dappCardComponent() {
             initialValue: 5678,
           );
 
+          final enabled = context.knobs.boolean(
+            label: 'Enabled',
+            initialValue: true,
+          );
+
           return Padding(
             padding: const EdgeInsets.all(16),
             child: DappCard(
@@ -44,6 +49,7 @@ WidgetbookComponent dappCardComponent() {
               description: description,
               users: users,
               txns: txns,
+              enabled: enabled,
               onTap: () {},
             ),
           );

--- a/lib/design_system/widgetbook/dapp_card_use_case.dart
+++ b/lib/design_system/widgetbook/dapp_card_use_case.dart
@@ -50,6 +50,7 @@ WidgetbookComponent dappCardComponent() {
               users: users,
               txns: txns,
               enabled: enabled,
+              disabledLabel: enabled ? null : 'Coming',
               onTap: () {},
             ),
           );

--- a/lib/features/challenges/challenge_mappers.dart
+++ b/lib/features/challenges/challenge_mappers.dart
@@ -341,6 +341,12 @@ bool isZkIdentityChallenge(ChallengeDto dto) {
   return dto.subCategory == zkIdentitySubCategory;
 }
 
+/// SubCategory identifier for the dApps challenge.
+const String kDappsSubCategory = 'DAPPS_CHALLENGE';
+
+/// Returns true when the challenge is the dApps challenge.
+bool isDappsChallenge(ChallengeDto dto) => dto.subCategory == kDappsSubCategory;
+
 /// Computes effective earned points for produce-blocks challenges.
 ///
 /// When [earnedPoints] (from per-challenge breakdown) is available, returns it

--- a/lib/features/dapps/dapps_screen.dart
+++ b/lib/features/dapps/dapps_screen.dart
@@ -2,6 +2,7 @@ import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 import 'package:crypto_mobile_app/features/dapps/dapp_webview_screen.dart';
 import 'package:crypto_mobile_app/features/dapps/models/dapp_item.dart';
+import 'package:crypto_mobile_app/features/dapps/providers/dapps_challenge_provider.dart';
 import 'package:crypto_mobile_app/features/dapps/providers/dapps_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,11 +27,12 @@ class _DappsScreenState extends ConsumerState<DappsScreen> {
 
   Future<void> _onRefresh() async {
     ref.invalidate(dappsProvider);
-    ref.invalidate(dappStatsProvider);
-    await Future.wait([
-      ref.read(dappsProvider.future),
-      ref.read(dappStatsProvider.future),
-    ]);
+    final futures = <Future<Object>>[ref.read(dappsProvider.future)];
+    if (ref.read(dappsLiveProvider)) {
+      ref.invalidate(dappStatsProvider);
+      futures.add(ref.read(dappStatsProvider.future));
+    }
+    await Future.wait(futures);
   }
 
   @override
@@ -39,7 +41,8 @@ class _DappsScreenState extends ConsumerState<DappsScreen> {
     final spacing = theme.extension<AppSpacing>()!;
     final sizing = theme.extension<AppSizing>()!;
     final dappsAsync = ref.watch(dappsProvider);
-    final statsAsync = ref.watch(dappStatsProvider);
+    final dappsLive = ref.watch(dappsLiveProvider);
+    final statsAsync = dappsLive ? ref.watch(dappStatsProvider) : null;
 
     final dappCount = dappsAsync.valueOrNull?.length;
 
@@ -54,12 +57,14 @@ class _DappsScreenState extends ConsumerState<DappsScreen> {
         header: _DappsHeader(
           count: dappCount,
           statsAsync: statsAsync,
+          dappsLive: dappsLive,
         ),
         surfaceSlivers: _buildSurfaceSlivers(
           dappsAsync,
           statsAsync,
           spacing,
           sizing,
+          dappsLive,
         ),
       ),
     );
@@ -67,16 +72,20 @@ class _DappsScreenState extends ConsumerState<DappsScreen> {
 
   List<Widget> _buildSurfaceSlivers(
     AsyncValue<List<DappItem>> dappsAsync,
-    AsyncValue<Map<String, DappStats>> statsAsync,
+    AsyncValue<Map<String, DappStats>>? statsAsync,
     AppSpacing spacing,
     AppSizing sizing,
+    bool dappsLive,
   ) {
+    final effectiveSort = dappsLive ? _sortMode : SortMode.alpha;
+
     return [
       SliverPadding(
         padding: EdgeInsets.symmetric(horizontal: spacing.space24),
         sliver: SliverToBoxAdapter(
           child: _SortBar(
-            sortMode: _sortMode,
+            sortMode: effectiveSort,
+            enabled: dappsLive,
             onSortChanged: (mode) => setState(() => _sortMode = mode),
           ),
         ),
@@ -110,7 +119,7 @@ class _DappsScreenState extends ConsumerState<DappsScreen> {
           ),
         ],
         data: (_) {
-          final sorted = ref.watch(sortedDappsProvider(_sortMode));
+          final sorted = ref.watch(sortedDappsProvider(effectiveSort));
 
           if (sorted.isEmpty) {
             return [
@@ -131,7 +140,7 @@ class _DappsScreenState extends ConsumerState<DappsScreen> {
                 itemCount: sorted.length,
                 separatorBuilder: (_, __) => SizedBox(height: spacing.space8),
                 itemBuilder: (_, index) =>
-                    _buildDappCard(context, sorted[index]),
+                    _buildDappCard(context, sorted[index], dappsLive),
               ),
             ),
             SliverToBoxAdapter(child: SizedBox(height: spacing.space32)),
@@ -144,25 +153,31 @@ class _DappsScreenState extends ConsumerState<DappsScreen> {
   Widget _buildDappCard(
     BuildContext context,
     DappItem dapp,
+    bool dappsLive,
   ) {
-    final statsAsync = ref.watch(dappStatsProvider);
-    final stats = statsAsync.valueOrNull?[dapp.pubkey];
+    final DappStats? stats = dappsLive
+        ? (ref.watch(dappStatsProvider).valueOrNull?[dapp.pubkey])
+        : null;
     return DappCard(
       name: dapp.name,
       author: dapp.author,
       description: dapp.description ?? DappCard.kDefaultDescription,
       users: stats?.users,
       txns: stats?.txns,
-      onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => DappWebViewScreen(
-              url: dapp.url,
-              name: dapp.name,
-            ),
-          ),
-        );
-      },
+      enabled: dappsLive,
+      disabledLabel: dappsLive ? null : 'Coming',
+      onTap: dappsLive
+          ? () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => DappWebViewScreen(
+                    url: dapp.url,
+                    name: dapp.name,
+                  ),
+                ),
+              );
+            }
+          : null,
     );
   }
 }
@@ -171,10 +186,12 @@ class _DappsHeader extends StatelessWidget {
   const _DappsHeader({
     required this.count,
     required this.statsAsync,
+    required this.dappsLive,
   });
 
   final int? count;
-  final AsyncValue<Map<String, DappStats>> statsAsync;
+  final AsyncValue<Map<String, DappStats>>? statsAsync;
+  final bool dappsLive;
 
   @override
   Widget build(BuildContext context) {
@@ -184,9 +201,13 @@ class _DappsHeader extends StatelessWidget {
 
     final countValue = count != null ? '$count' : '\u2014';
 
+    if (!dappsLive) {
+      return _StatPair(value: countValue, label: 'dApps Coming');
+    }
+
     String txnValue;
-    if (statsAsync.hasValue) {
-      final stats = statsAsync.requireValue;
+    if (statsAsync != null && statsAsync!.hasValue) {
+      final stats = statsAsync!.requireValue;
       var totalTxns = 0;
       for (final s in stats.values) {
         totalTxns += s.txns;
@@ -253,10 +274,12 @@ class _SortBar extends StatelessWidget {
   const _SortBar({
     required this.sortMode,
     required this.onSortChanged,
+    this.enabled = true,
   });
 
   final SortMode sortMode;
   final ValueChanged<SortMode> onSortChanged;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -270,6 +293,7 @@ class _SortBar extends StatelessWidget {
           Text('dApps', style: theme.textTheme.titleMedium),
           DropdownChip(
             label: _sortLabels[sortMode]!,
+            enabled: enabled,
             onTap: () async {
               final labels = _sortLabels.values.toList();
               final modes = _sortLabels.keys.toList();

--- a/lib/features/dapps/providers/dapps_challenge_provider.dart
+++ b/lib/features/dapps/providers/dapps_challenge_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:crypto_mobile_app/core/models/leaderboard_api_models.dart';
+import 'package:crypto_mobile_app/core/providers/challenges_provider.dart';
+import 'package:crypto_mobile_app/features/challenges/challenge_mappers.dart';
+
+/// Resolves the [ChallengeDto] for the dApps challenge by subCategory.
+final dappsChallengeProvider = Provider<ChallengeDto?>((ref) {
+  final challenges = ref.watch(challengesProvider.select((s) => s.value?.data));
+  if (challenges == null) return null;
+  for (final c in challenges) {
+    if (isDappsChallenge(c)) return c;
+  }
+  return null;
+});
+
+/// Whether dApps live functionality is enabled.
+///
+/// True when the dApps challenge exists and is enabled.
+final dappsLiveProvider = Provider<bool>((ref) {
+  final challenge = ref.watch(dappsChallengeProvider);
+  return challenge != null && challenge.enabled;
+});

--- a/test/features/dapps/providers/dapps_challenge_provider_test.dart
+++ b/test/features/dapps/providers/dapps_challenge_provider_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:crypto_mobile_app/core/models/leaderboard_api_models.dart';
+import 'package:crypto_mobile_app/core/providers/challenges_provider.dart';
+import 'package:crypto_mobile_app/core/utils/leaderboard_cache.dart';
+import 'package:crypto_mobile_app/features/challenges/challenge_mappers.dart';
+import 'package:crypto_mobile_app/features/dapps/providers/dapps_challenge_provider.dart';
+
+ChallengeDto _makeDto({
+  int id = 1,
+  bool enabled = true,
+  bool completed = false,
+  String? subCategory,
+}) {
+  return ChallengeDto(
+    id: id,
+    category: 'technical',
+    goal: 'Goal',
+    task: 'Task',
+    reward: '1000',
+    enabled: enabled,
+    completed: completed,
+    subCategory: subCategory,
+  );
+}
+
+ProviderContainer _container({
+  AsyncValue<CachedData<List<ChallengeDto>>?> challengesState =
+      const AsyncData(null),
+}) {
+  return ProviderContainer(
+    overrides: [
+      challengesProvider.overrideWith(() {
+        final controller = _StubChallengesController(challengesState);
+        return controller;
+      }),
+    ],
+  );
+}
+
+class _StubChallengesController
+    extends AsyncNotifier<CachedData<List<ChallengeDto>>?>
+    implements ChallengesController {
+  _StubChallengesController(this._state);
+
+  final AsyncValue<CachedData<List<ChallengeDto>>?> _state;
+
+  @override
+  Future<CachedData<List<ChallengeDto>>?> build() async {
+    state = _state;
+    return _state.value;
+  }
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  Future<void> silentRefresh() async {}
+}
+
+void main() {
+  group('dappsLiveProvider', () {
+    test('returns false when challenges are null', () {
+      final container = _container();
+      addTearDown(container.dispose);
+
+      expect(container.read(dappsLiveProvider), isFalse);
+    });
+
+    test('returns false when no matching challenge', () {
+      final container = _container(
+        challengesState: AsyncData(CachedData(
+          data: [_makeDto(subCategory: 'OTHER')],
+          isCached: false,
+        )),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(dappsLiveProvider), isFalse);
+    });
+
+    test('returns false when matching challenge is disabled', () {
+      final container = _container(
+        challengesState: AsyncData(CachedData(
+          data: [_makeDto(subCategory: kDappsSubCategory, enabled: false)],
+          isCached: false,
+        )),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(dappsLiveProvider), isFalse);
+    });
+
+    test('returns true when matching challenge is enabled', () {
+      final container = _container(
+        challengesState: AsyncData(CachedData(
+          data: [_makeDto(subCategory: kDappsSubCategory, enabled: true)],
+          isCached: false,
+        )),
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(dappsLiveProvider), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `dappsLiveProvider` that watches the leaderboard challenges for the dApps challenge gate — dApps are "not live" until the challenge is enabled
- **Header**: shows "N dApps Coming" (mono font) when not live instead of the stats divider + transaction count
- **Cards**: display a neutral `StatusBadge("Coming")` in the bottom row when disabled, via a new `disabledLabel` parameter on `DappCard`
- **Sort**: locked to alphabetical when not live; `DropdownChip` disabled
- **Efficiency**: stats provider is not watched/fetched when dApps aren't live (including pull-to-refresh)

## Test plan
- [x] `flutter analyze` — zero issues
- [x] `flutter test test/features/dapps/` — 4/4 pass (challenge provider unit tests)
- [x] `dart format` — clean
- [ ] Widgetbook: toggle `Enabled` knob on DappCard — disabled shows "Coming" badge, enabled shows stats + arrow
- [ ] Manual: verify header shows "N dApps Coming" when challenge inactive, "N dApps | M transactions" when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)