### PR TITLE
fix(registration): convert hex keys to bech32m before Rust FFI import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ gmp.md
 
 # Design system research archive (local only)
 lib/design_system/.archive/
+
+# Discord archive (local only)
+.discord-archive/

--- a/lib/core/providers/accounts_provider.dart
+++ b/lib/core/providers/accounts_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' show min;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -135,8 +136,13 @@ class AccountsRepository {
       _log.trace('importFromSecretKey - success (account id: ${result.id})');
       return result;
     } catch (e, stackTrace) {
-      _log.error('importFromSecretKey - FAILED with exception',
-          error: e, stackTrace: stackTrace);
+      _log.error(
+        'importFromSecretKey - FAILED '
+        '(key len: ${secretKey.length}, '
+        'prefix: ${secretKey.substring(0, min(6, secretKey.length))})',
+        error: e,
+        stackTrace: stackTrace,
+      );
       return null;
     }
   }

--- a/lib/features/onboarding/data/repositories/registration_repository.dart
+++ b/lib/features/onboarding/data/repositories/registration_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/providers/leaderboard_participant_provider.dart';
@@ -186,17 +187,26 @@ class RegistrationResult {
     final participantId = parseInt(json['participant_id'] ?? json['id']) ??
         (throw const FormatException('Missing participant_id'));
 
+    final rawSecretKey = requiredString(['secret_key', 'secret_key_hex']);
+    final rawPublicKey = requiredString(['public_key', 'public_key_hex']);
+    final rawAddress = requiredString([
+      'address',
+      'public_key_hash_bech32m',
+      'public_key_hash',
+    ]);
+
+    // Convert hex keys to bech32m if needed — Rust FFI expects bech32m encoding.
+    final secretKey = _ensureBech32m(rawSecretKey, 'utsk');
+    final publicKey = _ensureBech32m(rawPublicKey, 'utpk');
+    final address = _ensureBech32m(rawAddress, 'ut');
+
     return RegistrationResult(
       participantId: participantId,
       identityUid: requiredString(['identity_uid', 'identity_uid_hex']),
-      publicKey: requiredString(['public_key', 'public_key_hex']),
-      address: requiredString([
-        'address',
-        'public_key_hash_bech32m',
-        'public_key_hash',
-      ]),
+      publicKey: publicKey,
+      address: address,
       tier: json['tier'] as String,
-      secretKey: requiredString(['secret_key', 'secret_key_hex']),
+      secretKey: secretKey,
       eventId: event is Map<String, dynamic>
           ? parseInt(event['event_id'] ?? event['id'])
           : null,
@@ -205,5 +215,108 @@ class RegistrationResult {
       eventEndsAt:
           event is Map<String, dynamic> ? event['ends_at'] as String? : null,
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bech32m encoding helpers (BIP350)
+  // ---------------------------------------------------------------------------
+
+  static const _bech32mConst = 0x2bc830a3;
+  static const _charset = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+  static final _hexRegExp = RegExp(r'^[0-9a-fA-F]+$');
+
+  /// Returns [key] as-is if it already looks like bech32m (starts with [hrp]1).
+  /// If it looks like hex, encodes it as bech32m with the given [hrp].
+  static String _ensureBech32m(String key, String hrp) {
+    if (key.startsWith('${hrp}1')) return key;
+    // Only convert even-length hex strings
+    if (key.length.isEven && _hexRegExp.hasMatch(key)) {
+      _log.debug(
+        'Converting hex key to bech32m '
+        '(len: ${key.length}, hrp: $hrp)',
+      );
+      return _bech32mEncode(hrp, _hexToBytes(key));
+    }
+    // Unknown format — return as-is, let downstream report the error.
+    return key;
+  }
+
+  static Uint8List _hexToBytes(String hex) {
+    final length = hex.length ~/ 2;
+    final bytes = Uint8List(length);
+    for (var i = 0; i < length; i++) {
+      bytes[i] = int.parse(hex.substring(i * 2, i * 2 + 2), radix: 16);
+    }
+    return bytes;
+  }
+
+  static List<int> _convertBits(
+    List<int> data,
+    int fromBits,
+    int toBits, {
+    bool pad = true,
+  }) {
+    var acc = 0;
+    var bits = 0;
+    final result = <int>[];
+    final maxV = (1 << toBits) - 1;
+    for (final value in data) {
+      acc = (acc << fromBits) | value;
+      bits += fromBits;
+      while (bits >= toBits) {
+        bits -= toBits;
+        result.add((acc >> bits) & maxV);
+      }
+    }
+    if (pad && bits > 0) {
+      result.add((acc << (toBits - bits)) & maxV);
+    }
+    return result;
+  }
+
+  static int _bech32Polymod(List<int> values) {
+    const gen = [
+      0x3b6a57b2,
+      0x26508e6d,
+      0x1ea119fa,
+      0x3d4233dd,
+      0x2a1462b3,
+    ];
+    var chk = 1;
+    for (final v in values) {
+      final top = chk >> 25;
+      chk = ((chk & 0x1ffffff) << 5) ^ v;
+      for (var i = 0; i < 5; i++) {
+        chk ^= ((top >> i) & 1) != 0 ? gen[i] : 0;
+      }
+    }
+    return chk;
+  }
+
+  static List<int> _hrpExpand(String hrp) {
+    final result = <int>[];
+    for (final c in hrp.codeUnits) {
+      result.add(c >> 5);
+    }
+    result.add(0);
+    for (final c in hrp.codeUnits) {
+      result.add(c & 31);
+    }
+    return result;
+  }
+
+  static List<int> _bech32mChecksum(String hrp, List<int> data) {
+    final values = _hrpExpand(hrp) + data + [0, 0, 0, 0, 0, 0];
+    final polymod = _bech32Polymod(values) ^ _bech32mConst;
+    return List.generate(6, (i) => (polymod >> (5 * (5 - i))) & 31);
+  }
+
+  static String _bech32mEncode(String hrp, Uint8List data) {
+    final converted = _convertBits(data, 8, 5);
+    final checksum = _bech32mChecksum(hrp, converted);
+    final encoded =
+        (converted + checksum).map((d) => _charset[d]).join();
+    return '${hrp}1$encoded';
   }
 }

--- a/test/features/onboarding/data/registration_repository_test.dart
+++ b/test/features/onboarding/data/registration_repository_test.dart
@@ -64,6 +64,91 @@ void main() {
     });
   });
 
