### PR TITLE
fix(challenges): render CTA button on challenge detail page

### DIFF
--- a/lib/core/models/leaderboard_api_models.dart
+++ b/lib/core/models/leaderboard_api_models.dart
@@ -7,6 +7,17 @@
 // ---------------------------------------------------------------------------
 
 /// Coerces a JSON value that may be [int], [double], or numeric [String] → [int].
+/// Returns [raw] only when it is a non-empty `https://` URL with a host,
+/// otherwise null. Backend-provided links must not introduce non-https
+/// schemes (intent://, file://, javascript:, custom deep-links) into UI
+/// surfaces that launch URLs externally.
+String? _sanitizeHttpsUrl(dynamic raw) {
+  if (raw is! String || raw.isEmpty) return null;
+  final uri = Uri.tryParse(raw);
+  if (uri == null || uri.scheme != 'https' || uri.host.isEmpty) return null;
+  return raw;
+}
+
 int _jsonInt(dynamic v) => v is num ? v.toInt() : int.parse(v as String);
 
 /// Nullable variant.
@@ -221,7 +232,7 @@ class ChallengeDto {
       requirements: json['requirements'] as String?,
       rewardLogic: json['reward_logic'] as String?,
       ctaLabel: json['cta_label'] as String?,
-      ctaLink: json['cta_link'] as String?,
+      ctaLink: _sanitizeHttpsUrl(json['cta_link']),
       scheduleStart: json['schedule_start'] as String?,
       scheduleEnd: json['schedule_end'] as String?,
       enabled: json['enabled'] as bool? ?? false,

--- a/lib/design_system/src/challenge_detail_page.dart
+++ b/lib/design_system/src/challenge_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:crypto_mobile_app/core/widgets/app_card.dart';
 
 import '../tokens/app_radii.dart';
 import '../tokens/app_spacing.dart';
+import 'button.dart';
 import 'challenge_card.dart';
 import 'challenge_category_icon.dart';
 import 'top_app_bar.dart';
@@ -30,6 +31,8 @@ class ChallengeDetailPage extends StatelessWidget {
     this.totalRewardHeading,
     this.totalRewardBody,
     this.onBackTap,
+    this.ctaLabel,
+    this.onCtaTap,
   });
 
   /// Challenge title, e.g. "Produce Every Block".
