### PR TITLE
fix(leaderboard): handle extra points in breakdown and display

### DIFF
--- a/lib/core/models/leaderboard_api_models.dart
+++ b/lib/core/models/leaderboard_api_models.dart
@@ -521,12 +521,15 @@ class LeaderboardResult {
 // ---------------------------------------------------------------------------
 
 class BreakdownActivity {
-  final int id;
+  /// Activity ID. Regular activities have numeric IDs; extra-point activities
+  /// use string IDs like `"extra-point-123"`.
+  final String id;
   final String activityType;
   final int points;
   final String? description;
   final String? activityAt;
   final int? challengeId;
+  final String? activitySubCategory;
 
   const BreakdownActivity({
     required this.id,
@@ -535,16 +538,18 @@ class BreakdownActivity {
     this.description,
     this.activityAt,
     this.challengeId,
+    this.activitySubCategory,
   });
 
   factory BreakdownActivity.fromJson(Map<String, dynamic> json) {
     return BreakdownActivity(
-      id: _jsonInt(json['activity_id'] ?? json['id']),
+      id: (json['activity_id'] ?? json['id'] ?? '').toString(),
       activityType: json['activity_type'] as String? ?? '',
       points: _jsonInt(json['points']),
       description: json['description'] as String?,
       activityAt: json['activity_at'] as String?,
       challengeId: _jsonIntN(json['challenge_id']),
+      activitySubCategory: json['activity_sub_category'] as String?,
     );
   }
 
@@ -556,6 +561,8 @@ class BreakdownActivity {
         if (description != null) 'description': description,
         if (activityAt != null) 'activity_at': activityAt,
         if (challengeId != null) 'challenge_id': challengeId,
+        if (activitySubCategory != null)
+          'activity_sub_category': activitySubCategory,
       };
 }
 

--- a/lib/design_system/src/challenge_reward_card.dart
+++ b/lib/design_system/src/challenge_reward_card.dart
@@ -34,6 +34,7 @@ class ProduceBlocksRewardData extends ChallengeRewardData {
     this.rankLabel,
     required this.rankReward,
     this.rateLabel = 'SUCCESS RATE',
+    this.extraPoints,
   });
 
   /// Progress bar fill fraction, 0.0–1.0.
@@ -57,6 +58,10 @@ class ProduceBlocksRewardData extends ChallengeRewardData {
   /// Label for the rate row, e.g. "BLOCK RATE" mid-event or "SUCCESS RATE"
   /// when the event is completed.
   final String rateLabel;
+
+  /// Formatted extra points from manual adjustments, e.g. "+840".
+  /// When null the extra points row is hidden.
+  final String? extraPoints;
 }
 
 // ---------------------------------------------------------------------------
@@ -181,6 +186,7 @@ class ChallengeRewardCard extends StatelessWidget {
                       :final rankLabel,
                       :final rankReward,
                       :final rateLabel,
+                    :final extraPoints,
                     )) ...[
                   SizedBox(height: spacing.space24),
                   // Progress bar
@@ -245,6 +251,27 @@ class ChallengeRewardCard extends StatelessWidget {
                       ),
                     ],
                   ),
+                  // Extra points row (manual adjustments)
+                  if (extraPoints != null) ...[
+                    SizedBox(height: spacing.space12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          'EXTRA POINTS',
+                          style: textTheme.labelSmall
+                              ?.copyWith(color: dimOnColor),
+                        ),
+                        Text(
+                          extraPoints,
+                          style: textTheme.bodyMedium?.copyWith(
+                            fontFamily: kMonoFontFamily,
+                            color: onColor,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                 ],
               ],
             ),

--- a/lib/design_system/widgetbook/challenge_reward_card_use_case.dart
+++ b/lib/design_system/widgetbook/challenge_reward_card_use_case.dart
@@ -57,6 +57,10 @@ WidgetbookComponent challengeRewardCardComponent() {
             min: 0,
             max: 1,
           );
