### PR TITLE
Sleep always-on app setups on inactivity

### DIFF
--- a/lib/core/bootstrap/app_bootstrap.dart
+++ b/lib/core/bootstrap/app_bootstrap.dart
@@ -10,6 +10,7 @@ import 'package:crypto_mobile_app/core/providers/leaderboard_bootstrap.dart';
 import 'package:crypto_mobile_app/core/providers/leaderboard_participant_provider.dart';
 import 'package:crypto_mobile_app/core/providers/providers.dart';
 import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/core/utils/lifecycle.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
@@ -85,6 +86,10 @@ class AppBootstrap {
 
     // Metrics collector needs the container before any lifecycle/service starts
     MetricsCollectorService.instance.initialize(container);
+
+    if (registerLifecycleObserver) {
+      await AppSleepService.instance.initializeForInteractiveApp();
+    }
 
     void recoverZkSession() {
       container

--- a/lib/core/config/l10n/app_en.arb
+++ b/lib/core/config/l10n/app_en.arb
@@ -2101,6 +2101,18 @@
   "@settingsGeneral": {
     "description": "General settings section header"
   },
+  "settingsAutomaticAppSleep": "Sleep On Inactivity",
+  "@settingsAutomaticAppSleep": {
+    "description": "Settings toggle label for automatic app sleep"
+  },
+  "settingsAutomaticAppSleepEnabled": "Force the app to sleep when it becomes inactive, even if the display stays on. This helps avoid unnecessary battery and bandwidth drain in always-on setups.",
+  "@settingsAutomaticAppSleepEnabled": {
+    "description": "Subtitle shown when automatic app sleep is enabled"
+  },
+  "settingsAutomaticAppSleepDisabled": "When disabled, the app will not force itself to sleep during inactivity. In always-on setups with the display left on, enabling this avoids unnecessary battery and bandwidth drain.",
+  "@settingsAutomaticAppSleepDisabled": {
+    "description": "Subtitle shown when automatic app sleep is disabled"
+  },
   "settingsAppearance": "Appearance",
   "@settingsAppearance": {
     "description": "Appearance settings tile title and sheet title"

--- a/lib/core/config/l10n/app_en.arb
+++ b/lib/core/config/l10n/app_en.arb
@@ -8,6 +8,39 @@
   "@appTagline": {
     "description": "Application tagline"
   },
+  "appSleepTitle": "App asleep",
+  "@appSleepTitle": {
+    "description": "Title shown on the full-screen sleep page"
+  },
+  "appSleepUntilSlot": "Sleeping until slot {slotNumber} at {dateTime}.",
+  "@appSleepUntilSlot": {
+    "description": "Message shown when the next scheduled slot time is known",
+    "placeholders": {
+      "slotNumber": {
+        "type": "int"
+      },
+      "dateTime": {
+        "type": "String"
+      }
+    }
+  },
+  "appSleepUntilTime": "Sleeping until {dateTime}.",
+  "@appSleepUntilTime": {
+    "description": "Message shown when only the next wake time is known",
+    "placeholders": {
+      "dateTime": {
+        "type": "String"
+      }
+    }
+  },
+  "appSleepUntilUnknown": "Sleeping until the next scheduled slot. Tap anywhere to wake sooner.",
+  "@appSleepUntilUnknown": {
+    "description": "Fallback message shown when the next scheduled slot time is unavailable"
+  },
+  "appSleepTapToWake": "Tap anywhere to wake and return to the app.",
+  "@appSleepTapToWake": {
+    "description": "Instruction shown on the sleep page"
+  },
   "initializingNode": "Initializing node...",
   "@initializingNode": {
     "description": "Loading text on splash screen"

--- a/lib/core/config/l10n/app_localizations.dart
+++ b/lib/core/config/l10n/app_localizations.dart
@@ -2716,6 +2716,24 @@ abstract class AppLocalizations {
   /// **'General'**
   String get settingsGeneral;
 
+  /// Settings toggle label for automatic app sleep
+  ///
+  /// In en, this message translates to:
+  /// **'Sleep On Inactivity'**
+  String get settingsAutomaticAppSleep;
+
+  /// Subtitle shown when automatic app sleep is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Force the app to sleep when it becomes inactive, even if the display stays on. This helps avoid unnecessary battery and bandwidth drain in always-on setups.'**
+  String get settingsAutomaticAppSleepEnabled;
+
+  /// Subtitle shown when automatic app sleep is disabled
+  ///
+  /// In en, this message translates to:
+  /// **'When disabled, the app will not force itself to sleep during inactivity. In always-on setups with the display left on, enabling this avoids unnecessary battery and bandwidth drain.'**
+  String get settingsAutomaticAppSleepDisabled;
+
   /// Appearance settings tile title and sheet title
   ///
   /// In en, this message translates to:

--- a/lib/core/config/l10n/app_localizations.dart
+++ b/lib/core/config/l10n/app_localizations.dart
@@ -106,6 +106,36 @@ abstract class AppLocalizations {
   /// **'Your Gateway to DeFi'**
   String get appTagline;
 
+  /// Title shown on the full-screen sleep page
+  ///
+  /// In en, this message translates to:
+  /// **'App asleep'**
+  String get appSleepTitle;
+
+  /// Message shown when the next scheduled slot time is known
+  ///
+  /// In en, this message translates to:
+  /// **'Sleeping until slot {slotNumber} at {dateTime}.'**
+  String appSleepUntilSlot(int slotNumber, String dateTime);
+
+  /// Message shown when only the next wake time is known
+  ///
+  /// In en, this message translates to:
+  /// **'Sleeping until {dateTime}.'**
+  String appSleepUntilTime(String dateTime);
+
+  /// Fallback message shown when the next scheduled slot time is unavailable
+  ///
+  /// In en, this message translates to:
+  /// **'Sleeping until the next scheduled slot. Tap anywhere to wake sooner.'**
+  String get appSleepUntilUnknown;
+
+  /// Instruction shown on the sleep page
+  ///
+  /// In en, this message translates to:
+  /// **'Tap anywhere to wake and return to the app.'**
+  String get appSleepTapToWake;
+
   /// Loading text on splash screen
   ///
   /// In en, this message translates to:

--- a/lib/core/config/l10n/app_localizations_en.dart
+++ b/lib/core/config/l10n/app_localizations_en.dart
@@ -1533,6 +1533,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsGeneral => 'General';
 
   @override
+  String get settingsAutomaticAppSleep => 'Sleep On Inactivity';
+
+  @override
+  String get settingsAutomaticAppSleepEnabled =>
+      'Force the app to sleep when it becomes inactive, even if the display stays on. This helps avoid unnecessary battery and bandwidth drain in always-on setups.';
+
+  @override
+  String get settingsAutomaticAppSleepDisabled =>
+      'When disabled, the app will not force itself to sleep during inactivity. In always-on setups with the display left on, enabling this avoids unnecessary battery and bandwidth drain.';
+
+  @override
   String get settingsAppearance => 'Appearance';
 
   @override

--- a/lib/core/config/l10n/app_localizations_en.dart
+++ b/lib/core/config/l10n/app_localizations_en.dart
@@ -15,6 +15,26 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appTagline => 'Your Gateway to DeFi';
 
   @override
+  String get appSleepTitle => 'App asleep';
+
+  @override
+  String appSleepUntilSlot(int slotNumber, String dateTime) {
+    return 'Sleeping until slot $slotNumber at $dateTime.';
+  }
+
+  @override
+  String appSleepUntilTime(String dateTime) {
+    return 'Sleeping until $dateTime.';
+  }
+
+  @override
+  String get appSleepUntilUnknown =>
+      'Sleeping until the next scheduled slot. Tap anywhere to wake sooner.';
+
+  @override
+  String get appSleepTapToWake => 'Tap anywhere to wake and return to the app.';
+
+  @override
   String get initializingNode => 'Initializing node...';
 
   @override

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'package:crypto_mobile_app/core/models/vrf_status.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_state_store.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
@@ -69,11 +70,22 @@ class AndroidForegroundTaskController {
 
   Future<void> onNodeStarted() async {
     if (!Platform.isAndroid) return;
+    if (AppSleepStateStore.isSleeping) {
+      _log.info('Skipping Android monitoring start while app sleep is active');
+      return;
+    }
     await startMonitoring(reason: 'node_started');
   }
 
   Future<void> startMonitoring({String reason = 'manual'}) async {
     if (!Platform.isAndroid) return;
+    if (AppSleepStateStore.isSleeping) {
+      _log.info(
+        'Skipping Android monitoring start while app sleep is active',
+        context: {'reason': reason},
+      );
+      return;
+    }
     await initialize();
 
     // Ensure the Rust node is running before polling VRF or scheduling alarms.
@@ -125,6 +137,13 @@ class AndroidForegroundTaskController {
   }
 
   Future<void> handleAlarmFire({String reason = 'alarm'}) async {
+    if (AppSleepStateStore.isSleeping) {
+      _log.info(
+        'Ignoring alarm-fired monitoring start while app sleep is active',
+        context: {'reason': reason},
+      );
+      return;
+    }
     _log.info('Alarm fired, restarting foreground task ($reason)');
     await startMonitoring(reason: reason);
   }
@@ -397,6 +416,10 @@ class AndroidForegroundTaskController {
   void handleNativeEvent(String eventType, Map<String, dynamic> data) {
     if (!Platform.isAndroid) return;
     if (eventType != 'android_alarm_fired') return;
+    if (AppSleepStateStore.isSleeping) {
+      _log.info('Ignoring native alarm event while app sleep is active');
+      return;
+    }
 
     final alarmId = data['alarmId'] as String? ?? '';
     if (alarmId == 'fg_resume') {

--- a/lib/core/services/app_sleep_service.dart
+++ b/lib/core/services/app_sleep_service.dart
@@ -79,7 +79,10 @@ class AppSleepService extends ChangeNotifier {
         _inactiveWakelockRetryInterval = defaultInactiveWakelockRetryInterval,
         _sleepOverride = null,
         _wakeOverride = null,
+        _useStateStore = true,
         _persistSleepingOverride = null,
+        _persistEnabledOverride = null,
+        _isEnabled = false,
         _isWakelockHeldOverride = null;
 
   @visibleForTesting
@@ -90,13 +93,18 @@ class AppSleepService extends ChangeNotifier {
     Future<void> Function(AppSleepReason reason)? onSleep,
     Future<void> Function(String reason)? onWake,
     Future<void> Function(bool value)? persistSleepState,
+    Future<void> Function(bool value)? persistSleepEnabled,
     Future<bool> Function()? isWakelockHeld,
     AppLifecycleState initialLifecycleState = AppLifecycleState.resumed,
+    bool initiallyEnabled = true,
   })  : _idleTimeout = idleTimeout,
         _inactiveWakelockRetryInterval = inactiveWakelockRetryInterval,
         _sleepOverride = onSleep,
         _wakeOverride = onWake,
+        _useStateStore = false,
         _persistSleepingOverride = persistSleepState,
+        _persistEnabledOverride = persistSleepEnabled,
+        _isEnabled = initiallyEnabled,
         _isWakelockHeldOverride = isWakelockHeld {
     _snapshot = AppSleepSnapshot(
       isSleeping: false,
@@ -115,7 +123,9 @@ class AppSleepService extends ChangeNotifier {
   final Duration _inactiveWakelockRetryInterval;
   final Future<void> Function(AppSleepReason reason)? _sleepOverride;
   final Future<void> Function(String reason)? _wakeOverride;
+  final bool _useStateStore;
   final Future<void> Function(bool value)? _persistSleepingOverride;
+  final Future<void> Function(bool value)? _persistEnabledOverride;
   final Future<bool> Function()? _isWakelockHeldOverride;
 
   Timer? _idleTimer;
@@ -124,6 +134,7 @@ class AppSleepService extends ChangeNotifier {
   Future<void> _transition = Future.value();
   DateTime? _lastRecordedInteractionAt;
   bool _initialized = false;
+  bool _isEnabled;
   bool _resumeMetricsOnWake = false;
   bool _resumeNodeOnWake = false;
   bool _resumeIosKeepAliveOnWake = false;
@@ -137,19 +148,23 @@ class AppSleepService extends ChangeNotifier {
   );
 
   AppSleepSnapshot get snapshot => _snapshot;
+  bool get isEnabled => _isEnabled;
   bool get isSleeping => _snapshot.isSleeping;
   bool get isAwake => !_snapshot.isSleeping;
 
   Future<void> initializeForInteractiveApp() async {
+    if (_useStateStore) {
+      await AppSleepStateStore.load();
+      _isEnabled = AppSleepStateStore.isEnabled;
+    }
+
     if (_initialized) {
       await _persistSleeping(false);
       _rescheduleIdleTimer();
+      notifyListeners();
       return;
     }
 
-    if (_persistSleepingOverride == null) {
-      await AppSleepStateStore.load();
-    }
     _snapshot = _snapshot.copyWith(
       lifecycleState:
           WidgetsBinding.instance.lifecycleState ?? AppLifecycleState.resumed,
@@ -171,6 +186,13 @@ class AppSleepService extends ChangeNotifier {
     _rescheduleIdleTimer();
     notifyListeners();
 
+    if (!_isEnabled) {
+      if (isSleeping) {
+        await _wakeInternal('automatic_sleep_disabled');
+      }
+      return;
+    }
+
     switch (state) {
       case AppLifecycleState.resumed:
         await wake(reason: 'lifecycle_resumed');
@@ -191,6 +213,10 @@ class AppSleepService extends ChangeNotifier {
   }
 
   void recordUserInteraction({String source = 'pointer'}) {
+    if (!_isEnabled && !isSleeping) {
+      return;
+    }
+
     final now = DateTime.now();
     final last = _lastRecordedInteractionAt;
     if (last != null && now.difference(last) < _interactionThrottle) {
@@ -209,6 +235,11 @@ class AppSleepService extends ChangeNotifier {
     _rescheduleIdleTimer();
   }
 
+  Future<void> setEnabled(bool value) {
+    _transition = _transition.then((_) => _setEnabledInternal(value));
+    return _transition;
+  }
+
   Future<void> sleep({required AppSleepReason reason}) {
     _transition = _transition.then((_) => _sleepInternal(reason));
     return _transition;
@@ -220,6 +251,10 @@ class AppSleepService extends ChangeNotifier {
   }
 
   Future<void> _sleepInternal(AppSleepReason reason) async {
+    if (!_isEnabled) {
+      return;
+    }
+
     if (isSleeping) {
       return;
     }
@@ -346,11 +381,42 @@ class AppSleepService extends ChangeNotifier {
     _rescheduleIdleTimer();
   }
 
+  Future<void> _setEnabledInternal(bool value) async {
+    if (_isEnabled == value) {
+      return;
+    }
+
+    _isEnabled = value;
+    await _persistEnabled(value);
+
+    if (!value) {
+      _idleTimer?.cancel();
+      _idleTimer = null;
+      _scheduledWakeTimer?.cancel();
+      _scheduledWakeTimer = null;
+      _cancelInactiveWakelockRetry();
+
+      if (isSleeping) {
+        await _wakeInternal('automatic_sleep_disabled');
+        return;
+      }
+
+      notifyListeners();
+      return;
+    }
+
+    _snapshot = _snapshot.copyWith(lastInteractionAt: DateTime.now());
+    _rescheduleIdleTimer();
+    notifyListeners();
+  }
+
   void _rescheduleIdleTimer() {
     _idleTimer?.cancel();
     _idleTimer = null;
 
-    if (_snapshot.lifecycleState != AppLifecycleState.resumed || isSleeping) {
+    if (!_isEnabled ||
+        _snapshot.lifecycleState != AppLifecycleState.resumed ||
+        isSleeping) {
       return;
     }
 
@@ -476,6 +542,15 @@ class AppSleepService extends ChangeNotifier {
     }
 
     await AppSleepStateStore.setSleeping(value);
+  }
+
+  Future<void> _persistEnabled(bool value) async {
+    if (_persistEnabledOverride != null) {
+      await _persistEnabledOverride(value);
+      return;
+    }
+
+    await AppSleepStateStore.setEnabled(value);
   }
 
   @override

--- a/lib/core/services/app_sleep_service.dart
+++ b/lib/core/services/app_sleep_service.dart
@@ -1,0 +1,490 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
+import 'package:crypto_mobile_app/core/services/app_version_check.dart';
+import 'package:crypto_mobile_app/core/services/epoch_slot_scheduler_service.dart';
+import 'package:crypto_mobile_app/core/services/ios_foreground_keepalive_service.dart';
+import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
+import 'package:crypto_mobile_app/core/services/slot_monitor_service.dart';
+import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/features/metrics/metrics_reporting_service.dart';
+import 'package:crypto_mobile_app/features/node/node_service.dart';
+import 'package:flutter/widgets.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
+
+import 'app_sleep_state_store.dart';
+
+final _log = LoggingService.instance.withTag('usernode/AppSleep');
+
+enum AppSleepReason {
+  idleTimeout,
+  lifecycleInactive,
+  lifecyclePaused,
+  lifecycleHidden,
+  lifecycleDetached,
+}
+
+@immutable
+class AppSleepSnapshot {
+  const AppSleepSnapshot({
+    required this.isSleeping,
+    required this.lifecycleState,
+    required this.lastInteractionAt,
+    this.scheduledWakeAt,
+    this.scheduledWakeSlotNumber,
+    this.reason,
+  });
+
+  final bool isSleeping;
+  final AppLifecycleState lifecycleState;
+  final DateTime lastInteractionAt;
+  final DateTime? scheduledWakeAt;
+  final int? scheduledWakeSlotNumber;
+  final AppSleepReason? reason;
+
+  AppSleepSnapshot copyWith({
+    bool? isSleeping,
+    AppLifecycleState? lifecycleState,
+    DateTime? lastInteractionAt,
+    Object? scheduledWakeAt = _scheduledWakeAtSentinel,
+    Object? scheduledWakeSlotNumber = _scheduledWakeSlotSentinel,
+    Object? reason = _reasonSentinel,
+  }) {
+    return AppSleepSnapshot(
+      isSleeping: isSleeping ?? this.isSleeping,
+      lifecycleState: lifecycleState ?? this.lifecycleState,
+      lastInteractionAt: lastInteractionAt ?? this.lastInteractionAt,
+      scheduledWakeAt: identical(scheduledWakeAt, _scheduledWakeAtSentinel)
+          ? this.scheduledWakeAt
+          : scheduledWakeAt as DateTime?,
+      scheduledWakeSlotNumber:
+          identical(scheduledWakeSlotNumber, _scheduledWakeSlotSentinel)
+              ? this.scheduledWakeSlotNumber
+              : scheduledWakeSlotNumber as int?,
+      reason: identical(reason, _reasonSentinel)
+          ? this.reason
+          : reason as AppSleepReason?,
+    );
+  }
+}
+
+const _reasonSentinel = Object();
+const _scheduledWakeAtSentinel = Object();
+const _scheduledWakeSlotSentinel = Object();
+
+class AppSleepService extends ChangeNotifier {
+  AppSleepService._()
+      : _idleTimeout = defaultIdleTimeout,
+        _inactiveWakelockRetryInterval = defaultInactiveWakelockRetryInterval,
+        _sleepOverride = null,
+        _wakeOverride = null,
+        _persistSleepingOverride = null,
+        _isWakelockHeldOverride = null;
+
+  @visibleForTesting
+  AppSleepService.forTest({
+    Duration idleTimeout = defaultIdleTimeout,
+    Duration inactiveWakelockRetryInterval =
+        defaultInactiveWakelockRetryInterval,
+    Future<void> Function(AppSleepReason reason)? onSleep,
+    Future<void> Function(String reason)? onWake,
+    Future<void> Function(bool value)? persistSleepState,
+    Future<bool> Function()? isWakelockHeld,
+    AppLifecycleState initialLifecycleState = AppLifecycleState.resumed,
+  })  : _idleTimeout = idleTimeout,
+        _inactiveWakelockRetryInterval = inactiveWakelockRetryInterval,
+        _sleepOverride = onSleep,
+        _wakeOverride = onWake,
+        _persistSleepingOverride = persistSleepState,
+        _isWakelockHeldOverride = isWakelockHeld {
+    _snapshot = AppSleepSnapshot(
+      isSleeping: false,
+      lifecycleState: initialLifecycleState,
+      lastInteractionAt: DateTime.now(),
+    );
+  }
+
+  static final AppSleepService instance = AppSleepService._();
+
+  static const defaultIdleTimeout = Duration(seconds: 20);
+  static const defaultInactiveWakelockRetryInterval = Duration(seconds: 10);
+  static const _interactionThrottle = Duration(seconds: 1);
+
+  final Duration _idleTimeout;
+  final Duration _inactiveWakelockRetryInterval;
+  final Future<void> Function(AppSleepReason reason)? _sleepOverride;
+  final Future<void> Function(String reason)? _wakeOverride;
+  final Future<void> Function(bool value)? _persistSleepingOverride;
+  final Future<bool> Function()? _isWakelockHeldOverride;
+
+  Timer? _idleTimer;
+  Timer? _scheduledWakeTimer;
+  Timer? _inactiveWakelockRetryTimer;
+  Future<void> _transition = Future.value();
+  DateTime? _lastRecordedInteractionAt;
+  bool _initialized = false;
+  bool _resumeMetricsOnWake = false;
+  bool _resumeNodeOnWake = false;
+  bool _resumeIosKeepAliveOnWake = false;
+  bool _resumeEpochMonitoringOnWake = false;
+
+  AppSleepSnapshot _snapshot = AppSleepSnapshot(
+    isSleeping: false,
+    lifecycleState:
+        WidgetsBinding.instance.lifecycleState ?? AppLifecycleState.resumed,
+    lastInteractionAt: DateTime.now(),
+  );
+
+  AppSleepSnapshot get snapshot => _snapshot;
+  bool get isSleeping => _snapshot.isSleeping;
+  bool get isAwake => !_snapshot.isSleeping;
+
+  Future<void> initializeForInteractiveApp() async {
+    if (_initialized) {
+      await _persistSleeping(false);
+      _rescheduleIdleTimer();
+      return;
+    }
+
+    if (_persistSleepingOverride == null) {
+      await AppSleepStateStore.load();
+    }
+    _snapshot = _snapshot.copyWith(
+      lifecycleState:
+          WidgetsBinding.instance.lifecycleState ?? AppLifecycleState.resumed,
+      lastInteractionAt: DateTime.now(),
+      isSleeping: false,
+      reason: null,
+    );
+    _initialized = true;
+    await _persistSleeping(false);
+    _rescheduleIdleTimer();
+    notifyListeners();
+  }
+
+  Future<void> handleLifecycleStateChanged(AppLifecycleState state) async {
+    _snapshot = _snapshot.copyWith(lifecycleState: state);
+    if (state != AppLifecycleState.inactive) {
+      _cancelInactiveWakelockRetry();
+    }
+    _rescheduleIdleTimer();
+    notifyListeners();
+
+    switch (state) {
+      case AppLifecycleState.resumed:
+        await wake(reason: 'lifecycle_resumed');
+        break;
+      case AppLifecycleState.inactive:
+        await sleep(reason: AppSleepReason.lifecycleInactive);
+        break;
+      case AppLifecycleState.paused:
+        await sleep(reason: AppSleepReason.lifecyclePaused);
+        break;
+      case AppLifecycleState.hidden:
+        await sleep(reason: AppSleepReason.lifecycleHidden);
+        break;
+      case AppLifecycleState.detached:
+        await sleep(reason: AppSleepReason.lifecycleDetached);
+        break;
+    }
+  }
+
+  void recordUserInteraction({String source = 'pointer'}) {
+    final now = DateTime.now();
+    final last = _lastRecordedInteractionAt;
+    if (last != null && now.difference(last) < _interactionThrottle) {
+      return;
+    }
+
+    _lastRecordedInteractionAt = now;
+    _snapshot = _snapshot.copyWith(lastInteractionAt: now);
+    notifyListeners();
+
+    if (isSleeping) {
+      unawaited(wake(reason: 'user_interaction:$source'));
+      return;
+    }
+
+    _rescheduleIdleTimer();
+  }
+
+  Future<void> sleep({required AppSleepReason reason}) {
+    _transition = _transition.then((_) => _sleepInternal(reason));
+    return _transition;
+  }
+
+  Future<void> wake({required String reason}) {
+    _transition = _transition.then((_) => _wakeInternal(reason));
+    return _transition;
+  }
+
+  Future<void> _sleepInternal(AppSleepReason reason) async {
+    if (isSleeping) {
+      return;
+    }
+
+    if (await _shouldBlockSleepForWakelock(reason)) {
+      _log.info(
+        'Skipping app sleep because wakelock is held',
+        context: {'reason': reason.name},
+      );
+      if (reason == AppSleepReason.lifecycleInactive) {
+        _startInactiveWakelockRetry();
+      }
+      if (_snapshot.lifecycleState == AppLifecycleState.resumed) {
+        _rescheduleIdleTimer();
+      }
+      return;
+    }
+
+    _cancelInactiveWakelockRetry();
+    _idleTimer?.cancel();
+    _idleTimer = null;
+    _scheduledWakeTimer?.cancel();
+    _scheduledWakeTimer = null;
+
+    _resumeMetricsOnWake = MetricsReportingService.instance.isRunning;
+    _resumeNodeOnWake = RustBackendService.instance.isRunning;
+    _resumeIosKeepAliveOnWake =
+        Platform.isIOS && IOSForegroundKeepAliveService.instance.isActive;
+    _resumeEpochMonitoringOnWake =
+        EpochSlotSchedulerService.instance.isInitialized;
+    final nextWakeup = await _resolveNextScheduledWake();
+
+    _snapshot = _snapshot.copyWith(
+      isSleeping: true,
+      scheduledWakeAt: nextWakeup?.scheduledWakeAt,
+      scheduledWakeSlotNumber: nextWakeup?.scheduledWakeSlotNumber,
+      reason: reason,
+    );
+    notifyListeners();
+    await _persistSleeping(true);
+    _scheduleAutomaticWakeIfNeeded();
+
+    _log.info('Entering app sleep', context: {'reason': reason.name});
+
+    if (_sleepOverride != null) {
+      await _sleepOverride(reason);
+      return;
+    }
+
+    await PlatformAlarmService.instance.initialize();
+
+    if (_resumeMetricsOnWake) {
+      await MetricsReportingService.instance.stop();
+    }
+
+    AppVersionCheck.instance.stopPeriodicChecks();
+    EpochSlotSchedulerService.instance.stopEpochMonitoring();
+    await SlotMonitorService.instance.stopMonitoring();
+
+    if (Platform.isAndroid) {
+      await AndroidForegroundTaskController.instance
+          .stopMonitoring(reason: 'app_sleep:${reason.name}');
+    }
+
+    if (_resumeIosKeepAliveOnWake) {
+      await IOSForegroundKeepAliveService.instance.stopKeepAlive();
+    }
+
+    await PlatformAlarmService.instance.cancelAllAlarms();
+    await RustBackendService.instance.pauseNode();
+  }
+
+  Future<void> _wakeInternal(String reason) async {
+    if (!isSleeping) {
+      _rescheduleIdleTimer();
+      return;
+    }
+
+    _scheduledWakeTimer?.cancel();
+    _scheduledWakeTimer = null;
+    _cancelInactiveWakelockRetry();
+
+    _snapshot = _snapshot.copyWith(
+      isSleeping: false,
+      scheduledWakeAt: null,
+      scheduledWakeSlotNumber: null,
+      reason: null,
+      lastInteractionAt: DateTime.now(),
+    );
+    notifyListeners();
+    await _persistSleeping(false);
+
+    _log.info('Waking app', context: {'reason': reason});
+
+    if (_wakeOverride != null) {
+      await _wakeOverride(reason);
+      _rescheduleIdleTimer();
+      return;
+    }
+
+    if (_resumeNodeOnWake) {
+      await RustBackendService.instance.startNode();
+      await RustBackendService.instance.resumeNode();
+    }
+
+    if (_resumeEpochMonitoringOnWake) {
+      await EpochSlotSchedulerService.instance.initialize();
+      EpochSlotSchedulerService.instance.startEpochMonitoring();
+    }
+
+    if (_resumeMetricsOnWake) {
+      await MetricsReportingService.instance.start();
+    }
+
+    if (Platform.isAndroid && _resumeNodeOnWake) {
+      await AndroidForegroundTaskController.instance
+          .startMonitoring(reason: 'app_wake');
+    }
+
+    if (Platform.isIOS && _resumeIosKeepAliveOnWake) {
+      await IOSForegroundKeepAliveService.instance.startKeepAlive();
+    }
+
+    _rescheduleIdleTimer();
+  }
+
+  void _rescheduleIdleTimer() {
+    _idleTimer?.cancel();
+    _idleTimer = null;
+
+    if (_snapshot.lifecycleState != AppLifecycleState.resumed || isSleeping) {
+      return;
+    }
+
+    _idleTimer = Timer(_idleTimeout, () {
+      unawaited(sleep(reason: AppSleepReason.idleTimeout));
+    });
+  }
+
+  Future<bool> _shouldBlockSleepForWakelock(AppSleepReason reason) async {
+    if (_isWakelockHeldOverride != null) {
+      return _isWakelockHeldOverride();
+    }
+
+    try {
+      if (Platform.isAndroid) {
+        return await AndroidForegroundTaskController.instance.isWakelockHeld();
+      }
+
+      if (Platform.isIOS) {
+        if (IOSForegroundKeepAliveService.instance.isActive) {
+          return true;
+        }
+        return await WakelockPlus.enabled;
+      }
+    } catch (e) {
+      _log.debug('Failed to query wakelock state: $e');
+    }
+
+    return false;
+  }
+
+  void _startInactiveWakelockRetry() {
+    if (_snapshot.lifecycleState != AppLifecycleState.inactive || isSleeping) {
+      return;
+    }
+    if (_inactiveWakelockRetryTimer != null) {
+      return;
+    }
+
+    _log.info(
+      'Starting inactive wakelock sleep retry loop',
+      context: {'interval_seconds': _inactiveWakelockRetryInterval.inSeconds},
+    );
+    _inactiveWakelockRetryTimer = Timer.periodic(
+      _inactiveWakelockRetryInterval,
+      (_) => _handleInactiveWakelockRetryTick(),
+    );
+  }
+
+  void _cancelInactiveWakelockRetry() {
+    _inactiveWakelockRetryTimer?.cancel();
+    _inactiveWakelockRetryTimer = null;
+  }
+
+  void _handleInactiveWakelockRetryTick() {
+    if (_snapshot.lifecycleState != AppLifecycleState.inactive || isSleeping) {
+      _cancelInactiveWakelockRetry();
+      return;
+    }
+
+    unawaited(sleep(reason: AppSleepReason.lifecycleInactive));
+  }
+
+  Future<({DateTime scheduledWakeAt, int? scheduledWakeSlotNumber})?>
+      _resolveNextScheduledWake() async {
+    final now = DateTime.now();
+
+    try {
+      final epochInfo = await RustBackendService.instance.getEpochInfo();
+      final futureWonSlots = epochInfo?.wonSlots
+              .where(
+                (slot) => DateTime.fromMillisecondsSinceEpoch(
+                  slot.expectedTimeMs.toInt(),
+                ).isAfter(now),
+              )
+              .toList() ??
+          const [];
+      futureWonSlots
+          .sort((a, b) => a.expectedTimeMs.compareTo(b.expectedTimeMs));
+
+      if (futureWonSlots.isNotEmpty) {
+        final nextSlot = futureWonSlots.first;
+        return (
+          scheduledWakeAt: DateTime.fromMillisecondsSinceEpoch(
+              nextSlot.expectedTimeMs.toInt()),
+          scheduledWakeSlotNumber: nextSlot.globalSlot,
+        );
+      }
+    } catch (e) {
+      _log.debug('Failed to resolve next wake from epoch info: $e');
+    }
+
+    final scheduledSlot = EpochSlotSchedulerService.instance.getNextSlot();
+    if (scheduledSlot != null) {
+      return (
+        scheduledWakeAt: scheduledSlot.slotTime,
+        scheduledWakeSlotNumber: scheduledSlot.slotNumber,
+      );
+    }
+
+    return null;
+  }
+
+  void _scheduleAutomaticWakeIfNeeded() {
+    final scheduledWakeAt = _snapshot.scheduledWakeAt;
+    if (scheduledWakeAt == null) return;
+
+    final delay = scheduledWakeAt.difference(DateTime.now());
+    if (delay <= Duration.zero) {
+      unawaited(wake(reason: 'scheduled_slot'));
+      return;
+    }
+
+    _scheduledWakeTimer = Timer(delay, () {
+      unawaited(wake(reason: 'scheduled_slot'));
+    });
+  }
+
+  Future<void> _persistSleeping(bool value) async {
+    if (_persistSleepingOverride != null) {
+      await _persistSleepingOverride(value);
+      return;
+    }
+
+    await AppSleepStateStore.setSleeping(value);
+  }
+
+  @override
+  void dispose() {
+    _idleTimer?.cancel();
+    _idleTimer = null;
+    _scheduledWakeTimer?.cancel();
+    _scheduledWakeTimer = null;
+    _cancelInactiveWakelockRetry();
+    super.dispose();
+  }
+}

--- a/lib/core/services/app_sleep_state_store.dart
+++ b/lib/core/services/app_sleep_state_store.dart
@@ -5,18 +5,38 @@ class AppSleepStateStore {
   AppSleepStateStore._();
 
   static const _sleepingKey = 'app_sleep:is_sleeping';
+  static const _enabledKey = 'app_sleep:is_enabled';
   static bool _isSleeping = false;
+  static bool _isEnabled = false;
 
   static bool get isSleeping => _isSleeping;
+  static bool get isEnabled => _isEnabled;
 
   static Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
-    _isSleeping = prefs.getBool(_sleepingKey) ?? false;
+    _isEnabled = prefs.getBool(_enabledKey) ?? false;
+    final storedSleeping = prefs.getBool(_sleepingKey) ?? false;
+    _isSleeping = _isEnabled && storedSleeping;
+
+    if (!_isEnabled && storedSleeping) {
+      await prefs.setBool(_sleepingKey, false);
+    }
+  }
+
+  static Future<void> setEnabled(bool value) async {
+    _isEnabled = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledKey, value);
+
+    if (!value) {
+      _isSleeping = false;
+      await prefs.setBool(_sleepingKey, false);
+    }
   }
 
   static Future<void> setSleeping(bool value) async {
-    _isSleeping = value;
+    _isSleeping = _isEnabled ? value : false;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_sleepingKey, value);
+    await prefs.setBool(_sleepingKey, _isSleeping);
   }
 }

--- a/lib/core/services/app_sleep_state_store.dart
+++ b/lib/core/services/app_sleep_state_store.dart
@@ -1,0 +1,22 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persisted app sleep flag used by both UI and headless runtimes.
+class AppSleepStateStore {
+  AppSleepStateStore._();
+
+  static const _sleepingKey = 'app_sleep:is_sleeping';
+  static bool _isSleeping = false;
+
+  static bool get isSleeping => _isSleeping;
+
+  static Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _isSleeping = prefs.getBool(_sleepingKey) ?? false;
+  }
+
+  static Future<void> setSleeping(bool value) async {
+    _isSleeping = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_sleepingKey, value);
+  }
+}

--- a/lib/core/utils/lifecycle.dart
+++ b/lib/core/utils/lifecycle.dart
@@ -1,10 +1,8 @@
 import 'dart:async';
-import 'dart:io';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:flutter/widgets.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
-import '../../features/node/node_service.dart';
 import '../../features/metrics/metrics_collector_service.dart';
-import '../services/android_foreground_task_controller.dart';
 
 final _log = LoggingService.instance.withTag('usernode/Lifecycle');
 
@@ -40,6 +38,7 @@ class AppLifecycleLogger with WidgetsBindingObserver {
 
     // Update metrics collector with new state
     MetricsCollectorService.instance.updateAppLifecycleState(state);
+    await AppSleepService.instance.handleLifecycleStateChanged(state);
 
     switch (state) {
       case AppLifecycleState.resumed:
@@ -68,15 +67,8 @@ class AppLifecycleLogger with WidgetsBindingObserver {
     try {
       _log.info('Handling app resume...');
 
-      // 1. Check and restart node if needed (Android only)
-      if (Platform.isAndroid) {
-        await _ensureNodeRunning();
-      }
-
-      // 2. Check for epoch transition and reschedule if needed
-      await _checkEpochTransition();
-
-      // 3. Verify scheduled alarms still exist
+      // Native wake/resume is handled by AppSleepService. Resume work here
+      // should be limited to foreground-only recovery tasks.
       await _verifyScheduledAlarms();
 
       _log.info('App resume handling complete');
@@ -91,38 +83,6 @@ class AppLifecycleLogger with WidgetsBindingObserver {
   /// Handle app paused
   Future<void> _handleAppPaused() async {
     // Rust Node will be paused by the foreground service or MainActivity destructor.
-  }
-
-  /// Ensure node is running (Android only)
-  Future<void> _ensureNodeRunning() async {
-    try {
-      final rustBackend = RustBackendService.instance;
-
-      await rustBackend.startNode();
-      await rustBackend.resumeNode();
-
-      if (rustBackend.isRunning) {
-        _log.info('✓ Node successfully ensured running');
-      } else {
-        _log.error('✗ Failed to start and resume node');
-      }
-    } catch (e) {
-      _log.error('Error ensuring node running: $e');
-    }
-  }
-
-  /// Check if epoch has changed and reschedule slots if needed
-  ///
-  Future<void> _checkEpochTransition() async {
-    try {
-      if (!Platform.isAndroid) return;
-
-      _log.info('Resuming Android foreground VRF monitoring');
-      await AndroidForegroundTaskController.instance
-          .startMonitoring(reason: 'app_resumed');
-    } catch (e) {
-      _log.error('Error checking epoch transition: $e');
-    }
   }
 
   /// Verify that scheduled alarms still exist (could be cleared by system)

--- a/lib/design_system/widgetbook/settings_page_use_case.dart
+++ b/lib/design_system/widgetbook/settings_page_use_case.dart
@@ -325,7 +325,9 @@ class _SettingsPageState extends State<_SettingsPage> {
             GeneralSettingsSection(
               currentThemeLabel: _themeModeLabel(widget.themeMode),
               buildInfoSubtitle: 'v1.2.3 \u00b7 abc1234',
+              appSleepEnabled: false,
               onAppearanceTap: _showThemePicker,
+              onAppSleepChanged: (_) {},
               onBuildInfoTap: _showBuildInfo,
               onBuildInfoLongPress: () {},
             ),

--- a/lib/features/app_sleep/screens/app_sleep_screen.dart
+++ b/lib/features/app_sleep/screens/app_sleep_screen.dart
@@ -1,0 +1,111 @@
+import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
+import 'package:crypto_mobile_app/design_system/design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+class AppSleepScreen extends StatelessWidget {
+  const AppSleepScreen({
+    super.key,
+    required this.snapshot,
+    required this.onWakeRequested,
+  });
+
+  final AppSleepSnapshot snapshot;
+  final VoidCallback onWakeRequested;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final spacing = theme.extension<AppSpacing>()!;
+    final sizing = theme.extension<AppSizing>()!;
+    final semantic = theme.extension<AppSemanticColors>()!;
+    final l10n = AppLocalizations.of(context);
+
+    return PopScope(
+      canPop: false,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onWakeRequested,
+        child: Scaffold(
+          backgroundColor: theme.colorScheme.surface,
+          body: SafeArea(
+            child: Center(
+              child: Padding(
+                padding: EdgeInsets.all(spacing.space24),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Symbols.bedtime_sharp,
+                      size: sizing.iconDisplayLarge,
+                      color: semantic.technical.color,
+                    ),
+                    SizedBox(height: spacing.space24),
+                    Text(
+                      l10n.appSleepTitle,
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.headlineMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    SizedBox(height: spacing.space12),
+                    Text(
+                      _scheduledWakeText(context, l10n),
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    SizedBox(height: spacing.space24),
+                    Container(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: spacing.space16,
+                        vertical: spacing.space12,
+                      ),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.surfaceContainerHighest,
+                        borderRadius:
+                            theme.extension<AppRadii>()!.borderRadiusMedium,
+                      ),
+                      child: Text(
+                        l10n.appSleepTapToWake,
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _scheduledWakeText(
+    BuildContext context,
+    AppLocalizations l10n,
+  ) {
+    final scheduledWakeAt = snapshot.scheduledWakeAt;
+    if (scheduledWakeAt == null) {
+      return l10n.appSleepUntilUnknown;
+    }
+
+    final material = MaterialLocalizations.of(context);
+    final date = material.formatMediumDate(scheduledWakeAt);
+    final time = material.formatTimeOfDay(
+      TimeOfDay.fromDateTime(scheduledWakeAt),
+      alwaysUse24HourFormat: MediaQuery.of(context).alwaysUse24HourFormat,
+    );
+
+    final dateTimeText = '$date $time';
+    final slotNumber = snapshot.scheduledWakeSlotNumber;
+    if (slotNumber != null) {
+      return l10n.appSleepUntilSlot(slotNumber, dateTimeText);
+    }
+
+    return l10n.appSleepUntilTime(dateTimeText);
+  }
+}

--- a/lib/features/challenges/screens/challenges_screen.dart
+++ b/lib/features/challenges/screens/challenges_screen.dart
@@ -13,6 +13,7 @@ import 'package:crypto_mobile_app/core/providers/challenges_provider.dart';
 import 'package:crypto_mobile_app/core/providers/leaderboard_bootstrap.dart';
 import 'package:crypto_mobile_app/core/providers/ranking_provider.dart';
 import 'package:crypto_mobile_app/core/providers/seasons_provider.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/core/providers/syncing_text_provider.dart';
 import 'package:go_router/go_router.dart';
@@ -55,6 +56,7 @@ class _ChallengesScreenState extends ConsumerState<ChallengesScreen>
   final _scrollFraction = ValueNotifier<double>(0.0);
   late TabController _tabController;
   late final HeartbeatAnimation _heartbeat;
+  final _appSleepService = AppSleepService.instance;
   Timer? _refreshTimer;
 
   final _pullFeedback = ValueNotifier<PullFeedback>(const PullFeedback());
@@ -64,11 +66,13 @@ class _ChallengesScreenState extends ConsumerState<ChallengesScreen>
     super.initState();
     _tabController = TabController(length: kTabLabels.length, vsync: this);
     _heartbeat = HeartbeatAnimation(vsync: this);
+    _appSleepService.addListener(_handleAppSleepChanged);
     _startAutoRefresh();
   }
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _refreshTimer?.cancel();
     _heartbeat.dispose();
     _tabController.dispose();
@@ -78,8 +82,10 @@ class _ChallengesScreenState extends ConsumerState<ChallengesScreen>
   }
 
   void _startAutoRefresh() {
+    if (_appSleepService.isSleeping) return;
     _refreshTimer?.cancel();
     _refreshTimer = Timer.periodic(const Duration(seconds: 30), (_) async {
+      if (_appSleepService.isSleeping) return;
       if (!mounted) return;
       final currentTab = ref.read(currentHomeTabProvider);
       if (currentTab == HomeTab.challenges) {
@@ -112,6 +118,18 @@ class _ChallengesScreenState extends ConsumerState<ChallengesScreen>
       disableAnimations: MediaQuery.of(context).disableAnimations,
     );
     _startAutoRefresh();
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _refreshTimer?.cancel();
+      _refreshTimer = null;
+      return;
+    }
+
+    _startAutoRefresh();
+    unawaited(_onRefresh());
   }
 
   @override

--- a/lib/features/challenges/screens/epoch_performance_screen.dart
+++ b/lib/features/challenges/screens/epoch_performance_screen.dart
@@ -9,6 +9,7 @@ import 'package:crypto_mobile_app/core/config/app_router.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 import 'package:crypto_mobile_app/core/providers/produced_blocks_provider.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 
 /// Feature screen that wires live block-production data to
@@ -28,6 +29,7 @@ class EpochPerformanceScreen extends ConsumerStatefulWidget {
 
 class _EpochPerformanceScreenState
     extends ConsumerState<EpochPerformanceScreen> {
+  final _appSleepService = AppSleepService.instance;
   late int _viewedEpoch;
   Timer? _autoRefreshTimer;
   bool _refreshing = false;
@@ -35,6 +37,7 @@ class _EpochPerformanceScreenState
   @override
   void initState() {
     super.initState();
+    _appSleepService.addListener(_handleAppSleepChanged);
     _viewedEpoch = widget.initialEpoch;
     _startAutoRefresh();
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -45,13 +48,16 @@ class _EpochPerformanceScreenState
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _autoRefreshTimer?.cancel();
     super.dispose();
   }
 
   void _startAutoRefresh() {
+    if (_appSleepService.isSleeping) return;
     _autoRefreshTimer?.cancel();
     _autoRefreshTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
       if (!mounted || _refreshing) return;
       _refreshSummary();
     });
@@ -68,6 +74,18 @@ class _EpochPerformanceScreenState
     } finally {
       _refreshing = false;
     }
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _autoRefreshTimer?.cancel();
+      _autoRefreshTimer = null;
+      return;
+    }
+
+    _startAutoRefresh();
+    unawaited(_refreshSummary());
   }
 
   @override

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -71,6 +71,7 @@ class RustBackendService {
       _initCompleter; // Prevents race condition on concurrent init() calls
   Completer<bool>? _startNodeCompleter;
   bool _nodeRunning = false;
+  bool _nodePaused = false;
   String? _instanceId;
   String? _cachedPeerId;
   int? _cachedGenesisTimestamp;
@@ -333,6 +334,7 @@ class RustBackendService {
       _rpc = rpc;
       _control = control;
       _nodeRunning = true;
+      _nodePaused = false;
       control.resume();
       await _cachePeerIdFromRpc(rpc);
 
@@ -397,6 +399,7 @@ class RustBackendService {
       // Run the node in a background thread.
       _control = node.runForeverInNewThread();
       _nodeRunning = true;
+      _nodePaused = false;
 
       // Cache peer ID once on startup.
       // Prefer RPC status so callers don't depend on holding a Node handle.
@@ -459,11 +462,13 @@ class RustBackendService {
 
   Future<void> resumeNode() async {
     _log.info('Resuming node');
+    _nodePaused = false;
     _control?.resume();
   }
 
   Future<void> pauseNode() async {
     _log.info('Pausing node');
+    _nodePaused = true;
     _control?.pause();
   }
 
@@ -475,6 +480,7 @@ class RustBackendService {
     );
     _control?.shutdown();
     _nodeRunning = false;
+    _nodePaused = false;
     _rpc = null;
     _control = null;
     _cachedPeerId = null;
@@ -552,6 +558,7 @@ class RustBackendService {
     _initCompleter = null;
     _startNodeCompleter = null;
     _nodeRunning = false;
+    _nodePaused = false;
     _instanceId = null;
     _cachedPeerId = null;
     _cachedGenesisTimestamp = null;
@@ -568,8 +575,18 @@ class RustBackendService {
     return _cachedPeerId;
   }
 
+  bool _shouldSkipRpc(String methodName) {
+    if (!_nodePaused) {
+      return false;
+    }
+
+    _log.debug('$methodName skipped: node is paused');
+    return true;
+  }
+
   Future<RpcStatusNode?> getStatusNode() async {
     _log.trace('getStatusNode called');
+    if (_shouldSkipRpc('getStatusNode')) return null;
     final r = _rpc;
     if (r == null) return null;
     try {
@@ -595,6 +612,7 @@ class RustBackendService {
   Future<RpcStatusResp?> getStatus({
     bool includeVrfDetails = true,
   }) async {
+    if (_shouldSkipRpc('getStatus')) return null;
     final stopwatch = Stopwatch()..start();
     _log.debug(
         'getStatus RPC call started (includeVrfDetails: $includeVrfDetails)');
@@ -792,6 +810,7 @@ class RustBackendService {
     bool includeVrfDetails = true,
   }) async {
     _log.trace('getBlockProducerStatus called');
+    if (_shouldSkipRpc('getBlockProducerStatus')) return null;
     final r = _rpc;
     if (r == null) return null;
 
@@ -824,6 +843,7 @@ class RustBackendService {
     int? epoch,
     AccountPublicKey? blockProducer,
   }) async {
+    if (_shouldSkipRpc('listBlockchain')) return null;
     final stopwatch = Stopwatch()..start();
     _log.debug(
         'listBlockchain RPC call started (limit: $limit, fromTip: $fromTip, epoch: $epoch)');
@@ -932,6 +952,7 @@ class RustBackendService {
     bool? idsOnly,
     TransactionHash? cursorAfter,
   }) async {
+    if (_shouldSkipRpc('listMempool')) return null;
     final stopwatch = Stopwatch()..start();
     _log.debug(
         'listMempool RPC call started (limit: $limit, idsOnly: $idsOnly)');
@@ -1030,6 +1051,7 @@ class RustBackendService {
     int? epoch,
   }) async {
     _log.trace('epochRewards called with params: epoch=$epoch');
+    if (_shouldSkipRpc('epochRewards')) return null;
     final r = _rpc;
     if (r == null) return null;
 
@@ -1121,6 +1143,7 @@ class RustBackendService {
     _log.trace(
       'listUtxosByOwner called with params: owner=[PublicKeyHash], limit=$limit',
     );
+    if (_shouldSkipRpc('listUtxosByOwner')) return null;
     final r = _rpc;
     if (r == null) return null;
 
@@ -1253,6 +1276,7 @@ class RustBackendService {
   ///
   /// Returns null if backend is unavailable or calls fail.
   Future<BackendRPCResponse?> getEpochInfo({int? epoch}) async {
+    if (_shouldSkipRpc('getEpochInfo')) return null;
     try {
       // First, get current blockchain status to determine current slot
       final status = await getStatus();
@@ -1304,6 +1328,7 @@ class RustBackendService {
   /// Convenience helper to fetch epochs with slot data via RPC.
   Future<RpcEpochsWithDataResp?> getEpochsWithData() async {
     _log.trace('getEpochsWithData called');
+    if (_shouldSkipRpc('getEpochsWithData')) return null;
     final r = _rpc;
     if (r == null) return null;
 
@@ -1344,6 +1369,7 @@ class RustBackendService {
     required int epoch,
   }) async {
     _log.trace('getEpochSlotResults called with params: epoch=$epoch');
+    if (_shouldSkipRpc('getEpochSlotResults')) return null;
     final r = _rpc;
     if (r == null) return null;
 
@@ -1388,6 +1414,7 @@ class RustBackendService {
     required int slot,
   }) async {
     _log.trace('getSlotTime called with params: epoch=$epoch, slot=$slot');
+    if (_shouldSkipRpc('getSlotTime')) return null;
     final r = _rpc;
     if (r == null) return null;
 
@@ -1434,6 +1461,7 @@ class RustBackendService {
   }) async {
     _log.trace(
         'getProducedBlockMetadata called with params: epoch=$epoch, slot=$slot');
+    if (_shouldSkipRpc('getProducedBlockMetadata')) return null;
     final r = _rpc;
     if (r == null) return null;
 

--- a/lib/features/node/screens/mempool_details_screen.dart
+++ b/lib/features/node/screens/mempool_details_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:crypto_mobile_app/core/widgets/app_bar.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/core/utils/utils.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 import 'package:crypto_mobile_app/core/providers/node_data_providers.dart';
@@ -19,13 +20,17 @@ class MempoolDetailsScreen extends ConsumerStatefulWidget {
 }
 
 class _MempoolDetailsScreenState extends ConsumerState<MempoolDetailsScreen> {
+  final _appSleepService = AppSleepService.instance;
   Timer? _autoTimer;
   bool _refreshing = false;
 
   @override
   void initState() {
     super.initState();
+    _appSleepService.addListener(_handleAppSleepChanged);
+    if (_appSleepService.isSleeping) return;
     _autoTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
       if (mounted && !_refreshing) {
         _refresh();
       }
@@ -34,6 +39,7 @@ class _MempoolDetailsScreenState extends ConsumerState<MempoolDetailsScreen> {
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _autoTimer?.cancel();
     super.dispose();
   }
@@ -48,6 +54,24 @@ class _MempoolDetailsScreenState extends ConsumerState<MempoolDetailsScreen> {
         _refreshing = false;
       }
     }
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _autoTimer?.cancel();
+      _autoTimer = null;
+      return;
+    }
+
+    _autoTimer?.cancel();
+    _autoTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
+      if (mounted && !_refreshing) {
+        _refresh();
+      }
+    });
+    unawaited(_refresh());
   }
 
   @override

--- a/lib/features/node/screens/node_status_produced_blocks_screen.dart
+++ b/lib/features/node/screens/node_status_produced_blocks_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:crypto_mobile_app/core/config/app_router.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/core/utils/utils.dart';
 import 'package:crypto_mobile_app/core/widgets/app_bar.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
@@ -26,6 +27,7 @@ class NodeStatusProducedBlocksScreen extends ConsumerStatefulWidget {
 
 class _NodeStatusProducedBlocksScreenState
     extends ConsumerState<NodeStatusProducedBlocksScreen> {
+  final _appSleepService = AppSleepService.instance;
   Timer? _autoTimer;
   bool _refreshing = false;
   bool _active = true;
@@ -33,12 +35,14 @@ class _NodeStatusProducedBlocksScreenState
   @override
   void initState() {
     super.initState();
+    _appSleepService.addListener(_handleAppSleepChanged);
     _active = _isActiveTab();
     if (_active) _startTimer();
   }
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _autoTimer?.cancel();
     super.dispose();
   }
@@ -52,8 +56,10 @@ class _NodeStatusProducedBlocksScreenState
   }
 
   void _startTimer() {
+    if (_appSleepService.isSleeping) return;
     _autoTimer?.cancel();
     _autoTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
       if (mounted && _active && !_refreshing) {
         _refresh();
       }
@@ -63,6 +69,19 @@ class _NodeStatusProducedBlocksScreenState
   void _stopTimer() {
     _autoTimer?.cancel();
     _autoTimer = null;
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _stopTimer();
+      return;
+    }
+
+    if (_active) {
+      _startTimer();
+      unawaited(_refresh());
+    }
   }
 
   Future<void> _refresh() async {

--- a/lib/features/node/screens/node_status_screen.dart
+++ b/lib/features/node/screens/node_status_screen.dart
@@ -15,6 +15,7 @@ import 'package:crypto_mobile_app/core/widgets/app_progress_bar.dart';
 import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/core/providers/node_data_providers.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
 import 'package:device_info_plus/device_info_plus.dart';
@@ -34,6 +35,7 @@ class NodeStatusScreen extends ConsumerStatefulWidget {
 
 class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
   final _scrollFraction = ValueNotifier<double>(0.0);
+  final _appSleepService = AppSleepService.instance;
 
   // State flags
   bool _refreshing = false;
@@ -58,6 +60,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
   @override
   void initState() {
     super.initState();
+    _appSleepService.addListener(_handleAppSleepChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeData();
       _startTimer();
@@ -79,6 +82,7 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _scrollFraction.dispose();
     _autoTimer?.cancel();
     super.dispose();
@@ -205,8 +209,10 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
   // ============== TIMER MANAGEMENT ==============
 
   void _startTimer() {
+    if (_appSleepService.isSleeping) return;
     _autoTimer?.cancel();
     _autoTimer = Timer.periodic(const Duration(seconds: 2), (_) {
+      if (_appSleepService.isSleeping) return;
       if (mounted && _active && !_refreshing) {
         _refresh();
       }
@@ -216,6 +222,19 @@ class _NodeStatusScreenState extends ConsumerState<NodeStatusScreen> {
   void _stopTimer() {
     _autoTimer?.cancel();
     _autoTimer = null;
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _stopTimer();
+      return;
+    }
+
+    if (_active) {
+      _startTimer();
+      unawaited(_refresh());
+    }
   }
 
   // ============== BUILD ==============

--- a/lib/features/node/screens/node_won_slots_screen.dart
+++ b/lib/features/node/screens/node_won_slots_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:crypto_mobile_app/core/widgets/app_card.dart';
 import 'package:crypto_mobile_app/core/providers/node_data_providers.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_radii.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_sizing.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_spacing.dart';
@@ -49,13 +50,17 @@ class NodeWonSlotsScreen extends ConsumerStatefulWidget {
 }
 
 class _NodeWonSlotsScreenState extends ConsumerState<NodeWonSlotsScreen> {
+  final _appSleepService = AppSleepService.instance;
   Timer? _autoTimer;
   bool _refreshing = false;
 
   @override
   void initState() {
     super.initState();
+    _appSleepService.addListener(_handleAppSleepChanged);
+    if (_appSleepService.isSleeping) return;
     _autoTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
       if (mounted && !_refreshing) {
         _refresh();
       }
@@ -64,6 +69,7 @@ class _NodeWonSlotsScreenState extends ConsumerState<NodeWonSlotsScreen> {
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _autoTimer?.cancel();
     super.dispose();
   }
@@ -81,6 +87,24 @@ class _NodeWonSlotsScreenState extends ConsumerState<NodeWonSlotsScreen> {
         _refreshing = false;
       }
     }
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _autoTimer?.cancel();
+      _autoTimer = null;
+      return;
+    }
+
+    _autoTimer?.cancel();
+    _autoTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
+      if (mounted && !_refreshing) {
+        _refresh();
+      }
+    });
+    unawaited(_refresh());
   }
 
   @override

--- a/lib/features/node/screens/slot_assignments_screen.dart
+++ b/lib/features/node/screens/slot_assignments_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:crypto_mobile_app/core/providers/produced_blocks_provider.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 import 'package:crypto_mobile_app/core/config/app_router.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:go_router/go_router.dart';
@@ -44,6 +45,7 @@ class _ParsedItem {
 }
 
 class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
+  final _appSleepService = AppSleepService.instance;
   _Filter _selected = _Filter.wonSlots;
   bool _isInitialFilter = true;
   Timer? _autoRefreshTimer;
@@ -55,6 +57,7 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
   @override
   void initState() {
     super.initState();
+    _appSleepService.addListener(_handleAppSleepChanged);
     final filters = (widget.args?['filters'] as List?)?.cast<String>();
     if (filters != null && filters.isNotEmpty) {
       if (filters.contains('all')) {
@@ -81,13 +84,16 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _autoRefreshTimer?.cancel();
     super.dispose();
   }
 
   void _startAutoRefresh() {
+    if (_appSleepService.isSleeping) return;
     _autoRefreshTimer?.cancel();
     _autoRefreshTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
       if (!mounted || _refreshing) return;
       _refreshSummary();
     });
@@ -115,6 +121,18 @@ class _SlotAssignmentsScreenState extends ConsumerState<SlotAssignmentsScreen> {
     } finally {
       _refreshing = false;
     }
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _autoRefreshTimer?.cancel();
+      _autoRefreshTimer = null;
+      return;
+    }
+
+    _startAutoRefresh();
+    unawaited(_refreshSummary());
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/features/node/screens/widgets/node_status_summary_modal.dart
+++ b/lib/features/node/screens/widgets/node_status_summary_modal.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:crypto_mobile_app/core/config/app_router.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 
 /// Shows a bottom sheet with node status summary
@@ -27,6 +28,7 @@ class NodeStatusSummaryModal extends ConsumerStatefulWidget {
 
 class _NodeStatusSummaryModalState
     extends ConsumerState<NodeStatusSummaryModal> {
+  final _appSleepService = AppSleepService.instance;
   Timer? _refreshTimer;
   double? _blocksPerSecond;
   int? _previousBlockHeight;
@@ -35,8 +37,11 @@ class _NodeStatusSummaryModalState
   @override
   void initState() {
     super.initState();
+    _appSleepService.addListener(_handleAppSleepChanged);
     // Auto-refresh every 3 seconds while modal is open
+    if (_appSleepService.isSleeping) return;
     _refreshTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
       if (mounted) {
         ref.read(nodeStatusProvider.notifier).refresh();
       }
@@ -45,8 +50,27 @@ class _NodeStatusSummaryModalState
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _refreshTimer?.cancel();
     super.dispose();
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _refreshTimer?.cancel();
+      _refreshTimer = null;
+      return;
+    }
+
+    _refreshTimer?.cancel();
+    _refreshTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
+      if (mounted) {
+        ref.read(nodeStatusProvider.notifier).refresh();
+      }
+    });
+    ref.read(nodeStatusProvider.notifier).refresh();
   }
 
   @override

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -447,6 +447,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   Future<void> _resetChallengeState() => resetChallengeState(ref, context);
 
+  Future<void> _toggleAppSleep(bool value) async {
+    await _appSleepService.setEnabled(value);
+    if (!mounted) return;
+    setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -458,6 +464,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final perfState = ref.watch(perfBenchmarkProvider);
     final facematchStrict =
         zkSettings.whenOrNull(data: (s) => s.facematchStrict) ?? true;
+    final appSleepEnabled = _appSleepService.isEnabled;
     final hasCurrentBenchmarkRun = perfState.isStartingRun ||
         perfState.isRunning ||
         (perfState.activeRunId != null && !perfState.hasFinishedRun);
@@ -488,7 +495,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               GeneralSettingsSection(
                 currentThemeLabel: _themeModeLabel(themeMode),
                 buildInfoSubtitle: _buildInfoSubtitle,
+                appSleepEnabled: appSleepEnabled,
                 onAppearanceTap: _showThemePicker,
+                onAppSleepChanged: _toggleAppSleep,
                 onBuildInfoTap: _showBuildInfo,
                 onBuildInfoLongPress: _onVersionLongPress,
               ),

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -11,6 +11,7 @@ import 'package:crypto_mobile_app/core/providers/challenges_provider.dart';
 import 'package:crypto_mobile_app/core/providers/points_breakdown_provider.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/core/services/epoch_slot_scheduler_service.dart';
 import 'package:crypto_mobile_app/core/services/ios_foreground_keepalive_service.dart';
@@ -60,6 +61,7 @@ class SettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  final _appSleepService = AppSleepService.instance;
   bool _hasPermissions = false;
   bool _batteryOptDisabled = false;
   String? _deviceManufacturer;
@@ -74,6 +76,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   @override
   void initState() {
     super.initState();
+    _appSleepService.addListener(_handleAppSleepChanged);
     _checkStatus();
     _loadPackageInfo();
     _active = _isActiveTab();
@@ -99,6 +102,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _autoTimer?.cancel();
     _longPressTimer?.cancel();
     super.dispose();
@@ -113,8 +117,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   }
 
   void _startTimer() {
+    if (_appSleepService.isSleeping) return;
     _autoTimer?.cancel();
     _autoTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      if (_appSleepService.isSleeping) return;
       if (mounted && _active && !_refreshing) {
         _checkStatus();
       }
@@ -124,6 +130,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   void _stopTimer() {
     _autoTimer?.cancel();
     _autoTimer = null;
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _stopTimer();
+      return;
+    }
+
+    if (_active) {
+      _startTimer();
+      unawaited(_checkStatus());
+    }
   }
 
   Future<void> _checkStatus() async {

--- a/lib/features/settings/widgets/general_settings_section.dart
+++ b/lib/features/settings/widgets/general_settings_section.dart
@@ -9,7 +9,9 @@ class GeneralSettingsSection extends StatelessWidget {
     super.key,
     required this.currentThemeLabel,
     required this.buildInfoSubtitle,
+    required this.appSleepEnabled,
     required this.onAppearanceTap,
+    required this.onAppSleepChanged,
     required this.onBuildInfoTap,
     required this.onBuildInfoLongPress,
   });
@@ -19,8 +21,10 @@ class GeneralSettingsSection extends StatelessWidget {
 
   /// Short build info string like "v1.2.3 · abc1234".
   final String buildInfoSubtitle;
+  final bool appSleepEnabled;
 
   final VoidCallback onAppearanceTap;
+  final ValueChanged<bool> onAppSleepChanged;
   final VoidCallback onBuildInfoTap;
   final GestureLongPressCallback onBuildInfoLongPress;
 
@@ -48,6 +52,21 @@ class GeneralSettingsSection extends StatelessWidget {
                   ),
                 ),
                 onTap: onAppearanceTap,
+              ),
+              SwitchListTile(
+                secondary: const Icon(Symbols.bedtime_sharp),
+                title: Text(
+                  AppLocalizations.of(context).settingsAutomaticAppSleep,
+                ),
+                subtitle: Text(
+                  appSleepEnabled
+                      ? AppLocalizations.of(context)
+                          .settingsAutomaticAppSleepEnabled
+                      : AppLocalizations.of(context)
+                          .settingsAutomaticAppSleepDisabled,
+                ),
+                value: appSleepEnabled,
+                onChanged: onAppSleepChanged,
               ),
               GestureDetector(
                 onLongPress: onBuildInfoLongPress,

--- a/lib/features/wallet/screens/wallet_screen.dart
+++ b/lib/features/wallet/screens/wallet_screen.dart
@@ -11,6 +11,7 @@ import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/core/config/app_router.dart';
 import 'package:crypto_mobile_app/core/services/explorer_service.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/features/wallet/models/transaction_model.dart';
 import 'package:crypto_mobile_app/features/wallet/screens/wallet_delegates.dart';
 import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
@@ -33,6 +34,7 @@ class _WalletScreenState extends ConsumerState<WalletScreen>
   final _scrollFraction = ValueNotifier<double>(0.0);
   String _address = 'Loading...';
   late final AnimationController _fabAnimController;
+  final _appSleepService = AppSleepService.instance;
   bool _fabOpen = false;
 
   @override
@@ -42,6 +44,7 @@ class _WalletScreenState extends ConsumerState<WalletScreen>
       vsync: this,
       duration: const Duration(milliseconds: 250),
     );
+    _appSleepService.addListener(_handleAppSleepChanged);
     _startAutoRefresh();
 
     // Resolve address when accounts provider loads or changes.
@@ -68,6 +71,7 @@ class _WalletScreenState extends ConsumerState<WalletScreen>
 
   @override
   void dispose() {
+    _appSleepService.removeListener(_handleAppSleepChanged);
     _fabAnimController.dispose();
     _scrollFraction.dispose();
     _refreshTimer?.cancel();
@@ -142,8 +146,10 @@ class _WalletScreenState extends ConsumerState<WalletScreen>
   }
 
   void _startAutoRefresh() {
+    if (_appSleepService.isSleeping) return;
     _refreshTimer?.cancel();
     _refreshTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
+      if (_appSleepService.isSleeping) return;
       // Only refresh if currently on wallet tab (index 1)
       final currentTab = ref.read(currentHomeTabProvider);
       if (currentTab == HomeTab.wallet) {
@@ -162,6 +168,18 @@ class _WalletScreenState extends ConsumerState<WalletScreen>
     ]);
 
     _startAutoRefresh();
+  }
+
+  void _handleAppSleepChanged() {
+    if (!mounted) return;
+    if (_appSleepService.isSleeping) {
+      _refreshTimer?.cancel();
+      _refreshTimer = null;
+      return;
+    }
+
+    _startAutoRefresh();
+    unawaited(_onRefresh());
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,9 @@ import 'dart:convert';
 
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/services/app_reset_service.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
+import 'package:crypto_mobile_app/core/services/app_sleep_state_store.dart';
+import 'package:crypto_mobile_app/features/app_sleep/screens/app_sleep_screen.dart';
 import 'package:crypto_mobile_app/features/metrics/metrics_reporting_service.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/features/zkpassport/providers/zkpassport_flow_provider.dart';
@@ -10,6 +13,7 @@ import 'package:crypto_mobile_app/core/providers/accounts_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:crypto_mobile_app/core/bootstrap/app_bootstrap.dart';
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
@@ -64,8 +68,17 @@ Future<void> headlessMain() async {
   // Initialize Flutter binding manually (no Sentry in headless mode)
   WidgetsFlutterBinding.ensureInitialized();
   try {
+    await AppSleepStateStore.load();
+    if (AppSleepStateStore.isSleeping) {
+      await LoggingService.initialize();
+      final log = LoggingService.instance.withTag('usernode/HeadlessBootstrap');
+      log.info('Skipping headless bootstrap while app sleep is active');
+      return;
+    }
+
     final boot = await AppBootstrap.initNonUi(
       logTag: 'usernode/HeadlessBootstrap',
+      registerLifecycleObserver: false,
     );
     final log = boot.log;
     final container = boot.container;
@@ -343,13 +356,16 @@ class _AppWrapper extends ConsumerStatefulWidget {
 class _AppWrapperState extends ConsumerState<_AppWrapper>
     with WidgetsBindingObserver {
   bool _versionCheckShown = false;
+  bool _wasSleeping = false;
+  final _appSleepService = AppSleepService.instance;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    // Start periodic version checks
-    AppVersionCheck.instance.startPeriodicChecks(_handleVersionCheckResult);
+    _wasSleeping = _appSleepService.isSleeping;
+    _appSleepService.addListener(_handleAppSleepChanged);
+    _syncVersionChecks();
     // Check version after first frame
     WidgetsBinding.instance.addPostFrameCallback((_) => _checkInitialVersion());
   }
@@ -388,6 +404,7 @@ class _AppWrapperState extends ConsumerState<_AppWrapper>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _appSleepService.removeListener(_handleAppSleepChanged);
     AppVersionCheck.instance.stopPeriodicChecks();
     super.dispose();
   }
@@ -396,6 +413,29 @@ class _AppWrapperState extends ConsumerState<_AppWrapper>
     if (!mounted || _versionCheckShown) return;
     _versionCheckShown = true;
     showUpdateDialog(appNavigatorKey, result);
+  }
+
+  void _handleAppSleepChanged() {
+    final isSleeping = _appSleepService.isSleeping;
+    _syncVersionChecks();
+    if (_wasSleeping && !isSleeping) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final navContext = appNavigatorKey.currentContext;
+        if (navContext == null) return;
+        GoRouter.of(navContext).go(AppRoutes.home);
+      });
+    }
+    _wasSleeping = isSleeping;
+  }
+
+  void _syncVersionChecks() {
+    if (_appSleepService.isSleeping) {
+      AppVersionCheck.instance.stopPeriodicChecks();
+      return;
+    }
+
+    AppVersionCheck.instance.startPeriodicChecks(_handleVersionCheckResult);
   }
 
   @override
@@ -407,11 +447,45 @@ class _AppWrapperState extends ConsumerState<_AppWrapper>
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        Positioned.fill(child: widget.child ?? const SizedBox.shrink()),
-        const ClockDriftWarningOverlay(),
-      ],
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: (_) {
+        _appSleepService.recordUserInteraction(source: 'pointer_down');
+      },
+      onPointerMove: (_) {
+        _appSleepService.recordUserInteraction(source: 'pointer_move');
+      },
+      onPointerSignal: (_) {
+        _appSleepService.recordUserInteraction(source: 'pointer_signal');
+      },
+      child: ListenableBuilder(
+        listenable: _appSleepService,
+        builder: (context, child) {
+          final snapshot = _appSleepService.snapshot;
+          final showSleepScreen = snapshot.isSleeping &&
+              snapshot.lifecycleState == AppLifecycleState.resumed;
+          return TickerMode(
+            enabled: !_appSleepService.isSleeping,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                child ?? const SizedBox.shrink(),
+                const ClockDriftWarningOverlay(),
+                if (showSleepScreen)
+                  AppSleepScreen(
+                    snapshot: snapshot,
+                    onWakeRequested: () {
+                      _appSleepService.recordUserInteraction(
+                        source: 'sleep_screen',
+                      );
+                    },
+                  ),
+              ],
+            ),
+          );
+        },
+        child: widget.child ?? const SizedBox.shrink(),
+      ),
     );
   }
 }

--- a/test/core/services/app_sleep_service_test.dart
+++ b/test/core/services/app_sleep_service_test.dart
@@ -1,0 +1,190 @@
+import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('sleeps after idle timeout and wakes on user interaction',
+      (tester) async {
+    final sleepReasons = <AppSleepReason>[];
+    final wakeReasons = <String>[];
+    final persistedValues = <bool>[];
+
+    final service = AppSleepService.forTest(
+      idleTimeout: const Duration(seconds: 1),
+      onSleep: (reason) async => sleepReasons.add(reason),
+      onWake: (reason) async => wakeReasons.add(reason),
+      persistSleepState: (value) async => persistedValues.add(value),
+    );
+
+    await service.initializeForInteractiveApp();
+    expect(service.isSleeping, isFalse);
+
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(service.isSleeping, isTrue);
+    expect(sleepReasons, [AppSleepReason.idleTimeout]);
+
+    service.recordUserInteraction(source: 'test_tap');
+    await tester.pump();
+
+    expect(service.isSleeping, isFalse);
+    expect(wakeReasons, ['user_interaction:test_tap']);
+    expect(persistedValues, [false, true, false]);
+
+    service.dispose();
+    await tester.pump();
+  });
+
+  testWidgets('lifecycle inactive sleeps immediately and resumed wakes',
+      (tester) async {
+    final sleepReasons = <AppSleepReason>[];
+    final wakeReasons = <String>[];
+
+    final service = AppSleepService.forTest(
+      onSleep: (reason) async => sleepReasons.add(reason),
+      onWake: (reason) async => wakeReasons.add(reason),
+      persistSleepState: (_) async {},
+      initialLifecycleState: AppLifecycleState.resumed,
+    );
+
+    await service.initializeForInteractiveApp();
+    await service.handleLifecycleStateChanged(AppLifecycleState.inactive);
+
+    expect(service.isSleeping, isTrue);
+    expect(sleepReasons, [AppSleepReason.lifecycleInactive]);
+
+    await service.handleLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    expect(service.isSleeping, isFalse);
+    expect(wakeReasons, ['lifecycle_resumed']);
+
+    service.dispose();
+    await tester.pump();
+  });
+
+  testWidgets('idle timeout does not sleep while wakelock is held',
+      (tester) async {
+    final sleepReasons = <AppSleepReason>[];
+    var wakelockHeld = true;
+
+    final service = AppSleepService.forTest(
+      idleTimeout: const Duration(seconds: 1),
+      onSleep: (reason) async => sleepReasons.add(reason),
+      onWake: (_) async {},
+      persistSleepState: (_) async {},
+      isWakelockHeld: () async => wakelockHeld,
+    );
+
+    await service.initializeForInteractiveApp();
+
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(service.isSleeping, isFalse);
+    expect(sleepReasons, isEmpty);
+
+    wakelockHeld = false;
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(service.isSleeping, isTrue);
+    expect(sleepReasons, [AppSleepReason.idleTimeout]);
+
+    service.dispose();
+    await tester.pump();
+  });
+
+  testWidgets('lifecycle inactive does not sleep while wakelock is held',
+      (tester) async {
+    final sleepReasons = <AppSleepReason>[];
+
+    final service = AppSleepService.forTest(
+      onSleep: (reason) async => sleepReasons.add(reason),
+      onWake: (_) async {},
+      persistSleepState: (_) async {},
+      isWakelockHeld: () async => true,
+      initialLifecycleState: AppLifecycleState.resumed,
+    );
+
+    await service.initializeForInteractiveApp();
+    await service.handleLifecycleStateChanged(AppLifecycleState.inactive);
+
+    expect(service.isSleeping, isFalse);
+    expect(sleepReasons, isEmpty);
+
+    service.dispose();
+    await tester.pump();
+  });
+
+  testWidgets('inactive sleep retries until wakelock is released',
+      (tester) async {
+    final sleepReasons = <AppSleepReason>[];
+    var wakelockHeld = true;
+
+    final service = AppSleepService.forTest(
+      onSleep: (reason) async => sleepReasons.add(reason),
+      onWake: (_) async {},
+      persistSleepState: (_) async {},
+      isWakelockHeld: () async => wakelockHeld,
+      inactiveWakelockRetryInterval: const Duration(seconds: 1),
+      initialLifecycleState: AppLifecycleState.resumed,
+    );
+
+    await service.initializeForInteractiveApp();
+    await service.handleLifecycleStateChanged(AppLifecycleState.inactive);
+
+    expect(service.isSleeping, isFalse);
+    expect(sleepReasons, isEmpty);
+
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(service.isSleeping, isFalse);
+    expect(sleepReasons, isEmpty);
+
+    wakelockHeld = false;
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(service.isSleeping, isTrue);
+    expect(sleepReasons, [AppSleepReason.lifecycleInactive]);
+
+    service.dispose();
+    await tester.pump();
+  });
+
+  testWidgets('inactive sleep retry stops once app is no longer inactive',
+      (tester) async {
+    final sleepReasons = <AppSleepReason>[];
+    var wakelockHeld = true;
+
+    final service = AppSleepService.forTest(
+      onSleep: (reason) async => sleepReasons.add(reason),
+      onWake: (_) async {},
+      persistSleepState: (_) async {},
+      isWakelockHeld: () async => wakelockHeld,
+      inactiveWakelockRetryInterval: const Duration(seconds: 1),
+      initialLifecycleState: AppLifecycleState.resumed,
+    );
+
+    await service.initializeForInteractiveApp();
+    await service.handleLifecycleStateChanged(AppLifecycleState.inactive);
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
+    await service.handleLifecycleStateChanged(AppLifecycleState.resumed);
+    wakelockHeld = false;
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+
+    expect(service.isSleeping, isFalse);
+    expect(sleepReasons, isEmpty);
+
+    service.dispose();
+    await tester.pump();
+  });
+}

--- a/test/core/services/app_sleep_service_test.dart
+++ b/test/core/services/app_sleep_service_test.dart
@@ -187,4 +187,87 @@ void main() {
     service.dispose();
     await tester.pump();
   });
+
+  testWidgets('automatic sleep stays off until it is enabled', (tester) async {
+    final sleepReasons = <AppSleepReason>[];
+    final persistedEnabledValues = <bool>[];
+
+    final service = AppSleepService.forTest(
+      idleTimeout: const Duration(seconds: 1),
+      onSleep: (reason) async => sleepReasons.add(reason),
+      onWake: (_) async {},
+      persistSleepState: (_) async {},
+      persistSleepEnabled: (value) async => persistedEnabledValues.add(value),
+      initiallyEnabled: false,
+    );
+
+    await service.initializeForInteractiveApp();
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+
+    expect(service.isSleeping, isFalse);
+    expect(sleepReasons, isEmpty);
+
+    await service.setEnabled(true);
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(service.isSleeping, isTrue);
+    expect(sleepReasons, [AppSleepReason.idleTimeout]);
+    expect(persistedEnabledValues, [true]);
+
+    service.dispose();
+    await tester.pump();
+  });
+
+  testWidgets('automatic sleep disabled ignores lifecycle sleep triggers',
+      (tester) async {
+    final sleepReasons = <AppSleepReason>[];
+
+    final service = AppSleepService.forTest(
+      onSleep: (reason) async => sleepReasons.add(reason),
+      onWake: (_) async {},
+      persistSleepState: (_) async {},
+      initiallyEnabled: false,
+    );
+
+    await service.initializeForInteractiveApp();
+    await service.handleLifecycleStateChanged(AppLifecycleState.inactive);
+
+    expect(service.isSleeping, isFalse);
+    expect(sleepReasons, isEmpty);
+
+    service.dispose();
+    await tester.pump();
+  });
+
+  testWidgets('disabling automatic sleep wakes a sleeping app', (tester) async {
+    final wakeReasons = <String>[];
+    final persistedEnabledValues = <bool>[];
+
+    final service = AppSleepService.forTest(
+      idleTimeout: const Duration(seconds: 1),
+      onSleep: (_) async {},
+      onWake: (reason) async => wakeReasons.add(reason),
+      persistSleepState: (_) async {},
+      persistSleepEnabled: (value) async => persistedEnabledValues.add(value),
+    );
+
+    await service.initializeForInteractiveApp();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(service.isSleeping, isTrue);
+
+    await service.setEnabled(false);
+    await tester.pump();
+
+    expect(service.isSleeping, isFalse);
+    expect(wakeReasons, ['automatic_sleep_disabled']);
+    expect(persistedEnabledValues, [false]);
+
+    service.dispose();
+    await tester.pump();
+  });
 }


### PR DESCRIPTION
This is to prevent massive battery and bandwidth drain when the node/app is running 24/7, reporting metrics, observability.