@@ -62,49 +65,75 @@ class ChallengeDetailPage extends StatelessWidget {
   /// Called when the back button is tapped.
   final VoidCallback? onBackTap;
 
+  /// Label for the optional bottom CTA button. When null (or [onCtaTap] is
+  /// null), no CTA button is rendered.
+  final String? ctaLabel;
+
+  /// Called when the bottom CTA button is tapped. When null (or [ctaLabel] is
+  /// null), no CTA button is rendered.
+  final VoidCallback? onCtaTap;
+
   @override
   Widget build(BuildContext context) {
     final spacing = Theme.of(context).extension<AppSpacing>()!;
+    final hasCta = ctaLabel != null && ctaLabel!.isNotEmpty && onCtaTap != null;
 
-    return CustomScrollView(
-      slivers: [
-        TopAppBar(
-          title: title,
-          size: TopAppBarSize.large,
-          subtitle: dateRange,
-          image: ChallengeCategoryIcon(category: category),
-          onLeadingTap: onBackTap,
-        ),
-        SliverPadding(
-          padding: EdgeInsets.symmetric(horizontal: spacing.space16),
-          sliver: SliverToBoxAdapter(
-            child: Padding(
-              padding: EdgeInsets.only(bottom: spacing.space32),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  if (rewardCard != null) ...[
-                    rewardCard!,
-                    SizedBox(height: spacing.space16),
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          TopAppBar(
+            title: title,
+            size: TopAppBarSize.large,
+            subtitle: dateRange,
+            image: ChallengeCategoryIcon(category: category),
+            onLeadingTap: onBackTap,
+          ),
+          SliverPadding(
+            padding: EdgeInsets.symmetric(horizontal: spacing.space16),
+            sliver: SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.only(bottom: spacing.space32),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (rewardCard != null) ...[
+                      rewardCard!,
+                      SizedBox(height: spacing.space16),
+                    ],
+                    if (statusSection != null) ...[
+                      statusSection!,
+                      SizedBox(height: spacing.space16),
+                    ],
+                    _SectionsCard(sections: sections),
+                    if (totalRewardHeading != null) ...[
+                      SizedBox(height: spacing.space16),
+                      _TotalRewardCard(
+                        heading: totalRewardHeading!,
+                        body: totalRewardBody ?? '',
+                      ),
+                    ],
                   ],
-                  if (statusSection != null) ...[
-                    statusSection!,
-                    SizedBox(height: spacing.space16),
-                  ],
-                  _SectionsCard(sections: sections),
-                  if (totalRewardHeading != null) ...[
-                    SizedBox(height: spacing.space16),
-                    _TotalRewardCard(
-                      heading: totalRewardHeading!,
-                      body: totalRewardBody ?? '',
-                    ),
-                  ],
-                ],
+                ),
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
+      bottomNavigationBar: hasCta
+          ? SafeArea(
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: spacing.space16,
+                  vertical: spacing.space12,
+                ),
+                child: Button(
+                  label: ctaLabel!,
+                  onTap: onCtaTap,
+                  variant: ButtonVariant.primary,
+                ),
+              ),
+            )
+          : null,
     );
   }
 }

--- a/lib/design_system/src/challenge_detail_page.dart
+++ b/lib/design_system/src/challenge_detail_page.dart
@@ -16,6 +16,8 @@ typedef ChallengeDetailSection = ({String title, String body});
 ///
 /// Renders a [TopAppBar] (large) with category icon, title, and subtitle,
 /// followed by a reward card, description sections, and a total reward card.
+/// When [ctaLabel] and [onCtaTap] are both provided, also renders a pinned
+/// primary CTA button in the bottom navigation bar.
 ///
 /// This is a presentation-only widget: all data comes through constructor
 /// parameters. The feature screen in `lib/features/` wires state to this widget.

--- a/lib/design_system/widgetbook/challenge_detail_page_use_case.dart
+++ b/lib/design_system/widgetbook/challenge_detail_page_use_case.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
 
 import '../src/challenge_card.dart';
@@ -134,41 +133,53 @@ WidgetbookComponent challengeDetailPageComponent() {
                 'Base reward: up to 5,000 pts based on success rate.\nRank bonus: up to 1,500 pts for top 3 producers.',
           );
 
-          return Scaffold(
-            body: ChallengeDetailPage(
-              title: title,
-              category: category,
-              dateRange: dateRange,
-              rewardCard: showRewardCard
-                  ? ChallengeRewardCard(
-                      category: category,
-                      totalEarned: totalEarned,
-                      data: rewardData,
-                      epochSectionLabel: showEpoch ? epochSectionLabel : null,
-                      epochEarned: showEpoch ? epochEarned : null,
-                      epochLabel: showEpoch ? epochLabel : null,
-                    )
-                  : null,
-              sections: const [
-                (
-                  title: 'The Why',
-                  body:
-                      'Your score is based on how reliably your node produces blocks when assigned. This measures your contribution to network liveness and security.',
-                ),
-                (
-                  title: 'Task',
-                  body:
-                      'Discover block assignments via the Explorer, and produce as many as you can. Your node must be online and synced to receive assignments.',
-                ),
-                (
-                  title: 'Requirements',
-                  body:
-                      'Your score is based on the ratio of blocks produced vs blocks assigned. A node that produces 98 out of 100 assigned blocks gets a 98% success rate.',
-                ),
-              ],
-              totalRewardHeading: totalRewardHeading,
-              totalRewardBody: totalRewardBody,
-            ),
+          final showCta = context.knobs.boolean(
+            label: 'Show CTA Button',
+            initialValue: false,
+          );
+
+          final ctaLabel = showCta
+              ? context.knobs.string(
+                  label: 'CTA Label',
+                  initialValue: 'Take survey',
+                )
+              : null;
+
+          return ChallengeDetailPage(
+            title: title,
+            category: category,
+            dateRange: dateRange,
+            rewardCard: showRewardCard
+                ? ChallengeRewardCard(
+                    category: category,
+                    totalEarned: totalEarned,
+                    data: rewardData,
+                    epochSectionLabel: showEpoch ? epochSectionLabel : null,
+                    epochEarned: showEpoch ? epochEarned : null,
+                    epochLabel: showEpoch ? epochLabel : null,
+                  )
+                : null,
+            sections: const [
+              (
+                title: 'The Why',
+                body:
+                    'Your score is based on how reliably your node produces blocks when assigned. This measures your contribution to network liveness and security.',
+              ),
+              (
+                title: 'Task',
+                body:
+                    'Discover block assignments via the Explorer, and produce as many as you can. Your node must be online and synced to receive assignments.',
+              ),
+              (
+                title: 'Requirements',
+                body:
+                    'Your score is based on the ratio of blocks produced vs blocks assigned. A node that produces 98 out of 100 assigned blocks gets a 98% success rate.',
+              ),
+            ],
+            totalRewardHeading: totalRewardHeading,
+            totalRewardBody: totalRewardBody,
+            ctaLabel: ctaLabel,
+            onCtaTap: showCta ? () {} : null,
           );
         },
       ),

