### PR TITLE
fix(explorer): migrate defaults from alpha1 to testnet-explorer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -238,13 +238,13 @@ EPOCH_MONITOR_BASE_INTERVAL_SECONDS=900
 # =============================================================================
 # Primary explorer API URL for balance and transaction data
 # Used as the first choice for fetching wallet data from external explorer
-# Default: https://alpha1.usernodelabs.org/explorer
-EXPLORER_PRIMARY_URL=https://alpha1.usernodelabs.org/explorer
+# Default: https://testnet-explorer.usernodelabs.org/api
+EXPLORER_PRIMARY_URL=https://testnet-explorer.usernodelabs.org/api
 
 # Secondary explorer API URL for fallback when primary is unavailable
 # Used when the primary explorer API fails or times out
-# Default: https://alpha1.usernodelabs.org/explorer  
-EXPLORER_SECONDARY_URL=https://alpha1.usernodelabs.org/explorer
+# Default: https://testnet-explorer.usernodelabs.org/api
+EXPLORER_SECONDARY_URL=https://testnet-explorer.usernodelabs.org/api
 
 # Chain ID is automatically detected from running node status
 # No configuration needed - uses the actual blockchain network chain ID

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -269,14 +269,19 @@ class AppConfig {
     defaultValue: false,
   );
 
-  // Explorer API configuration
+  // Explorer API configuration. Both default to the same canonical
+  // testnet explorer host; the primary/secondary split is a fallback
+  // mechanism for ops to point one at a backup if/when one exists. The
+  // legacy alpha1/alpha2.usernodelabs.org hosts have been retired (502
+  // / 503); the path prefix moved from /explorer/api to /api in the same
+  // migration.
   static const String primaryExplorerUrl = String.fromEnvironment(
     'EXPLORER_PRIMARY_URL',
-    defaultValue: 'https://alpha1.usernodelabs.org/api',
+    defaultValue: 'https://testnet-explorer.usernodelabs.org/api',
   );
   static const String secondaryExplorerUrl = String.fromEnvironment(
     'EXPLORER_SECONDARY_URL',
-    defaultValue: 'https://alpha1.usernodelabs.org/api',
+    defaultValue: 'https://testnet-explorer.usernodelabs.org/api',
   );
   static const int explorerTimeoutSeconds = int.fromEnvironment(
     'EXPLORER_TIMEOUT_SECONDS',


### PR DESCRIPTION
The legacy alpha1/alpha2.usernodelabs.org explorer hosts have been retired (alpha1 returns 502, alpha2 returns 503). Update the in-code EXPLORER_PRIMARY_URL and EXPLORER_SECONDARY_URL defaults plus the .env.example template to point at the new canonical host testnet-explorer.usernodelabs.org/api.

Both primary and secondary default to the same host because no public secondary exists yet — the split is preserved so ops can override one without the other when a backup explorer comes online. The .env.example also still listed the older /explorer path prefix; corrected to /api which is what the new host serves (the in-code defaults already moved to /api in a prior change).

Verified the new explorer's API contract is identical to the old one (/active_chain and POST /<chain>/transactions return the same shapes), so no caller-side code changes are required.