+  group('RegistrationResult hex-to-bech32m conversion', () {
+    test('converts 64-char hex secret key to bech32m', () {
+      final result = RegistrationResult.fromJson({
+        'participant_id': 1,
+        'identity_uid': 'uid-1',
+        'public_key': 'utpk1already',
+        'secret_key_hex':
+            'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+        'address': 'ut1already',
+        'tier': 'gold',
+      });
+
+      expect(result.secretKey, startsWith('utsk1'));
+      expect(result.secretKey, isNot(contains('abcdef')));
+      // 32 bytes → 52 five-bit groups + 6 checksum + 'utsk1' = 63 chars
+      expect(result.secretKey.length, 63);
+    });
+
+    test('passes through bech32m secret key unchanged', () {
+      final result = RegistrationResult.fromJson({
+        'participant_id': 1,
+        'identity_uid': 'uid-1',
+        'public_key': 'utpk1abc',
+        'secret_key': 'utsk1somevalidbech32mdata',
+        'address': 'ut1someaddr',
+        'tier': 'gold',
+      });
+
+      expect(result.secretKey, 'utsk1somevalidbech32mdata');
+    });
+
+    test('passes through non-hex key unchanged', () {
+      final result = RegistrationResult.fromJson({
+        'participant_id': 1,
+        'identity_uid': 'uid-1',
+        'public_key': '0xNotHex!',
+        'secret_key': '0xAlsoNotHex!',
+        'address': '0xAddr!',
+        'tier': 'gold',
+      });
+
+      expect(result.secretKey, '0xAlsoNotHex!');
+      expect(result.publicKey, '0xNotHex!');
+    });
+
+    test('converts hex public key and address', () {
+      final hex32 =
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+      final result = RegistrationResult.fromJson({
+        'participant_id': 1,
+        'identity_uid': 'uid-1',
+        'public_key_hex': hex32,
+        'secret_key': 'utsk1passthrough',
+        'public_key_hash': 'aabbccdd' * 5, // 40-char hex (20 bytes)
+        'tier': 'gold',
+      });
+
+      expect(result.publicKey, startsWith('utpk1'));
+      expect(result.address, startsWith('ut1'));
+    });
+
+    test('produces consistent encoding for same input', () {
+      final hex =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      final r1 = RegistrationResult.fromJson({
+        'participant_id': 1,
+        'identity_uid': 'uid',
+        'public_key': 'utpk1x',
+        'secret_key_hex': hex,
+        'address': 'ut1x',
+        'tier': 'gold',
+      });
+      final r2 = RegistrationResult.fromJson({
+        'participant_id': 2,
+        'identity_uid': 'uid',
+        'public_key': 'utpk1x',
+        'secret_key_hex': hex,
+        'address': 'ut1x',
+        'tier': 'gold',
+      });
+
+      expect(r1.secretKey, r2.secretKey);
+    });
+  });
+
   group('RegistrationRepository.register', () {
     setUp(() {
       SharedPreferences.setMockInitialValues({});


### PR DESCRIPTION
## Summary

- Fixes "Failed to import account from API" (#332) caused by hex-format secret keys rejected by the Rust FFI `accountFromPrivateKey()`, which only accepts bech32m
- Adds an inline BIP350 bech32m encoder in `RegistrationResult.fromJson()` that auto-detects hex keys and converts them with the correct HRP (`utsk`/`utpk`/`ut`)
- Improves error logging in `importFromSecretKey` with key length and prefix for diagnostics (never logs the full key)

## Context: Leaderboard V2 Migration

This bug is a direct consequence of the v1 → v2 leaderboard API migration:

1. **Registration endpoint moved** from `topo.usernodelabs.org/api/v1/register` to `leaderboard.usernodelabs.org/api/v2/mobile/register` (commit `bab26bb3`)
2. **Backend field renames**: `secret_key_hex` column was renamed to `secret_key` without converting existing data — older import batches still contain raw hex, while newer batches use bech32m
3. **v2 API model renames** (`phase` → `event`, `entries` → `leaderboard`, etc.) were handled in commit `5e5e3b8e`, but the key format mismatch was missed
4. **Only some users affected**: those whose accounts were imported during early batches (hex format) vs. later batches (bech32m) — explaining the intermittent reports

The fix normalizes keys at the parsing boundary (`fromJson`) so downstream code always receives bech32m regardless of what the backend returns.

## Changes

| File | Change |
|------|--------|
| `lib/features/onboarding/data/repositories/registration_repository.dart` | BIP350 bech32m encoder (~80 lines), hex detection + conversion in `fromJson()` |
| `lib/core/providers/accounts_provider.dart` | Diagnostic logging with key length/prefix in catch block |
| `test/.../registration_repository_test.dart` | 5 new tests: hex conversion, bech32m passthrough, non-hex passthrough, multi-field conversion, determinism |

## Test plan

- [x] All 9 existing + new tests pass (`flutter test test/features/onboarding/data/registration_repository_test.dart`)
- [x] `flutter analyze` clean on both modified files
- [ ] Manual test: register with an account known to have hex keys in the backend
- [ ] Verify Sentry logs show the new diagnostic format on any future failures

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)