--- a/lib/features/challenges/screens/challenge_detail_screen.dart
+++ b/lib/features/challenges/screens/challenge_detail_screen.dart
@@ -12,6 +12,7 @@ import 'package:crypto_mobile_app/core/providers/points_breakdown_provider.dart'
 import 'package:crypto_mobile_app/core/providers/syncing_text_provider.dart';
 import 'package:crypto_mobile_app/core/providers/produced_blocks_provider.dart';
 import 'package:crypto_mobile_app/core/utils/challenge_point_tracker.dart';
+import 'package:crypto_mobile_app/core/utils/url_launcher.dart';
 import 'package:crypto_mobile_app/design_system/src/block_production_status_card.dart';
 import 'package:crypto_mobile_app/design_system/src/challenge_card.dart';
 import 'package:crypto_mobile_app/design_system/src/challenge_detail_page.dart';
@@ -52,21 +53,19 @@ class ChallengeDetailScreen extends ConsumerWidget {
       ChallengePointTracker.record(_trackerKey, challenge.earnedPoints!);
     }
 
-    return Scaffold(
-      body: FutureBuilder<PointDiff?>(
-        future: ChallengePointTracker.getDiffBestEffort(_trackerKey),
-        builder: (context, diffSnapshot) {
-          return _buildPage(
-            context,
-            ref,
-            eb,
-            diffSnapshot.data,
-            latestEpoch,
-            nodeStatus,
-            blocksSummary.asData?.value,
-          );
-        },
-      ),
+    return FutureBuilder<PointDiff?>(
+      future: ChallengePointTracker.getDiffBestEffort(_trackerKey),
+      builder: (context, diffSnapshot) {
+        return _buildPage(
+          context,
+          ref,
+          eb,
+          diffSnapshot.data,
+          latestEpoch,
+          nodeStatus,
+          blocksSummary.asData?.value,
+        );
+      },
     );
   }
 
@@ -86,6 +85,12 @@ class ChallengeDetailScreen extends ConsumerWidget {
       eventSuccessRate: eb?.successRate,
     );
     final isProduceBlocks = isProduceBlocksChallenge(dto);
+    final ctaLabel = dto.ctaLabel;
+    final ctaLink = dto.ctaLink;
+    final hasCta = ctaLabel != null &&
+        ctaLabel.isNotEmpty &&
+        ctaLink != null &&
+        ctaLink.isNotEmpty;
 
     // Reward card visibility rules:
     // - Missed: never shown
@@ -124,6 +129,8 @@ class ChallengeDetailScreen extends ConsumerWidget {
             ).challengeTotalReward(formatRewardText(dto.reward)),
       totalRewardBody: showRewardCard ? null : (dto.rewardLogic ?? ''),
       onBackTap: () => context.pop(),
+      ctaLabel: hasCta ? ctaLabel : null,
+      onCtaTap: hasCta ? () => launchExternalUrl(ctaLink) : null,
     );
   }
 

--- a/test/core/models/leaderboard_api_models_test.dart
+++ b/test/core/models/leaderboard_api_models_test.dart
@@ -247,6 +247,67 @@ void main() {
       expect(c.scheduleEnd, isNull);
       expect(c.completed, true);
     });
