### PR TITLE
fix: use valueOrNull on remaining AsyncValue accesses

### DIFF
--- a/lib/core/providers/epoch_rewards_provider.dart
+++ b/lib/core/providers/epoch_rewards_provider.dart
@@ -115,7 +115,7 @@ class EpochRewardsController extends AsyncNotifier<EpochRewardsState?> {
   Future<EpochRewardsState?> build() async {
     // Read status to get epoch value (use read, not watch, to avoid rebuilds on every status update)
     final statusAsync = ref.read(nodeStatusProvider);
-    final epoch = statusAsync.value?.epoch;
+    final epoch = statusAsync.valueOrNull?.epoch;
 
     // Step 1: Load cache immediately to show previous data (only on initial build)
     _log.debug('Loading cached epoch rewards...');
@@ -143,7 +143,7 @@ class EpochRewardsController extends AsyncNotifier<EpochRewardsState?> {
 
   Future<void> refresh() async {
     final statusAsync = ref.read(nodeStatusProvider);
-    final epoch = statusAsync.value?.epoch;
+    final epoch = statusAsync.valueOrNull?.epoch;
 
     if (epoch == null) {
       state = const AsyncData(null);

--- a/lib/core/widgets/app_drawer.dart
+++ b/lib/core/widgets/app_drawer.dart
@@ -260,7 +260,7 @@ class _AppDrawerState extends ConsumerState<AppDrawer> {
             const Divider(height: 16),
             Text(l10n.drawerP2pPeerId),
             SelectableText(
-              ref.watch(nodeStatusProvider).value?.peerId ??
+              ref.watch(nodeStatusProvider).valueOrNull?.peerId ??
                   l10n.nodeNotAvailable,
               style: const TextStyle(
                 fontFamily: kMonoFontFamily,

--- a/lib/features/challenges/screens/challenge_detail_screen.dart
+++ b/lib/features/challenges/screens/challenge_detail_screen.dart
@@ -150,7 +150,7 @@ class ChallengeDetailScreen extends ConsumerWidget {
       successRate: successRate,
     );
     final syncingText = isSyncing
-        ? ref.watch(syncingTextProvider).value ?? kSyncingTextFallback
+        ? ref.watch(syncingTextProvider).valueOrNull ?? kSyncingTextFallback
         : null;
     // Calculation row shows base points (success rate × max pts).
     final displayBasePoints =

--- a/lib/features/challenges/screens/challenges_screen.dart
+++ b/lib/features/challenges/screens/challenges_screen.dart
@@ -556,7 +556,7 @@ class _ChallengesScreenState extends ConsumerState<ChallengesScreen>
           : null,
       earnedPoints: variant == ChallengeCardVariant.ongoing
           ? isSyncing
-                ? ref.watch(syncingTextProvider).value ?? kSyncingTextFallback
+                ? ref.watch(syncingTextProvider).valueOrNull ?? kSyncingTextFallback
                 : effectiveEarned != null
                 ? formatEarnedPoints(effectiveEarned)
                 : null

--- a/lib/features/challenges/screens/epoch_performance_screen.dart
+++ b/lib/features/challenges/screens/epoch_performance_screen.dart
@@ -73,7 +73,7 @@ class _EpochPerformanceScreenState
   @override
   Widget build(BuildContext context) {
     final summary = ref.watch(producedBlocksSummaryProvider);
-    final nodeStatus = ref.watch(nodeStatusProvider).value;
+    final nodeStatus = ref.watch(nodeStatusProvider).valueOrNull;
     final l10n = AppLocalizations.of(context);
 
     final dataValue = summary.valueOrNull;

--- a/lib/features/leaderboard/screens/leaderboard_screen.dart
+++ b/lib/features/leaderboard/screens/leaderboard_screen.dart
@@ -65,7 +65,7 @@ class _LeaderboardScreenState extends ConsumerState<LeaderboardScreen> {
     final ranking = ref.watch(rankingProvider.select((s) => s.valueOrNull));
     final leaderboard = ref.watch(leaderboardProvider.select((s) => s.valueOrNull));
     final eventPoints = ref.watch(eventPointsProvider.select((s) => s.valueOrNull));
-    final participantId = ref.watch(participantIdProvider).value;
+    final participantId = ref.watch(participantIdProvider).valueOrNull;
     final categorized = ref.watch(categorizedChallengesProvider);
     ref.watch(seasonsProvider);
 

--- a/lib/features/node/screens/node_status_produced_blocks_screen.dart
+++ b/lib/features/node/screens/node_status_produced_blocks_screen.dart
@@ -94,9 +94,9 @@ class _NodeStatusProducedBlocksScreenState
     }
 
     final blockchainAsync = ref.watch(nodeBlockchainProvider);
-    final status = ref.watch(nodeStatusProvider).value;
+    final status = ref.watch(nodeStatusProvider).valueOrNull;
     final rewardsAsync = ref.watch(epochRewardsProvider);
-    final rewardPerBlock = rewardsAsync.value?.rewardPerBlock ?? BigInt.zero;
+    final rewardPerBlock = rewardsAsync.valueOrNull?.rewardPerBlock ?? BigInt.zero;
     final l10n = AppLocalizations.of(context);
 
     return Scaffold(

--- a/lib/features/node/screens/node_status_screen.dart
+++ b/lib/features/node/screens/node_status_screen.dart
@@ -183,7 +183,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
 
       if (!mounted) return;
 
-      final status = ref.read(nodeStatusProvider).value;
+      final status = ref.read(nodeStatusProvider).valueOrNull;
       if (status != null) {
         _peers = status.peers;
       }
@@ -281,7 +281,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
     final spacing = theme.extension<AppSpacing>()!;
     final sizing = theme.extension<AppSizing>()!;
     final colorScheme = theme.colorScheme;
-    final statusFromProvider = ref.read(nodeStatusProvider).value;
+    final statusFromProvider = ref.read(nodeStatusProvider).valueOrNull;
     final sync = statusFromProvider?.syncStatus;
 
     // Determine status display
@@ -384,7 +384,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
     final theme = Theme.of(context);
     final spacing = theme.extension<AppSpacing>()!;
     final colorScheme = theme.colorScheme;
-    final statusFromProvider = ref.read(nodeStatusProvider).value;
+    final statusFromProvider = ref.read(nodeStatusProvider).valueOrNull;
 
     final sync = statusFromProvider?.syncStatus;
     final isNodeSynced = sync?.isSynced == true;
@@ -482,7 +482,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    final status = ref.read(nodeStatusProvider).value;
+    final status = ref.read(nodeStatusProvider).valueOrNull;
     final vrf = status?.vrfEvaluator;
     final displayBestTip = status?.networkBest ?? status?.localBest;
     final bestTipHash = displayBestTip?.hash.toString() ?? '';
@@ -508,7 +508,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
             text: _buildEpochTrailingText(),
           ),
           onTap: () {
-            final epoch = ref.read(nodeStatusProvider).value?.currentEpoch ?? 0;
+            final epoch = ref.read(nodeStatusProvider).valueOrNull?.currentEpoch ?? 0;
             context.push(
               AppRoutes.epochPerformance,
               extra: {'initialEpoch': epoch},
@@ -520,7 +520,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
           title: Text(l10n.nodeMempool),
           subtitle: _buildMempoolSubtitle(),
           trailing: TextChevronTrailing(
-            text: '${ref.read(nodeMempoolProvider).value?.count.toInt() ?? 0}',
+            text: '${ref.read(nodeMempoolProvider).valueOrNull?.count.toInt() ?? 0}',
           ),
           onTap: () => context.push(AppRoutes.mainNodeMempool),
         ),
@@ -584,7 +584,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
   }
 
   Widget _buildPeersSubtitle() {
-    final statusFromProvider = ref.read(nodeStatusProvider).value;
+    final statusFromProvider = ref.read(nodeStatusProvider).valueOrNull;
     final connectedPeers = statusFromProvider?.connectedPeers ?? 0;
     final totalPeers = statusFromProvider?.totalPeers ?? 0;
     final l10n = AppLocalizations.of(context);
@@ -592,14 +592,14 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
   }
 
   Widget _buildEpochTitle() {
-    final statusFromProvider = ref.read(nodeStatusProvider).value;
+    final statusFromProvider = ref.read(nodeStatusProvider).valueOrNull;
     final currentEpoch = statusFromProvider?.currentEpoch ?? 0;
     final l10n = AppLocalizations.of(context);
     return Text(l10n.nodeEpochN(currentEpoch));
   }
 
   (int slotInEpoch, int slotsPerEpoch, int currentSlot) _epochSlotData() {
-    final status = ref.read(nodeStatusProvider).value;
+    final status = ref.read(nodeStatusProvider).valueOrNull;
     final currentSlot = status?.currentGlobalSlot ?? 0;
     final slotsPerEpoch = status?.slotsInEpoch ?? 0;
     final slotInEpoch = slotsPerEpoch > 0 ? currentSlot % slotsPerEpoch : 0;
@@ -640,7 +640,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
   }
 
   Widget _buildMempoolSubtitle() {
-    final mempool = ref.read(nodeMempoolProvider).value;
+    final mempool = ref.read(nodeMempoolProvider).valueOrNull;
     final l10n = AppLocalizations.of(context);
     if (mempool == null) return Text(l10n.nodeNotAvailable);
 
@@ -652,7 +652,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
   // ============== NAVIGATION ==============
 
   void _navigateToPeers() {
-    final status = ref.read(nodeStatusProvider).value;
+    final status = ref.read(nodeStatusProvider).valueOrNull;
     final peers = status?.peers.isNotEmpty == true ? status!.peers : _peers;
     if (peers.isEmpty) return;
     context.push(


### PR DESCRIPTION
## Summary
- Replaces 20 unsafe `.value` accesses on `AsyncValue` with `.valueOrNull` across 8 files
- `.value` rethrows stored exceptions in `AsyncError` state before `?.`/`??` fallbacks execute, crashing the UI
- Continues the pattern established in #341 (commits a4a92077, 54d26e7c) which fixed ~12 sites

## Affected files
- `node_status_screen.dart` — 11 sites (`nodeStatusProvider`, `nodeMempoolProvider`)
- `node_status_produced_blocks_screen.dart` — 2 sites
- `epoch_performance_screen.dart` — 1 site
- `epoch_rewards_provider.dart` — 2 sites
- `app_drawer.dart` — 1 site
- `leaderboard_screen.dart` — 1 site
- `challenge_detail_screen.dart` — 1 site
- `challenges_screen.dart` — 1 site

## Test plan
- [x] `flutter analyze` — no issues
- [ ] `flutter test` — no behavior change expected (`.valueOrNull` returns same data in `AsyncData` state)
- [ ] Manual: node status screen renders correctly with node running
- [ ] Follow-up: #356 tracks adding explicit error state UI for these screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)