### PR TITLE
Use systemExempted foreground service instead of dataSync when possible

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     
     <application
         android:label="@string/app_name"
@@ -99,7 +100,7 @@
             android:name=".alarm.SlotMonitoringService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="dataSync|systemExempted" />
 
     </application>
     <!-- Required to query activities that can process text, see:

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
@@ -82,6 +82,8 @@ class AlarmReceiver : BroadcastReceiver() {
             putExtra("slotNumber", slotNumber)
             putExtra("nodeRunning", nodeRunning)
             putExtra("alarmTimeMs", scheduledTimeMs)
+            // Exact alarms are the strongest match for systemExempted FGS.
+            putExtra(SlotMonitoringService.EXTRA_CONTINUE_EXACT_ALARM, true)
         }
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -128,6 +130,7 @@ class AlarmReceiver : BroadcastReceiver() {
             putExtra("alarmId", alarmId)
             putExtra("slotNumber", slotNumber)
             putExtra("nodeRunning", nodeRunning)
+            putExtra(SlotMonitoringService.EXTRA_CONTINUE_EXACT_ALARM, false)
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/ForegroundServiceManager.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/ForegroundServiceManager.kt
@@ -17,6 +17,7 @@ class ForegroundServiceManager(private val context: Context) {
                 putExtra("slotNumber", slotNumber)
                 putExtra("title", title)
                 putExtra("message", message)
+                putExtra(SlotMonitoringService.EXTRA_CONTINUE_EXACT_ALARM, false)
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
@@ -3,6 +3,7 @@ package com.usernode_labs.usernode.alarm
 import android.app.*
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
@@ -16,6 +17,7 @@ class SlotMonitoringService : Service() {
         const val ACTION_STOP_MONITORING = "com.usernode.app.STOP_MONITORING"
         const val ACTION_START_PERSISTENT = "com.usernode.app.START_PERSISTENT"
         const val ACTION_STOP_PERSISTENT = "com.usernode.app.STOP_PERSISTENT"
+        const val EXTRA_CONTINUE_EXACT_ALARM = "continueExactAlarm"
 
         private const val NOTIFICATION_ID = 1001
         private const val CHANNEL_ID = "slot_monitoring_channel"
@@ -82,11 +84,18 @@ class SlotMonitoringService : Service() {
                 val alarmId = intent.getStringExtra("alarmId")
                 val nodeRunning = intent.getBooleanExtra("nodeRunning", false)
                 val alarmTimeMs = intent.getLongExtra("alarmTimeMs", -1L)
+                val continueExactAlarm =
+                    intent.getBooleanExtra(EXTRA_CONTINUE_EXACT_ALARM, false)
                 Log.d(TAG, "[SlotMonitoringService] START_MONITORING - Slot: $slotNumber, AlarmId: $alarmId, nodeRunning=$nodeRunning")
 
                 // Allow alarmId-only wake (e.g., fg_resume) by using 0 as placeholder
                 val safeSlot = if (slotNumber != -1) slotNumber else 0
-                startMonitoring(safeSlot, nodeRunning, alarmTimeMs)
+                startMonitoring(
+                    slotNumber = safeSlot,
+                    nodeRunning = nodeRunning,
+                    alarmTimeMs = alarmTimeMs,
+                    continueExactAlarm = continueExactAlarm,
+                )
 
                 val eventData = mapOf(
                     "alarmId" to (alarmId ?: "unknown"),
@@ -131,7 +140,12 @@ class SlotMonitoringService : Service() {
         return START_STICKY
     }
 
-    private fun startMonitoring(slotNumber: Int, nodeRunning: Boolean, alarmTimeMs: Long = -1L) {
+    private fun startMonitoring(
+        slotNumber: Int,
+        nodeRunning: Boolean,
+        alarmTimeMs: Long = -1L,
+        continueExactAlarm: Boolean = false,
+    ) {
         currentSlotNumber = slotNumber
         Log.i(TAG, "[SlotMonitoringService] ✓ Starting foreground monitoring for slot $slotNumber")
 
@@ -153,7 +167,11 @@ class SlotMonitoringService : Service() {
         )
 
         try {
-            startForeground(NOTIFICATION_ID, notification)
+            startInForeground(
+                notification = notification,
+                continueExactAlarm = continueExactAlarm,
+                reason = "slot_monitoring",
+            )
             Log.d(TAG, "[SlotMonitoringService] Foreground service started with notification ID $NOTIFICATION_ID")
             isForegroundServiceActive = true
 
@@ -223,8 +241,13 @@ class SlotMonitoringService : Service() {
         )
 
         try {
-            startForeground(NOTIFICATION_ID, notification)
+            startInForeground(
+                notification = notification,
+                continueExactAlarm = false,
+                reason = "persistent_mode",
+            )
             Log.d(TAG, "[SlotMonitoringService] Persistent foreground service started with notification ID $NOTIFICATION_ID")
+            isForegroundServiceActive = true
 
             // Send event to Flutter
             Log.d(TAG, "[SlotMonitoringService] Sending android_persistent_foreground_started event to Flutter")
@@ -320,6 +343,48 @@ class SlotMonitoringService : Service() {
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .setOngoing(true)
             .build()
+    }
+
+    private fun startInForeground(
+        notification: Notification,
+        continueExactAlarm: Boolean,
+        reason: String,
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            startForeground(NOTIFICATION_ID, notification)
+            return
+        }
+
+        val preferredType = if (
+            continueExactAlarm &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        ) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED
+        } else {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+        }
+
+        try {
+            startForeground(NOTIFICATION_ID, notification, preferredType)
+        } catch (e: Exception) {
+            if (
+                preferredType == ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+            ) {
+                Log.w(
+                    TAG,
+                    "[SlotMonitoringService] systemExempted rejected for $reason; falling back to dataSync",
+                    e
+                )
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                )
+                return
+            }
+            throw e
+        }
     }
 
     fun updateNotification(title: String, message: String) {


### PR DESCRIPTION
**PR Summary**

This PR tightens how we classify the Android foreground service used for background block production. When the app is resumed by an exact slot alarm, `SlotMonitoringService` now requests `systemExempted`. For manual, persistent, boot, and other non-alarm starts, it continues using `dataSync`. If Android rejects `systemExempted` at runtime, the service falls back to `dataSync` so the app still comes up safely.

**Why `systemExempted`**

Our strongest Android background path is: exact alarm fires, app wakes, foreground service continues the alarm-driven work. That matches Android’s documented `systemExempted` case much better than `dataSync`. `dataSync` is meant for upload/download/import/export/fetch/file-processing work, which is not really what slot monitoring and block-production wakeup are doing.

Using `systemExempted` only for the exact-alarm continuation path gives us a narrower and more accurate declaration:
- Better semantic match to the actual alarm-driven execution model.
- More precise use of Android’s foreground-service type system instead of treating all starts as generic `dataSync`.
- Lower risk of over-claiming the type for manual or persistent starts, because those still stay on `dataSync`.
- Safe rollout, because we fall back to `dataSync` if the platform refuses `systemExempted`.

One additional likely benefit: Android 15 documents a six-hour background timeout for `dataSync` foreground services. `systemExempted` is not documented under that timeout bucket, so using it for the exact-alarm path may help avoid that specific limit. That part is an inference from the docs, not an explicit Android guarantee.

**Why not `specialUse`**

We did not use `specialUse` because Android positions it as the catch-all type for cases that are not covered by any predefined foreground-service type. Our alarm-driven wakeup flow already has a more specific candidate: `systemExempted`. So `specialUse` would be the weaker argument.

`specialUse` also adds extra justification overhead and is harder to defend, because we would be saying “no standard type fits” when Android already provides a type that plausibly matches exact-alarm continuation. In short, `systemExempted` is narrower, more specific, and easier to justify for this path.

**Validation**

`./gradlew app:compileDebugKotlin` passed.

**Sources**

- Android foreground service types: https://developer.android.com/develop/background-work/services/fgs/service-types
- Android 14 foreground service type requirements: https://developer.android.com/about/versions/14/changes/fgs-types-required
- Android foreground service time limits: https://developer.android.com/develop/background-work/services/fgs/timeout