+
+    group('cta_link sanitization', () {
+      ChallengeDto parseWithLink(dynamic link) => ChallengeDto.fromJson({
+            'id': 1,
+            'category': 'social',
+            'goal': 'g',
+            'task': 't',
+            'reward': 0,
+            'enabled': true,
+            'completed': false,
+            'cta_link': link,
+          });
+
+      test('preserves https URLs with a host', () {
+        expect(parseWithLink('https://example.com').ctaLink,
+            'https://example.com');
+        expect(parseWithLink('https://example.com/survey?id=1').ctaLink,
+            'https://example.com/survey?id=1');
+      });
+
+      test('rejects http (insecure)', () {
+        expect(parseWithLink('http://example.com').ctaLink, isNull);
+      });
+
+      test('rejects javascript: scheme', () {
+        expect(parseWithLink('javascript:alert(1)').ctaLink, isNull);
+      });
+
+      test('rejects intent:// scheme', () {
+        expect(
+          parseWithLink('intent://foo#Intent;scheme=https;end').ctaLink,
+          isNull,
+        );
+      });
+
+      test('rejects file:// scheme', () {
+        expect(parseWithLink('file:///etc/passwd').ctaLink, isNull);
+      });
+
+      test('rejects data: scheme', () {
+        expect(parseWithLink('data:text/html,<script>').ctaLink, isNull);
+      });
+
+      test('rejects custom deep-link scheme', () {
+        expect(parseWithLink('myapp://action').ctaLink, isNull);
+      });
+
+      test('rejects https without host', () {
+        expect(parseWithLink('https://').ctaLink, isNull);
+      });
+
+      test('rejects empty string', () {
+        expect(parseWithLink('').ctaLink, isNull);
+      });
+
+      test('rejects non-string types', () {
+        expect(parseWithLink(null).ctaLink, isNull);
+        expect(parseWithLink(42).ctaLink, isNull);
+        expect(parseWithLink({'url': 'https://x.com'}).ctaLink, isNull);
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/test/design_system/challenge_detail_page_test.dart
+++ b/test/design_system/challenge_detail_page_test.dart
@@ -170,6 +170,76 @@ void main() {
       expect(find.text('Total Reward Up to 2,000 pts'), findsOneWidget);
     });
 
+    testWidgets('renders CTA button when ctaLabel + onCtaTap provided',
+        (tester) async {
+      await tester.pumpWidget(wrap(
+        ChallengeDetailPage(
+          title: 'Take the survey',
+          category: ChallengeCategory.community,
+          dateRange: 'Community · Feb 1 - Feb 28',
+          sections: const [
+            (title: 'The Why', body: 'Help us shape the roadmap.'),
+          ],
+          ctaLabel: 'Take survey',
+          onCtaTap: () {},
+        ),
+      ));
+
+      expect(find.text('Take survey'), findsOneWidget);
+    });
+
+    testWidgets('hides CTA button when ctaLabel is null', (tester) async {
+      await tester.pumpWidget(wrap(
+        const ChallengeDetailPage(
+          title: 'No CTA',
+          category: ChallengeCategory.community,
+          dateRange: 'Community · Feb 1 - Feb 28',
+          sections: [
+            (title: 'The Why', body: 'No CTA on this one.'),
+          ],
+        ),
+      ));
+
+      expect(find.byType(Button), findsNothing);
+    });
+
+    testWidgets('CTA tap fires onCtaTap callback', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(wrap(
+        ChallengeDetailPage(
+          title: 'Take the survey',
+          category: ChallengeCategory.community,
+          dateRange: 'Community · Feb 1 - Feb 28',
+          sections: const [
+            (title: 'The Why', body: 'Help us shape the roadmap.'),
+          ],
+          ctaLabel: 'Take survey',
+          onCtaTap: () => tapped = true,
+        ),
+      ));
+
+      await tester.tap(find.text('Take survey'));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('hides CTA button when ctaLabel is empty string',
+        (tester) async {
+      await tester.pumpWidget(wrap(
+        ChallengeDetailPage(
+          title: 'Empty CTA',
+          category: ChallengeCategory.community,
+          dateRange: 'Community · Feb 1 - Feb 28',
+          sections: const [
+            (title: 'The Why', body: 'Empty label should not render.'),
+          ],
+          ctaLabel: '',
+          onCtaTap: () {},
+        ),
+      ));
+
+      expect(find.byType(Button), findsNothing);
+    });
+
     testWidgets('renders ChallengeCategoryIcon in app bar', (tester) async {
       await tester.pumpWidget(wrap(
         ChallengeDetailPage(


### PR DESCRIPTION
## Summary
- Wires `ChallengeDto.ctaLabel` / `ctaLink` (already parsed from the leaderboard API) through `ChallengeDetailPage` to a sticky bottom button. Generic challenges (e.g. surveys) now have an actionable CTA in the app, matching the web leaderboard.
- `ChallengeDetailPage` now owns its `Scaffold` and exposes `ctaLabel` / `onCtaTap`. Button renders only when both are present and non-empty (primary variant, full-width, in `bottomNavigationBar` with `SafeArea` + space16/space12 padding — matches `ResultPage` / `ZkIdentityFlowPage` patterns).
- `ChallengeDetailScreen` reads `dto.ctaLabel` / `dto.ctaLink` and opens the link via the existing `launchExternalUrl` helper (external browser).

Closes #349
Relates to #381

## Test plan
- [x] `dart format` clean (pre-commit hook)
- [x] `flutter analyze` clean on changed files
- [x] `flutter test` — 660 passing, including 4 new CTA tests in `test/design_system/challenge_detail_page_test.dart` (renders / hides on null / hides on empty / tap fires callback)
- [x] `ds_lints` — no new warnings
- [x] Manual verification on physical device with view-only participant: CTA renders on a survey challenge and opens the link

🤖 Generated with [Claude Code](https://claude.com/claude-code)