+          final extraPoints = context.knobs.stringOrNull(
+            label: 'Extra Points',
+            initialValue: '+840',
+          );
 
           return Center(
             child: Padding(
@@ -74,6 +78,7 @@ WidgetbookComponent challengeRewardCardComponent() {
                     rankLabel: '1st',
                     rankReward: '+500',
                     rateLabel: 'BLOCK RATE',
+                    extraPoints: extraPoints,
                   ),
                   epochSectionLabel: 'This Epoch Earned',
                   epochEarned: '+50',

--- a/lib/features/challenges/challenge_mappers.dart
+++ b/lib/features/challenges/challenge_mappers.dart
@@ -95,13 +95,25 @@ class EnrichedChallenge {
   final ChallengeDto dto;
   final BreakdownActivity? activity;
 
-  const EnrichedChallenge({required this.dto, this.activity});
+  /// Extra points from manual adjustments for this challenge.
+  final int extraPoints;
+
+  const EnrichedChallenge({
+    required this.dto,
+    this.activity,
+    this.extraPoints = 0,
+  });
 
   /// Whether the participant completed this challenge (has a matching activity).
   bool get participantCompleted => activity != null;
 
-  /// Actual points earned by the participant, or null if not completed.
-  int? get earnedPoints => activity?.points;
+  /// Actual points earned by the participant (including extra points),
+  /// or null if not completed.
+  int? get earnedPoints {
+    final base = activity?.points;
+    if (base == null && extraPoints == 0) return null;
+    return (base ?? 0) + extraPoints;
+  }
 }
 
 /// Cross-references challenges with breakdown activities.
@@ -109,6 +121,10 @@ class EnrichedChallenge {
 /// Prefers matching by [BreakdownActivity.challengeId] → [ChallengeDto.id].
 /// Falls back to [BreakdownActivity.description] → [ChallengeDto.goal] when
 /// `challengeId` is null (older cached data).
+///
+/// When multiple activities share the same [challengeId] (e.g. regular epoch
+/// activities plus extra-point activities for produce-blocks), the primary
+/// (non-extra-point) activity is preferred.
 ///
 /// When [activities] is null (breakdown unavailable), wraps all challenges
 /// with `activity: null` for graceful v1-style fallback.
@@ -120,10 +136,12 @@ List<EnrichedChallenge> enrichChallenges(
     return challenges.map((dto) => EnrichedChallenge(dto: dto)).toList();
   }
 
-  final byId = <int, BreakdownActivity>{};
+  final byId = <int, List<BreakdownActivity>>{};
   final byDesc = <String, BreakdownActivity>{};
   for (final a in activities) {
-    if (a.challengeId != null) byId[a.challengeId!] = a;
+    if (a.challengeId != null) {
+      byId.putIfAbsent(a.challengeId!, () => []).add(a);
+    }
     if (a.description != null) byDesc[a.description!] = a;
   }
 
@@ -133,9 +151,32 @@ List<EnrichedChallenge> enrichChallenges(
             // TODO(challenges): Remove description fallback once all breakdown
             // activities include challengeId. The assumption that
             // description == goal is a reliable match is fragile.
-            activity: byId[dto.id] ?? byDesc[dto.goal],
+            activity: _primaryActivity(byId[dto.id]) ?? byDesc[dto.goal],
+            extraPoints: _sumExtraPoints(byId[dto.id]),
           ))
       .toList();
+}
+
+/// Picks the primary activity from a list sharing the same [challengeId].
+///
+/// Prefers non-extra-point activities (regular epoch evaluations) over
+/// extra-point entries so that [EnrichedChallenge.activity] reflects the
+/// base reward. Extra points are summed separately via [_sumExtraPoints].
+BreakdownActivity? _primaryActivity(List<BreakdownActivity>? list) {
+  if (list == null || list.isEmpty) return null;
+  if (list.length == 1 && !list.first.id.startsWith('extra-point-')) {
+    return list.first;
+  }
+  final primary = list.where((a) => !a.id.startsWith(kExtraPointIdPrefix));
+  return primary.isNotEmpty ? primary.first : null;
+}
+
+/// Sums points from extra-point activities in [list].
+int _sumExtraPoints(List<BreakdownActivity>? list) {
+  if (list == null || list.isEmpty) return 0;
+  return list
+      .where((a) => a.id.startsWith(kExtraPointIdPrefix))
+      .fold<int>(0, (sum, a) => sum + a.points);
 }
 
 /// Result of categorizing enriched challenges into tab buckets.
@@ -310,6 +351,10 @@ String formatDiffLabel(Duration since) {
 
 /// The subcategory value that identifies produce-blocks challenges.
 const String kProduceBlocksSubCategory = 'PRODUCE_BLOCKS_CHALLENGE';
+
+/// ID prefix for extra-point activities returned by the backend, e.g.
+/// `"extra-point-42"`.
+const String kExtraPointIdPrefix = 'extra-point-';
 
 /// Points reserved for top-3 rank bonus in the reward ceiling.
 ///

--- a/lib/features/challenges/screens/challenge_detail_screen.dart
+++ b/lib/features/challenges/screens/challenge_detail_screen.dart
@@ -135,19 +135,25 @@ class ChallengeDetailScreen extends ConsumerWidget {
         : null;
     final maxPts = ceiling != null ? ceiling - kTop3RankBonusPoints : 0;
 
-    // Use API-provided earned points directly (breakdown with include_activity=1).
+    // earnedPoints includes extra points; base is the success-rate calculation only.
     final earnedPoints = challenge.earnedPoints;
+    final basePoints = challenge.activity?.points;
+    final extraPointsTotal = challenge.extraPoints;
     final isSyncing = isProduceBlocksSyncing(
       isProduceBlocks: isProduceBlocks,
-      earnedPoints: earnedPoints,
+      earnedPoints: basePoints,
       successRate: successRate,
     );
-    // Only subscribe to the 500ms ticker when actually syncing.
-    final displayPoints = isSyncing
+    final syncingText = isSyncing
         ? ref.watch(syncingTextProvider).value ?? kSyncingTextFallback
-        : earnedPoints != null
-            ? formatPoints(earnedPoints)
-            : '--';
+        : null;
+    // Calculation row shows base points (success rate × max pts).
+    final displayBasePoints =
+        syncingText ?? (basePoints != null ? formatPoints(basePoints) : '--');
+    // Total earned includes base + extra + top3.
+    final totalWithTop3 = (earnedPoints ?? 0) + (eb?.top3Points ?? 0);
+    final displayTotalEarned = syncingText ??
+        (earnedPoints != null ? formatPoints(totalWithTop3) : '--');
 
     // Epoch section: only for produce-blocks challenges.
     final String? epochEarned;
@@ -156,7 +162,7 @@ class ChallengeDetailScreen extends ConsumerWidget {
       if (diff != null) {
         epochEarned = '+${formatPoints(diff.points)}';
         epochSectionLabel = formatDiffLabel(diff.since);
-      } else if (challenge.earnedPoints != null || successRate > 0) {
+      } else if (earnedPoints != null || successRate > 0) {
         epochEarned = AppLocalizations.of(context).challengeEpochNoChange;
         epochSectionLabel = AppLocalizations.of(context).challengeEpochLast24h;
       } else {
@@ -174,10 +180,13 @@ class ChallengeDetailScreen extends ConsumerWidget {
         progressFraction: successRate / 100.0,
         successRate: '${successRate.round()}%',
         maxPoints: formatPoints(maxPts),
-        totalPoints: displayPoints,
+        totalPoints: displayBasePoints,
         rankLabel: formatRankOrdinal(eb?.rank),
         rankReward: '+${formatPoints(eb?.top3Points ?? 0)}',
         rateLabel: dto.completed ? 'SUCCESS RATE' : 'BLOCK RATE',
+        extraPoints: extraPointsTotal > 0
+            ? '+${formatPoints(extraPointsTotal)}'
+            : null,
       );
     } else {
       data = const SimpleRewardData();
@@ -185,7 +194,7 @@ class ChallengeDetailScreen extends ConsumerWidget {
 
     return ChallengeRewardCard(
       category: category,
-      totalEarned: displayPoints,
+      totalEarned: isProduceBlocks ? displayTotalEarned : displayBasePoints,
       data: data,
       epochSectionLabel: epochSectionLabel,
       epochEarned: epochEarned,

--- a/test/core/models/leaderboard_api_models_test.dart
+++ b/test/core/models/leaderboard_api_models_test.dart
@@ -595,7 +595,7 @@ void main() {
         'activity_at': '2025-01-15T10:00:00Z',
         'challenge_id': 7,
       });
-      expect(a.id, 1);
+      expect(a.id, '1');
       expect(a.activityType, 'block_produced');
       expect(a.points, 50);
       expect(a.description, 'Produced block #123');
@@ -609,7 +609,24 @@ void main() {
         'activity_type': 'bonus',
         'points': 10,
       });
-      expect(a.id, 2);
+      expect(a.id, '2');
+    });
+
+    test('fromJson parses string activity_id (extra points)', () {
+      final a = BreakdownActivity.fromJson({
+        'activity_id': 'extra-point-42',
+        'activity_type': 'technical',
+        'points': 125,
+        'description': 'Manual recovery bonus',
+        'activity_at': '2026-03-27T14:00:00Z',
+        'challenge_id': 7,
+        'activity_sub_category': 'PRODUCE_BLOCKS_CHALLENGE',
+      });
+      expect(a.id, 'extra-point-42');
+      expect(a.activityType, 'technical');
+      expect(a.points, 125);
+      expect(a.challengeId, 7);
+      expect(a.activitySubCategory, 'PRODUCE_BLOCKS_CHALLENGE');
     });
 
     test('fromJson handles nullable fields', () {
@@ -621,6 +638,7 @@ void main() {
       expect(a.description, isNull);
       expect(a.activityAt, isNull);
       expect(a.challengeId, isNull);
+      expect(a.activitySubCategory, isNull);
     });
   });
 
@@ -1011,6 +1029,7 @@ void main() {
         'description': 'Produced block #123',
         'activity_at': '2025-01-15T10:00:00Z',
         'challenge_id': 7,
+        'activity_sub_category': 'PRODUCE_BLOCKS_CHALLENGE',
       };
       final a = BreakdownActivity.fromJson(json);
       final a2 = BreakdownActivity.fromJson(a.toJson());
@@ -1020,6 +1039,23 @@ void main() {
       expect(a2.description, a.description);
       expect(a2.activityAt, a.activityAt);
       expect(a2.challengeId, a.challengeId);
+      expect(a2.activitySubCategory, a.activitySubCategory);
+    });
+
+    test('BreakdownActivity round-trip with string id (extra points)', () {
+      final json = {
+        'activity_id': 'extra-point-42',
+        'activity_type': 'technical',
+        'points': 125,
+        'description': 'Manual recovery bonus',
+        'challenge_id': 7,
+        'activity_sub_category': 'PRODUCE_BLOCKS_CHALLENGE',
+      };
+      final a = BreakdownActivity.fromJson(json);
+      final a2 = BreakdownActivity.fromJson(a.toJson());
+      expect(a2.id, 'extra-point-42');
+      expect(a2.points, 125);
+      expect(a2.challengeId, 7);
     });
 
     test('EventBreakdown', () {

--- a/test/core/providers/categorized_challenges_provider_test.dart
+++ b/test/core/providers/categorized_challenges_provider_test.dart
@@ -85,7 +85,7 @@ const _breakdown = BreakdownResult(
     offchainPoints: 0,
     activities: [
       BreakdownActivity(
-        id: 100,
+        id: '100',
         activityType: 'COMMUNITY',
         points: 1000,
         description: 'Prove Humanity',

--- a/test/design_system/challenge_reward_card_test.dart
+++ b/test/design_system/challenge_reward_card_test.dart
@@ -190,6 +190,38 @@ void main() {
       expect(find.text('3rd'), findsNothing);
     });
 
+    testWidgets('renders extra points row when provided', (tester) async {
+      await tester.pumpWidget(wrap(
+        const ChallengeRewardCard(
+          category: ChallengeCategory.technical,
+          totalEarned: '5,025',
+          data: ProduceBlocksRewardData(
+            progressFraction: 0.98,
+            successRate: '98%',
+            maxPoints: '5,000',
+            totalPoints: '4,900',
+            rankReward: '+0',
+            extraPoints: '+840',
+          ),
+        ),
+      ));
+
+      expect(find.text('EXTRA POINTS'), findsOneWidget);
+      expect(find.text('+840'), findsOneWidget);
+    });
+
+    testWidgets('hides extra points row when null', (tester) async {
+      await tester.pumpWidget(wrap(
+        const ChallengeRewardCard(
+          category: ChallengeCategory.technical,
+          totalEarned: '4,900',
+          data: produceBlocksData,
+        ),
+      ));
+
+      expect(find.text('EXTRA POINTS'), findsNothing);
+    });
+
     testWidgets('uses custom rateLabel when provided', (tester) async {
       await tester.pumpWidget(wrap(
         const ChallengeRewardCard(

--- a/test/features/challenges/challenge_mappers_test.dart
+++ b/test/features/challenges/challenge_mappers_test.dart
@@ -30,7 +30,7 @@ ChallengeDto _makeDto({
 }
 
 BreakdownActivity _makeActivity({
-  int id = 1,
+  String id = '1',
   int points = 100,
   String? description,
   int? challengeId,
@@ -173,12 +173,12 @@ void main() {
       ];
       final activities = [
         _makeActivity(
-            id: 10,
+            id: '10',
             challengeId: 1,
             description: 'Produce Every Block',
             points: 6491),
         _makeActivity(
-            id: 11,
+            id: '11',
             challengeId: 3,
             description: 'Feedback Survey',
             points: 500),
@@ -200,7 +200,8 @@ void main() {
         _makeDto(id: 2, goal: 'Report a Bug'),
       ];
       final activities = [
-        _makeActivity(id: 10, description: 'Produce Every Block', points: 6491),
+        _makeActivity(
+            id: '10', description: 'Produce Every Block', points: 6491),
       ];
 
       final enriched = enrichChallenges(challenges, activities);
@@ -216,12 +217,61 @@ void main() {
       // Activity has challengeId=1 but description doesn't match goal
       final activities = [
         _makeActivity(
-            id: 10, challengeId: 1, description: 'Different Desc', points: 999),
+            id: '10',
+            challengeId: 1,
+            description: 'Different Desc',
+            points: 999),
       ];
 
       final enriched = enrichChallenges(challenges, activities);
       expect(enriched[0].participantCompleted, isTrue);
       expect(enriched[0].earnedPoints, 999);
+    });
+
+    test('prefers primary activity over extra-point when both share challengeId',
+        () {
+      final challenges = [
+        _makeDto(
+            id: 1,
+            goal: 'Produce Every Block',
+            subCategory: 'PRODUCE_BLOCKS_CHALLENGE'),
+      ];
+      final activities = [
+        _makeActivity(
+            id: '10', challengeId: 1, points: 4166), // regular epoch activity
+        _makeActivity(
+            id: 'extra-point-42',
+            challengeId: 1,
+            points: 125), // extra points
+      ];
+
+      final enriched = enrichChallenges(challenges, activities);
+      expect(enriched[0].participantCompleted, isTrue);
+      // Should pick the regular activity, not the extra-point one
+      expect(enriched[0].activity!.id, '10');
+      expect(enriched[0].activity!.points, 4166);
+      // earnedPoints includes extra points
+      expect(enriched[0].earnedPoints, 4291);
+      expect(enriched[0].extraPoints, 125);
+    });
+
+    test('uses extra points when no regular activity exists', () {
+      final challenges = [
+        _makeDto(
+            id: 1,
+            goal: 'Produce Every Block',
+            subCategory: 'PRODUCE_BLOCKS_CHALLENGE'),
+      ];
+      final activities = [
+        _makeActivity(
+            id: 'extra-point-42', challengeId: 1, points: 125),
+      ];
+
+      final enriched = enrichChallenges(challenges, activities);
+      // No primary activity, but extra points still contribute
+      expect(enriched[0].activity, isNull);
+      expect(enriched[0].extraPoints, 125);
+      expect(enriched[0].earnedPoints, 125);
     });
 
     test('null activities wraps all with activity: null', () {
@@ -236,7 +286,7 @@ void main() {
 
     test('activities without description or challengeId are skipped', () {
       final challenges = [_makeDto(id: 1, goal: 'Goal')];
-      final activities = [_makeActivity(id: 10, description: null)];
+      final activities = [_makeActivity(id: '10', description: null)];
 
       final enriched = enrichChallenges(challenges, activities);
       expect(enriched[0].participantCompleted, isFalse);
@@ -245,7 +295,7 @@ void main() {
     test('unmatched activities are ignored', () {
       final challenges = [_makeDto(id: 1, goal: 'Goal')];
       final activities = [
-        _makeActivity(id: 10, description: 'Something Else'),
+        _makeActivity(id: '10', description: 'Something Else'),
       ];
 
       final enriched = enrichChallenges(challenges, activities);

--- a/test/features/challenges/challenges_screen_test.dart
+++ b/test/features/challenges/challenges_screen_test.dart
@@ -269,7 +269,7 @@ void main() {
               offchainPoints: 0,
               activities: [
                 BreakdownActivity(
-                  id: 100,
+                  id: '100',
                   activityType: 'COMMUNITY',
                   points: 1000,
                   description: 'Prove Humanity',
@@ -414,7 +414,7 @@ void main() {
               offchainPoints: 0,
               activities: [
                 BreakdownActivity(
-                  id: 100,
+                  id: '100',
                   activityType: 'COMMUNITY',
                   points: 6491,
                   description: 'Prove Humanity',


### PR DESCRIPTION
## Summary

Parse backend `ActivityExtraPoint` entries (string IDs like `extra-point-123`) without crashing `BreakdownActivity.fromJson`. Display extra points in challenge cards, reward card breakdown, and category tile totals.

### Changes
- `BreakdownActivity.id`: `int` → `String` (handles both numeric and string IDs)
- `BreakdownActivity.activitySubCategory`: new optional field from API
- `EnrichedChallenge`: gains `extraPoints` field, `earnedPoints` getter includes them
- `ChallengeRewardCard`: new EXTRA POINTS row in produce-blocks breakdown
- Challenge cards/category tiles: earned points totals include extra points
- New `kExtraPointIdPrefix` constant

### Blocked on
- topochain#48 (backend `ActivityExtraPoint` API) must be merged and deployed first

## Test plan
- [x] `flutter analyze` — zero issues
- [x] All affected tests pass
- [x] String activity ID parsing (extra-point-42) tested
- [x] Multi-activity enrichment (primary vs extra-point) tested
- [x] Reward card extra points row render/hide tested

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)