### PR TITLE
feat(observability): Hooks for exposing device and mobile data to backend

### DIFF
--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
@@ -41,6 +41,11 @@ class AlarmReceiver : BroadcastReceiver() {
         val slotNumber = intent.getIntExtra("slotNumber", -1)
         val scheduledTimeMs = intent.getLongExtra("alarmTimeMs", -1L)
         val nodeRunning = intent.getBooleanExtra("nodeRunning", false)
+        val globalSlot = optionalLongExtra(intent, "globalSlot")
+            ?: optionalLongExtra(intent, "global_slot")
+            ?: slotNumber.takeIf { it > 0 }?.toLong()
+        val reason = intent.getStringExtra("reason")
+        val purpose = intent.getStringExtra("purpose")
 
         Log.d(TAG, "[AlarmReceiver] Slot alarm details - ID: $alarmId, Slot: $slotNumber, Scheduled: $scheduledTimeMs")
 
@@ -61,14 +66,20 @@ class AlarmReceiver : BroadcastReceiver() {
         // inactivity sleep path cannot win a race against alarm recovery.
         NativeWakeLockManager.acquire(context)
 
-        val eventData = mapOf(
+        val eventData = mutableMapOf<String, Any?>(
             "alarmId" to alarmId,
             "slotNumber" to slotNumber,
             "alarmTimeMs" to scheduledTimeMs,
+            "firedAtMs" to currentTime,
+            "latencyMs" to latencyMs,
             "batteryLevel" to 0,
             "networkState" to "unknown",
             "nodeRunning" to nodeRunning
         )
+        globalSlot?.let { eventData["globalSlot"] = it }
+        reason?.let { eventData["reason"] = it }
+        purpose?.let { eventData["purpose"] = it }
+
         val handler = AlarmMethodChannelHandler.getInstance()
         if (handler != null && handler.isActivityAttached()) {
             Log.d(TAG, "[AlarmReceiver] Sending android_alarm_fired event to attached Flutter activity")
@@ -90,6 +101,9 @@ class AlarmReceiver : BroadcastReceiver() {
             putExtra("slotNumber", slotNumber)
             putExtra("nodeRunning", nodeRunning)
             putExtra("alarmTimeMs", scheduledTimeMs)
+            globalSlot?.let { putExtra("globalSlot", it) }
+            reason?.let { putExtra("reason", it) }
+            purpose?.let { putExtra("purpose", it) }
         }
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -188,6 +202,19 @@ class AlarmReceiver : BroadcastReceiver() {
             .build()
 
         nm.notify(slotNumber, notification)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun optionalLongExtra(intent: Intent, key: String): Long? {
+        if (!intent.hasExtra(key)) return null
+        val value = intent.extras?.get(key) ?: return null
+        return when (value) {
+            is Int -> value.toLong()
+            is Long -> value
+            is Number -> value.toLong()
+            is String -> value.toLongOrNull()
+            else -> null
+        }?.takeIf { it > 0 }
     }
 
 }

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
@@ -51,10 +51,12 @@ class SlotMonitoringService : Service() {
             Log.w(TAG, "[SlotMonitoringService] Received null intent in onStartCommand")
 
             startMonitoring(0, false)
+            val firedAtMs = System.currentTimeMillis()
 
             val eventData = mapOf(
                 "alarmId" to "slot_monitoring_null_intent",
                 "slotNumber" to 0,
+                "firedAtMs" to firedAtMs,
                 "batteryLevel" to 0,
                 "networkState" to "unknown",
                 "nodeRunning" to false
@@ -82,20 +84,32 @@ class SlotMonitoringService : Service() {
                 val alarmId = intent.getStringExtra("alarmId")
                 val nodeRunning = intent.getBooleanExtra("nodeRunning", false)
                 val alarmTimeMs = intent.getLongExtra("alarmTimeMs", -1L)
+                val reason = intent.getStringExtra("reason")
+                val purpose = intent.getStringExtra("purpose")
                 Log.d(TAG, "[SlotMonitoringService] START_MONITORING - Slot: $slotNumber, AlarmId: $alarmId, nodeRunning=$nodeRunning")
 
                 // Allow alarmId-only wake (e.g., fg_resume) by using 0 as placeholder
                 val safeSlot = if (slotNumber != -1) slotNumber else 0
+                val globalSlot = optionalLongExtra(intent, "globalSlot")
+                    ?: optionalLongExtra(intent, "global_slot")
+                    ?: safeSlot.takeIf { it > 0 }?.toLong()
                 startMonitoring(safeSlot, nodeRunning, alarmTimeMs)
+                val firedAtMs = System.currentTimeMillis()
+                val latencyMs = if (alarmTimeMs > 0) firedAtMs - alarmTimeMs else 0L
 
-                val eventData = mapOf(
+                val eventData = mutableMapOf<String, Any?>(
                     "alarmId" to (alarmId ?: "unknown"),
                     "slotNumber" to safeSlot,
                     "alarmTimeMs" to alarmTimeMs,
+                    "firedAtMs" to firedAtMs,
+                    "latencyMs" to latencyMs,
                     "batteryLevel" to 0,
                     "networkState" to "unknown",
                     "nodeRunning" to nodeRunning
                 )
+                globalSlot?.let { eventData["globalSlot"] = it }
+                reason?.let { eventData["reason"] = it }
+                purpose?.let { eventData["purpose"] = it }
 
                 // Enforce a single-engine policy:
                 // - If the UI engine/channel exists, deliver the event through it (no headless engine).
@@ -247,6 +261,19 @@ class SlotMonitoringService : Service() {
             isPersistentMode = false
             isPersistentModeActive = false
         }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun optionalLongExtra(intent: Intent, key: String): Long? {
+        if (!intent.hasExtra(key)) return null
+        val value = intent.extras?.get(key) ?: return null
+        return when (value) {
+            is Int -> value.toLong()
+            is Long -> value
+            is Number -> value.toLong()
+            is String -> value.toLongOrNull()
+            else -> null
+        }?.takeIf { it > 0 }
     }
 
     private fun stopPersistentMode() {

--- a/lib/core/bootstrap/app_bootstrap.dart
+++ b/lib/core/bootstrap/app_bootstrap.dart
@@ -11,6 +11,7 @@ import 'package:crypto_mobile_app/core/providers/leaderboard_participant_provide
 import 'package:crypto_mobile_app/core/providers/providers.dart';
 import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
 import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/core/utils/lifecycle.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
@@ -92,6 +93,9 @@ class AppBootstrap {
 
     // Metrics collector needs the container before any lifecycle/service starts
     MetricsCollectorService.instance.initialize(container);
+    ObservabilityReportingService.instance.configureMobileContextCollector(
+      MetricsCollectorService.instance,
+    );
 
     if (registerLifecycleObserver) {
       await AppSleepService.instance.initializeForInteractiveApp();
@@ -108,7 +112,10 @@ class AppBootstrap {
       AppLifecycleLogger.onForegroundResume = recoverZkSession;
     }
 
-    _bootstrapBackendAsync(log: log, container: container);
+    _bootstrapBackendAsync(
+      log: log,
+      container: container,
+    );
 
     return AppBootstrapResult(
       container: container,
@@ -249,7 +256,8 @@ class AppBootstrap {
       }
 
       // Initialize FRB only; start backend only if an account exists
-      if (!RustBackendService.instance.isRunning) {
+      final nodeWasRunning = RustBackendService.instance.isRunning;
+      if (!nodeWasRunning) {
         log.info('Backend not running, initializing...');
         await RustBackendService.instance.init();
         log.info('FRB initialized, starting node...');
@@ -267,6 +275,9 @@ class AppBootstrap {
         }
       } else {
         log.info('Backend already running, skipping start');
+        await ObservabilityReportingService.instance.reportNodeInitialized(
+          resetStaticContext: false,
+        );
       }
 
       // Kick off Android foreground VRF monitoring once the node is running

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -256,6 +256,8 @@ class AndroidForegroundTaskController {
           await _scheduleResume(
             rustSlotTimeMs - _alarmLead.inMilliseconds,
             'next_won_slot:${nextWon.globalSlot}',
+            targetGlobalSlot: nextWon.globalSlot,
+            targetSlotTimeMs: localSlotTimeMs,
           );
         } else {
           _log.info(
@@ -368,7 +370,12 @@ class AndroidForegroundTaskController {
     }
   }
 
-  Future<void> _scheduleResume(int rustWakeTimeMs, String reason) async {
+  Future<void> _scheduleResume(
+    int rustWakeTimeMs,
+    String reason, {
+    int? targetGlobalSlot,
+    int? targetSlotTimeMs,
+  }) async {
     if (await _shouldHoldForOtherProducerBlock()) {
       final height = _awaitingOtherProducerState?.height;
       _log.info(
@@ -397,6 +404,12 @@ class AndroidForegroundTaskController {
       data: {
         'reason': reason,
         'nodeRunning': RustBackendService.instance.isRunning,
+        'rustWakeTimeMs': rustWakeTimeMs,
+        'localWakeTimeMs': localWakeTimeMs,
+        'clockDriftMs': clockDriftMs,
+        'purpose': 'foreground_resume',
+        if (targetGlobalSlot != null) 'globalSlot': targetGlobalSlot,
+        if (targetSlotTimeMs != null) 'slotTimeMs': targetSlotTimeMs,
       },
     );
 

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -6,6 +6,7 @@ import 'package:permission_handler/permission_handler.dart';
 
 import 'package:crypto_mobile_app/core/models/vrf_status.dart';
 import 'package:crypto_mobile_app/core/services/app_sleep_state_store.dart';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
@@ -67,6 +68,7 @@ class AndroidForegroundTaskController {
     } catch (e) {
       _log.warn('Error handling notification permission: $e');
     }
+    _recordRuntimeContextChanged('permissions_changed');
 
     _initialized = true;
     _log.info('AndroidForegroundTask initialized');
@@ -534,6 +536,14 @@ class AndroidForegroundTaskController {
   bool isWakelockHeldSync() {
     if (!Platform.isAndroid) return false;
     return _wakelockHeld;
+  }
+
+  void _recordRuntimeContextChanged(String reason) {
+    unawaited(
+      ObservabilityReportingService.instance.reportRuntimeMobileContextSnapshot(
+        reason: reason,
+      ),
+    );
   }
 }
 

--- a/lib/core/services/epoch_slot_scheduler_service.dart
+++ b/lib/core/services/epoch_slot_scheduler_service.dart
@@ -427,6 +427,9 @@ class EpochSlotSchedulerService {
         data: {
           'epoch': slot.epoch,
           'slotTime': slot.slotTime.toIso8601String(),
+          'slotTimeMs': slot.slotTime.millisecondsSinceEpoch,
+          'alarmTimeMs': slot.alarmTime.millisecondsSinceEpoch,
+          'purpose': 'slot_wake',
         },
       );
 

--- a/lib/core/services/ios_foreground_keepalive_service.dart
+++ b/lib/core/services/ios_foreground_keepalive_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
@@ -45,6 +46,7 @@ class IOSForegroundKeepAliveService {
 
       _isKeepAliveActive = true;
       _log.info('Keep-alive mode activated');
+      _recordRuntimeContextChanged('keep_alive_changed');
 
       return true;
     } catch (e) {
@@ -69,6 +71,7 @@ class IOSForegroundKeepAliveService {
 
       _isKeepAliveActive = false;
       _log.info('Keep-alive mode deactivated');
+      _recordRuntimeContextChanged('keep_alive_changed');
     } catch (e) {
       _log.error('Error stopping keep-alive: $e');
     }
@@ -114,6 +117,14 @@ class IOSForegroundKeepAliveService {
   /// - Safe to run indefinitely while charging
   double getEstimatedBatteryDrainPerHour() {
     return 7.5; // Average percentage per hour
+  }
+
+  void _recordRuntimeContextChanged(String reason) {
+    unawaited(
+      ObservabilityReportingService.instance.reportRuntimeMobileContextSnapshot(
+        reason: reason,
+      ),
+    );
   }
 
   /// Recommendations for user

--- a/lib/core/services/observability_reporting_service.dart
+++ b/lib/core/services/observability_reporting_service.dart
@@ -42,6 +42,7 @@ class ObservabilityReportingService {
   static const _powerNetworkServiceSnapshotMinimumGap = Duration(minutes: 1);
   static const _batteryUsageSampleWindow = Duration(minutes: 5);
   static const _batteryStateDuplicateWindow = Duration(seconds: 30);
+  static const _maxPendingEarlyRecords = 16;
 
   final ObservabilityRecordClient _record;
   final bool Function()? _canRecordOverride;
@@ -58,6 +59,7 @@ class ObservabilityReportingService {
   bool _staticMobileContextReported = false;
   bool _powerNetworkServiceSnapshotInFlight = false;
   bool _nodeInitialized = false;
+  final List<_PendingObservabilityRecord> _pendingEarlyRecords = [];
   DateTime? _lastPowerNetworkServiceSnapshotAt;
   int? _lastBatteryLevel;
   DateTime? _lastBatteryLevelAt;
@@ -69,6 +71,7 @@ class ObservabilityReportingService {
     if (resetStaticContext) {
       _staticMobileContextReported = false;
     }
+    _flushPendingEarlyRecords();
   }
 
   void configureMobileContextCollector(
@@ -220,6 +223,104 @@ class ObservabilityReportingService {
     );
   }
 
+  FlutterObservabilityRecordResult reportBlockProductionAlarmScheduled({
+    required String alarmId,
+    required int scheduledAtMs,
+    required int alarmTimeMs,
+    required int requestedDelayMs,
+    required int delayMs,
+    required String platform,
+    required bool success,
+    String? purpose,
+    int? globalSlot,
+    int? epoch,
+    int? slotTimeMs,
+    int? leadMs,
+    String? schedulerReason,
+    bool? nodeRunning,
+    int? rustWakeTimeMs,
+    int? localWakeTimeMs,
+    int? clockDriftMs,
+    String? failureReason,
+  }) {
+    return recordEvent(
+      event: 'app_block_production_alarm_scheduled',
+      details: {
+        'alarm_id': alarmId,
+        if (purpose != null) 'purpose': purpose,
+        if (globalSlot != null) 'global_slot': globalSlot,
+        if (epoch != null) 'epoch': epoch,
+        if (slotTimeMs != null) 'slot_time_ms': slotTimeMs,
+        'scheduled_at_ms': scheduledAtMs,
+        'alarm_time_ms': alarmTimeMs,
+        'requested_delay_ms': requestedDelayMs,
+        'delay_ms': delayMs,
+        if (leadMs != null) 'lead_ms': leadMs,
+        'platform': platform,
+        'success': success,
+        if (schedulerReason != null) 'scheduler_reason': schedulerReason,
+        if (nodeRunning != null) 'node_running': nodeRunning,
+        if (rustWakeTimeMs != null) 'rust_wake_time_ms': rustWakeTimeMs,
+        if (localWakeTimeMs != null) 'local_wake_time_ms': localWakeTimeMs,
+        if (clockDriftMs != null) 'clock_drift_ms': clockDriftMs,
+        if (failureReason != null) 'failure_reason': failureReason,
+      },
+    );
+  }
+
+  FlutterObservabilityRecordResult reportBlockProductionAlarmFired({
+    required String nativeEvent,
+    required int firedAtMs,
+    required String platform,
+    String? alarmId,
+    String? purpose,
+    int? globalSlot,
+    int? alarmTimeMs,
+    int? latencyMs,
+    bool? nodeRunning,
+    int? batteryLevel,
+    String? networkState,
+  }) {
+    return _recordStructured(
+      kind: FlutterObservabilityKind.event,
+      event: 'app_block_production_alarm_fired',
+      details: {
+        'native_event': nativeEvent,
+        if (alarmId != null) 'alarm_id': alarmId,
+        if (purpose != null) 'purpose': purpose,
+        if (globalSlot != null) 'global_slot': globalSlot,
+        if (alarmTimeMs != null) 'alarm_time_ms': alarmTimeMs,
+        'fired_at_ms': firedAtMs,
+        if (latencyMs != null) 'latency_ms': latencyMs,
+        'platform': platform,
+        if (nodeRunning != null) 'node_running': nodeRunning,
+        if (batteryLevel != null) 'battery_level': batteryLevel,
+        if (networkState != null) 'network_state': networkState,
+      },
+      requireNodeInitialized: false,
+      retainUntilNodeInitialized: true,
+    );
+  }
+
+  FlutterObservabilityRecordResult reportBlockProductionMonitoringStarted({
+    required int globalSlot,
+    required int monitoringStartedAtMs,
+    int? epoch,
+    int? slotTimeMs,
+    int? alarmTimeMs,
+  }) {
+    return recordEvent(
+      event: 'app_block_production_monitoring_started',
+      details: {
+        'global_slot': globalSlot,
+        if (epoch != null) 'epoch': epoch,
+        if (slotTimeMs != null) 'slot_time_ms': slotTimeMs,
+        if (alarmTimeMs != null) 'alarm_time_ms': alarmTimeMs,
+        'monitoring_started_at_ms': monitoringStartedAtMs,
+      },
+    );
+  }
+
   Future<void> reportStaticMobileContextSnapshot({
     String reason = 'node_initialized',
     Map<String, dynamic>? eventData,
@@ -302,10 +403,12 @@ class ObservabilityReportingService {
   }
 
   bool get _canRecordObservability =>
+      _canUseObservabilityTransport && _nodeInitialized;
+
+  bool get _canUseObservabilityTransport =>
       _canRecordOverride?.call() ??
       (!AppConfig.viewOnly &&
-          AppConfig.observabilityHubBaseUrl.trim().isNotEmpty &&
-          _nodeInitialized);
+          AppConfig.observabilityHubBaseUrl.trim().isNotEmpty);
 
   bool get _canReportMobileContextSnapshots => _canRecordObservability;
 
@@ -390,8 +493,11 @@ class ObservabilityReportingService {
     required FlutterObservabilityKind kind,
     required String event,
     Map<String, dynamic>? details,
+    bool requireNodeInitialized = true,
+    bool retainUntilNodeInitialized = false,
   }) {
-    if (!_canRecordObservability) {
+    if (!_canUseObservabilityTransport ||
+        (requireNodeInitialized && !_nodeInitialized)) {
       return const FlutterObservabilityRecordResult(
         queued: false,
         discarded: true,
@@ -412,11 +518,60 @@ class ObservabilityReportingService {
       }
     }
 
-    return _record(
+    final result = _record(
       kind: kind,
       event: event,
       payloadJson: payloadJson,
     );
+    if (retainUntilNodeInitialized &&
+        result.discarded &&
+        result.reason == 'node_not_running') {
+      _retainPendingEarlyRecord(
+        _PendingObservabilityRecord(
+          kind: kind,
+          event: event,
+          payloadJson: payloadJson,
+        ),
+      );
+      return const FlutterObservabilityRecordResult(
+        queued: true,
+        discarded: false,
+      );
+    }
+
+    return result;
+  }
+
+  void _retainPendingEarlyRecord(_PendingObservabilityRecord record) {
+    if (_pendingEarlyRecords.contains(record)) {
+      return;
+    }
+
+    if (_pendingEarlyRecords.length >= _maxPendingEarlyRecords) {
+      _pendingEarlyRecords.removeAt(0);
+    }
+    _pendingEarlyRecords.add(record);
+  }
+
+  void _flushPendingEarlyRecords() {
+    if (!_nodeInitialized ||
+        !_canUseObservabilityTransport ||
+        _pendingEarlyRecords.isEmpty) {
+      return;
+    }
+
+    final pending = List<_PendingObservabilityRecord>.of(_pendingEarlyRecords);
+    _pendingEarlyRecords.clear();
+    for (final record in pending) {
+      final result = _record(
+        kind: record.kind,
+        event: record.event,
+        payloadJson: record.payloadJson,
+      );
+      if (result.discarded && result.reason == 'node_not_running') {
+        _retainPendingEarlyRecord(record);
+      }
+    }
   }
 
   Map<String, dynamic>? _batteryUsageDetails(Map<String, dynamic> details) {
@@ -468,4 +623,27 @@ class ObservabilityReportingService {
       'estimated_drain_percent_per_hour': estimatedDrainPerHour,
     };
   }
+}
+
+class _PendingObservabilityRecord {
+  const _PendingObservabilityRecord({
+    required this.kind,
+    required this.event,
+    required this.payloadJson,
+  });
+
+  final FlutterObservabilityKind kind;
+  final String event;
+  final String? payloadJson;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _PendingObservabilityRecord &&
+        other.kind == kind &&
+        other.event == event &&
+        other.payloadJson == payloadJson;
+  }
+
+  @override
+  int get hashCode => Object.hash(kind, event, payloadJson);
 }

--- a/lib/core/services/observability_reporting_service.dart
+++ b/lib/core/services/observability_reporting_service.dart
@@ -1,0 +1,471 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:battery_plus/battery_plus.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/features/metrics/mobile_context_snapshot_collector.dart';
+import 'package:crypto_mobile_app/src/rust/observability.dart';
+import 'package:flutter/widgets.dart';
+
+final _log = LoggingService.instance.withTag('usernode/Observability');
+
+typedef ObservabilityRecordClient = FlutterObservabilityRecordResult Function({
+  required FlutterObservabilityKind kind,
+  required String event,
+  String? payloadJson,
+});
+
+typedef _MobileContextCollectorCall = Future<Map<String, dynamic>> Function({
+  Map<String, dynamic>? eventData,
+});
+
+class ObservabilityReportingService {
+  ObservabilityReportingService._()
+      : _record = observabilityRecord,
+        _canRecordOverride = null;
+
+  ObservabilityReportingService.test({
+    required MobileContextSnapshotCollector collector,
+    required ObservabilityRecordClient record,
+    bool Function()? canRecord,
+  })  : _collector = collector,
+        _record = record,
+        _canRecordOverride = canRecord;
+
+  static final ObservabilityReportingService instance =
+      ObservabilityReportingService._();
+
+  static const _lifecycleDuplicateWindow = Duration(seconds: 2);
+  static const _powerNetworkServiceSnapshotInterval = Duration(minutes: 10);
+  static const _powerNetworkServiceSnapshotMinimumGap = Duration(minutes: 1);
+  static const _batteryUsageSampleWindow = Duration(minutes: 5);
+  static const _batteryStateDuplicateWindow = Duration(seconds: 30);
+
+  final ObservabilityRecordClient _record;
+  final bool Function()? _canRecordOverride;
+  final Battery _battery = Battery();
+  final Connectivity _connectivity = Connectivity();
+  MobileContextSnapshotCollector? _collector;
+
+  String? _lastLifecycleEvent;
+  DateTime? _lastLifecycleEventAt;
+  Timer? _powerNetworkServiceSnapshotTimer;
+  StreamSubscription<BatteryState>? _batteryStateSubscription;
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
+  bool _mobileContextReportingStarted = false;
+  bool _staticMobileContextReported = false;
+  bool _powerNetworkServiceSnapshotInFlight = false;
+  bool _nodeInitialized = false;
+  DateTime? _lastPowerNetworkServiceSnapshotAt;
+  int? _lastBatteryLevel;
+  DateTime? _lastBatteryLevelAt;
+  BatteryState? _lastBatteryStateEvent;
+  DateTime? _lastBatteryStateEventAt;
+
+  void markNodeInitialized({bool resetStaticContext = false}) {
+    _nodeInitialized = true;
+    if (resetStaticContext) {
+      _staticMobileContextReported = false;
+    }
+  }
+
+  void configureMobileContextCollector(
+      MobileContextSnapshotCollector collector) {
+    _collector = collector;
+  }
+
+  Future<void> reportNodeInitialized({
+    bool resetStaticContext = false,
+  }) async {
+    markNodeInitialized(resetStaticContext: resetStaticContext);
+    await reportStaticMobileContextSnapshot(reason: 'node_initialized');
+    await startMobileContextSnapshotReporting(initialReason: 'startup');
+  }
+
+  Future<void> reportLifecycleStateChanged(AppLifecycleState state) async {
+    final event = switch (state) {
+      AppLifecycleState.resumed => 'app_foreground',
+      AppLifecycleState.paused ||
+      AppLifecycleState.hidden ||
+      AppLifecycleState.detached =>
+        'app_background',
+      AppLifecycleState.inactive => null,
+    };
+
+    if (event == null || _isDuplicateLifecycleEvent(event)) {
+      return;
+    }
+
+    final eventData = {'lifecycle_state': state.name};
+    await reportRuntimeMobileContextSnapshot(
+      reason: event == 'app_foreground' ? 'foreground' : 'background',
+      eventData: eventData,
+    );
+    await reportPowerNetworkServiceContextSnapshot(
+      reason: event == 'app_foreground' ? 'foreground' : 'background',
+      eventData: eventData,
+      force: true,
+    );
+  }
+
+  bool _isDuplicateLifecycleEvent(String event) {
+    final now = DateTime.now();
+    final lastAt = _lastLifecycleEventAt;
+    if (_lastLifecycleEvent == event &&
+        lastAt != null &&
+        now.difference(lastAt) < _lifecycleDuplicateWindow) {
+      return true;
+    }
+
+    _lastLifecycleEvent = event;
+    _lastLifecycleEventAt = now;
+    return false;
+  }
+
+  Future<void> startMobileContextSnapshotReporting({
+    String initialReason = 'startup',
+    Map<String, dynamic>? initialEventData,
+  }) async {
+    if (!_canReportMobileContextSnapshots) {
+      return;
+    }
+
+    if (_mobileContextReportingStarted) {
+      await reportRuntimeMobileContextSnapshot(
+        reason: initialReason,
+        eventData: initialEventData,
+      );
+      await reportPowerNetworkServiceContextSnapshot(
+        reason: initialReason,
+        eventData: initialEventData,
+        force: true,
+      );
+      return;
+    }
+
+    _mobileContextReportingStarted = true;
+    _batteryStateSubscription = _battery.onBatteryStateChanged.listen(
+      _handleBatteryStateChanged,
+      onError: (Object e) {
+        _log.debug('Battery state stream error: $e');
+      },
+    );
+    _connectivitySubscription = _connectivity.onConnectivityChanged.listen(
+      _handleNetworkChanged,
+      onError: (Object e) {
+        _log.debug('Connectivity stream error: $e');
+      },
+    );
+    _powerNetworkServiceSnapshotTimer = Timer.periodic(
+      _powerNetworkServiceSnapshotInterval,
+      (_) => unawaited(
+        reportPowerNetworkServiceContextSnapshot(reason: 'periodic'),
+      ),
+    );
+
+    await reportRuntimeMobileContextSnapshot(
+      reason: initialReason,
+      eventData: initialEventData,
+    );
+    await reportPowerNetworkServiceContextSnapshot(
+      reason: initialReason,
+      eventData: initialEventData,
+      force: true,
+    );
+  }
+
+  Future<void> stopMobileContextSnapshotReporting() async {
+    _powerNetworkServiceSnapshotTimer?.cancel();
+    _powerNetworkServiceSnapshotTimer = null;
+    await _batteryStateSubscription?.cancel();
+    _batteryStateSubscription = null;
+    await _connectivitySubscription?.cancel();
+    _connectivitySubscription = null;
+    _mobileContextReportingStarted = false;
+    _powerNetworkServiceSnapshotInFlight = false;
+  }
+
+  FlutterObservabilityRecordResult recordEvent({
+    required String event,
+    Map<String, dynamic>? details,
+  }) {
+    return _recordStructured(
+      kind: FlutterObservabilityKind.event,
+      event: event,
+      details: details,
+    );
+  }
+
+  FlutterObservabilityRecordResult recordMetricSample({
+    required String event,
+    Map<String, dynamic>? details,
+  }) {
+    return _recordStructured(
+      kind: FlutterObservabilityKind.metrics,
+      event: event,
+      details: details,
+    );
+  }
+
+  FlutterObservabilityRecordResult recordError({
+    required String event,
+    Map<String, dynamic>? details,
+  }) {
+    return _recordStructured(
+      kind: FlutterObservabilityKind.error,
+      event: event,
+      details: details,
+    );
+  }
+
+  Future<void> reportStaticMobileContextSnapshot({
+    String reason = 'node_initialized',
+    Map<String, dynamic>? eventData,
+  }) async {
+    if (_staticMobileContextReported) {
+      return;
+    }
+
+    final collector = _collector;
+    if (collector == null) {
+      _log.debug('Skipping static mobile context; collector not configured');
+      return;
+    }
+
+    final recorded = await _recordMobileContextSnapshot(
+      reason: reason,
+      eventData: eventData,
+      collect: collector.collectStaticMobileContextSnapshot,
+    );
+    if (recorded) {
+      _staticMobileContextReported = true;
+    }
+  }
+
+  Future<void> reportRuntimeMobileContextSnapshot({
+    required String reason,
+    Map<String, dynamic>? eventData,
+  }) async {
+    final collector = _collector;
+    if (collector == null) {
+      _log.debug('Skipping runtime mobile context; collector not configured');
+      return;
+    }
+
+    await _recordMobileContextSnapshot(
+      reason: reason,
+      eventData: eventData,
+      collect: collector.collectRuntimeMobileContextSnapshot,
+    );
+  }
+
+  Future<void> reportPowerNetworkServiceContextSnapshot({
+    required String reason,
+    Map<String, dynamic>? eventData,
+    bool force = false,
+  }) async {
+    if (!_canReportMobileContextSnapshots ||
+        _powerNetworkServiceSnapshotInFlight) {
+      return;
+    }
+
+    final collector = _collector;
+    if (collector == null) {
+      _log.debug(
+        'Skipping power/network/service mobile context; collector not configured',
+      );
+      return;
+    }
+
+    final now = DateTime.now();
+    if (!force &&
+        _lastPowerNetworkServiceSnapshotAt != null &&
+        now.difference(_lastPowerNetworkServiceSnapshotAt!) <
+            _powerNetworkServiceSnapshotMinimumGap) {
+      return;
+    }
+
+    _lastPowerNetworkServiceSnapshotAt = now;
+    _powerNetworkServiceSnapshotInFlight = true;
+    try {
+      await _recordMobileContextSnapshot(
+        reason: reason,
+        eventData: eventData,
+        collect: collector.collectPowerNetworkServiceContextSnapshot,
+        includeBatteryUsage: true,
+      );
+    } finally {
+      _powerNetworkServiceSnapshotInFlight = false;
+    }
+  }
+
+  bool get _canRecordObservability =>
+      _canRecordOverride?.call() ??
+      (!AppConfig.viewOnly &&
+          AppConfig.observabilityHubBaseUrl.trim().isNotEmpty &&
+          _nodeInitialized);
+
+  bool get _canReportMobileContextSnapshots => _canRecordObservability;
+
+  void _handleBatteryStateChanged(BatteryState state) {
+    final now = DateTime.now();
+    final lastAt = _lastBatteryStateEventAt;
+    if (_lastBatteryStateEvent == state &&
+        lastAt != null &&
+        now.difference(lastAt) < _batteryStateDuplicateWindow) {
+      return;
+    }
+
+    _lastBatteryStateEvent = state;
+    _lastBatteryStateEventAt = now;
+    unawaited(
+      reportPowerNetworkServiceContextSnapshot(
+        reason: 'battery_state_changed',
+        eventData: {'battery_state_changed_to': state.name},
+        force: true,
+      ),
+    );
+  }
+
+  void _handleNetworkChanged(List<ConnectivityResult> _) {
+    unawaited(
+      reportPowerNetworkServiceContextSnapshot(
+        reason: 'network_changed',
+        force: true,
+      ),
+    );
+  }
+
+  Future<bool> _recordMobileContextSnapshot({
+    required String reason,
+    Map<String, dynamic>? eventData,
+    required _MobileContextCollectorCall collect,
+    bool includeBatteryUsage = false,
+  }) async {
+    if (!_canReportMobileContextSnapshots) {
+      return false;
+    }
+
+    try {
+      final details = await collect(
+        eventData: {
+          'snapshot_reason': reason,
+          if (eventData != null) ...eventData,
+        },
+      );
+      if (includeBatteryUsage) {
+        final batteryUsage = _batteryUsageDetails(details);
+        if (batteryUsage != null) {
+          details['battery_usage'] = batteryUsage;
+        }
+      }
+
+      final result = recordEvent(
+        event: 'app_mobile_context_snapshot',
+        details: details,
+      );
+
+      if (result.discarded) {
+        _log.debug(
+          'Observability mobile context snapshot discarded',
+          context: {
+            'reason': reason,
+            if (result.reason != null) 'discard_reason': result.reason,
+          },
+        );
+      }
+      return result.queued || !result.discarded;
+    } catch (e) {
+      _log.warn(
+        'Failed to record observability mobile context snapshot: $e',
+        context: {'reason': reason},
+      );
+      return false;
+    }
+  }
+
+  FlutterObservabilityRecordResult _recordStructured({
+    required FlutterObservabilityKind kind,
+    required String event,
+    Map<String, dynamic>? details,
+  }) {
+    if (!_canRecordObservability) {
+      return const FlutterObservabilityRecordResult(
+        queued: false,
+        discarded: true,
+        reason: 'observability_disabled',
+      );
+    }
+
+    String? payloadJson;
+    if (details != null) {
+      try {
+        payloadJson = jsonEncode(details);
+      } catch (_) {
+        return const FlutterObservabilityRecordResult(
+          queued: false,
+          discarded: true,
+          reason: 'invalid_payload_json',
+        );
+      }
+    }
+
+    return _record(
+      kind: kind,
+      event: event,
+      payloadJson: payloadJson,
+    );
+  }
+
+  Map<String, dynamic>? _batteryUsageDetails(Map<String, dynamic> details) {
+    final battery = details['battery'];
+    if (battery is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final levelValue = battery['battery_level'];
+    final level = switch (levelValue) {
+      int value => value,
+      num value => value.round(),
+      _ => null,
+    };
+    if (level == null) {
+      return null;
+    }
+
+    final now = DateTime.now();
+    final previousLevel = _lastBatteryLevel;
+    final previousAt = _lastBatteryLevelAt;
+    _lastBatteryLevel = level;
+    _lastBatteryLevelAt = now;
+
+    if (previousLevel == null || previousAt == null) {
+      return null;
+    }
+
+    final sampleInterval = now.difference(previousAt);
+    if (sampleInterval < _batteryUsageSampleWindow) {
+      return null;
+    }
+
+    final state = battery['battery_state'];
+    if (state == 'charging' || state == 'full') {
+      return null;
+    }
+
+    final deltaPercent = level - previousLevel;
+    final drainedPercent = deltaPercent < 0 ? -deltaPercent : 0;
+    final sampleHours = sampleInterval.inMilliseconds / 3600000;
+    final estimatedDrainPerHour =
+        sampleHours <= 0 ? 0.0 : drainedPercent / sampleHours;
+
+    return {
+      'previous_battery_level': previousLevel,
+      'battery_delta_percent': deltaPercent,
+      'battery_sample_interval_ms': sampleInterval.inMilliseconds,
+      'estimated_drain_percent_per_hour': estimatedDrainPerHour,
+    };
+  }
+}

--- a/lib/core/services/platform_alarm_service.dart
+++ b/lib/core/services/platform_alarm_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 
@@ -19,12 +20,24 @@ typedef NativeEventCallback = void Function(
 /// iOS: Uses BGProcessingTask and local notifications
 class PlatformAlarmService {
   static final PlatformAlarmService instance = PlatformAlarmService._();
-  PlatformAlarmService._();
+  PlatformAlarmService._({ObservabilityReportingService? observability})
+      : _observability =
+            observability ?? ObservabilityReportingService.instance;
+
+  @visibleForTesting
+  PlatformAlarmService.test({
+    required ObservabilityReportingService observability,
+  }) : _observability = observability;
 
   static const MethodChannel _channel = MethodChannel('com.usernode.app/alarm');
+  final ObservabilityReportingService _observability;
 
   bool _initialized = false;
   bool _permissionsGranted = false;
+  String? _lastAlarmFiredEventKey;
+  DateTime? _lastAlarmFiredEventAt;
+
+  static const _alarmFiredDuplicateWindow = Duration(seconds: 10);
 
   /// Callback to invoke when device reboots and alarms need to be rescheduled
   BootRescheduleCallback? _onBootReschedule;
@@ -94,6 +107,8 @@ class PlatformAlarmService {
 
       _log.debug('Native event received: $eventType');
 
+      _recordNativeAlarmFiredEvent(eventType, eventData ?? {});
+
       if (_onNativeEvent == null) {
         _log.warn('No native event callback registered for event: $eventType');
         return;
@@ -104,6 +119,70 @@ class PlatformAlarmService {
     } catch (e) {
       _log.error('Error handling native event: $e');
     }
+  }
+
+  void _recordNativeAlarmFiredEvent(
+    String eventType,
+    Map<String, dynamic> eventData,
+  ) {
+    if (eventType != 'android_alarm_fired' &&
+        eventType != 'ios_bgtask_executed') {
+      return;
+    }
+
+    final alarmId = _stringFromDynamic(eventData['alarmId']);
+    final slotNumber = _intFromDynamic(eventData['slotNumber']);
+    final globalSlot = _globalSlotForAlarm(
+      alarmId: alarmId,
+      slotNumber: slotNumber,
+      data: eventData,
+    );
+    final alarmTimeMs = _intFromDynamic(eventData['alarmTimeMs']);
+    final eventKey = '$eventType:${alarmId ?? ''}:${alarmTimeMs ?? ''}:'
+        '${globalSlot ?? slotNumber ?? ''}';
+    final now = DateTime.now();
+    final lastAt = _lastAlarmFiredEventAt;
+    if (_lastAlarmFiredEventKey == eventKey &&
+        lastAt != null &&
+        now.difference(lastAt) < _alarmFiredDuplicateWindow) {
+      return;
+    }
+
+    _lastAlarmFiredEventKey = eventKey;
+    _lastAlarmFiredEventAt = now;
+
+    final firedAtMs =
+        _intFromDynamic(eventData['firedAtMs']) ?? now.millisecondsSinceEpoch;
+    final latencyMs = _intFromDynamic(eventData['latencyMs']) ??
+        (alarmTimeMs == null ? null : firedAtMs - alarmTimeMs);
+
+    _observability.reportBlockProductionAlarmFired(
+      nativeEvent: eventType,
+      alarmId: alarmId,
+      purpose: _alarmPurposeForNativeEvent(eventType, alarmId),
+      globalSlot: globalSlot,
+      alarmTimeMs: alarmTimeMs,
+      firedAtMs: firedAtMs,
+      latencyMs: latencyMs,
+      platform: Platform.operatingSystem,
+      nodeRunning: _boolFromDynamic(eventData['nodeRunning']),
+      batteryLevel: _intFromDynamic(eventData['batteryLevel']),
+      networkState: _stringFromDynamic(eventData['networkState']),
+    );
+  }
+
+  @visibleForTesting
+  void handleNativeEventForTest(
+    String eventType,
+    Map<String, dynamic> eventData,
+  ) {
+    _recordNativeAlarmFiredEvent(eventType, eventData);
+  }
+
+  String _alarmPurposeForNativeEvent(String eventType, String? alarmId) {
+    if (alarmId != null) return _alarmPurpose(alarmId, const {});
+    if (eventType == 'ios_bgtask_executed') return 'ios_background_task';
+    return 'block_production_wake';
   }
 
   /// Set the callback to invoke when device reboots
@@ -395,13 +474,64 @@ class PlatformAlarmService {
     required int delayMs,
     Map<String, dynamic>? data,
   }) async {
+    final alarmData = Map<String, dynamic>.from(data ?? const {});
+    final requestedDelayMs = delayMs;
+    final normalizedDelayMs = delayMs < 0 ? 0 : delayMs;
+    final scheduledAtMs = DateTime.now().millisecondsSinceEpoch;
+    final alarmTimeMs = _intFromDynamic(alarmData['alarmTimeMs']) ??
+        scheduledAtMs + normalizedDelayMs;
+    final globalSlot = _globalSlotForAlarm(
+      alarmId: alarmId,
+      slotNumber: slotNumber,
+      data: alarmData,
+    );
+    if (globalSlot != null) {
+      alarmData['globalSlot'] = globalSlot;
+    }
+
+    void recordScheduleResult({
+      required bool success,
+      String? failureReason,
+    }) {
+      final slotTimeMs = _slotTimeMsFromData(alarmData);
+      final leadMs = slotTimeMs == null ? null : slotTimeMs - alarmTimeMs;
+      _observability.reportBlockProductionAlarmScheduled(
+        alarmId: alarmId,
+        purpose: _alarmPurpose(alarmId, alarmData),
+        globalSlot: globalSlot,
+        epoch: _intFromDynamic(alarmData['epoch']),
+        slotTimeMs: slotTimeMs,
+        scheduledAtMs: scheduledAtMs,
+        alarmTimeMs: alarmTimeMs,
+        requestedDelayMs: requestedDelayMs,
+        delayMs: normalizedDelayMs,
+        leadMs: leadMs,
+        platform: Platform.operatingSystem,
+        success: success,
+        schedulerReason: _stringFromDynamic(alarmData['reason']),
+        nodeRunning: _boolFromDynamic(alarmData['nodeRunning']),
+        rustWakeTimeMs: _intFromDynamic(alarmData['rustWakeTimeMs']),
+        localWakeTimeMs: _intFromDynamic(alarmData['localWakeTimeMs']),
+        clockDriftMs: _intFromDynamic(alarmData['clockDriftMs']),
+        failureReason: failureReason,
+      );
+    }
+
     if (!_initialized) {
       _log.warn('Cannot schedule alarm: service not initialized');
+      recordScheduleResult(
+        success: false,
+        failureReason: 'service_not_initialized',
+      );
       return false;
     }
 
     if (!_permissionsGranted) {
       _log.warn('Cannot schedule alarm: permissions not granted');
+      recordScheduleResult(
+        success: false,
+        failureReason: 'permissions_not_granted',
+      );
       return false;
     }
 
@@ -409,21 +539,119 @@ class PlatformAlarmService {
       final params = {
         'alarmId': alarmId,
         'slotNumber': slotNumber,
-        'delayMs': delayMs < 0 ? 0 : delayMs,
-        'data': data ?? {},
+        'delayMs': normalizedDelayMs,
+        'data': alarmData,
       };
 
+      bool success;
       if (Platform.isAndroid) {
-        return await _scheduleAndroidAlarm(params);
+        success = await _scheduleAndroidAlarm(params);
       } else if (Platform.isIOS) {
-        return await _scheduleIOSAlarm(params);
+        success = await _scheduleIOSAlarm(params);
+      } else {
+        recordScheduleResult(
+          success: false,
+          failureReason: 'unsupported_platform',
+        );
+        return false;
       }
 
-      return false;
+      recordScheduleResult(
+        success: success,
+        failureReason: success ? null : 'platform_schedule_failed',
+      );
+      return success;
     } catch (e) {
       _log.error('Error scheduling alarm: $e');
+      recordScheduleResult(
+        success: false,
+        failureReason: 'schedule_exception',
+      );
       return false;
     }
+  }
+
+  String _alarmPurpose(String alarmId, Map<String, dynamic> data) {
+    final explicitPurpose = _stringFromDynamic(data['purpose']);
+    if (explicitPurpose != null) return explicitPurpose;
+    if (alarmId == 'fg_resume') return 'foreground_resume';
+    if (alarmId.startsWith('slot_')) return 'slot_wake';
+    return 'block_production_wake';
+  }
+
+  int? _globalSlotForAlarm({
+    required String? alarmId,
+    required int? slotNumber,
+    required Map<String, dynamic> data,
+  }) {
+    for (final key in const [
+      'globalSlot',
+      'global_slot',
+      'targetGlobalSlot',
+      'target_global_slot',
+    ]) {
+      final explicit = _intFromDynamic(data[key]);
+      if (explicit != null && explicit > 0) {
+        return explicit;
+      }
+    }
+
+    if (slotNumber != null && slotNumber > 0) {
+      return slotNumber;
+    }
+
+    final alarmSlot = _slotFromAlarmId(alarmId);
+    if (alarmSlot != null) {
+      return alarmSlot;
+    }
+
+    return _slotFromReason(_stringFromDynamic(data['reason']));
+  }
+
+  int? _slotFromAlarmId(String? alarmId) {
+    if (alarmId == null || !alarmId.startsWith('slot_')) {
+      return null;
+    }
+    final slot = int.tryParse(alarmId.substring('slot_'.length));
+    return slot != null && slot > 0 ? slot : null;
+  }
+
+  int? _slotFromReason(String? reason) {
+    if (reason == null || !reason.startsWith('next_won_slot:')) {
+      return null;
+    }
+    final slot = int.tryParse(reason.substring('next_won_slot:'.length));
+    return slot != null && slot > 0 ? slot : null;
+  }
+
+  int? _slotTimeMsFromData(Map<String, dynamic> data) {
+    final explicitMs = _intFromDynamic(data['slotTimeMs']);
+    if (explicitMs != null) return explicitMs;
+
+    final slotTime = _stringFromDynamic(data['slotTime']);
+    if (slotTime == null) return null;
+    return DateTime.tryParse(slotTime)?.millisecondsSinceEpoch;
+  }
+
+  int? _intFromDynamic(Object? value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value);
+    return null;
+  }
+
+  bool? _boolFromDynamic(Object? value) {
+    if (value is bool) return value;
+    if (value is String) {
+      if (value == 'true') return true;
+      if (value == 'false') return false;
+    }
+    return null;
+  }
+
+  String? _stringFromDynamic(Object? value) {
+    if (value is String && value.isNotEmpty) return value;
+    return null;
   }
 
   /// Schedule Android exact alarm
@@ -817,7 +1045,7 @@ class PlatformAlarmService {
 
   void _recordRuntimeContextChanged(String reason) {
     unawaited(
-      ObservabilityReportingService.instance.reportRuntimeMobileContextSnapshot(
+      _observability.reportRuntimeMobileContextSnapshot(
         reason: reason,
       ),
     );
@@ -825,8 +1053,7 @@ class PlatformAlarmService {
 
   void _recordPowerNetworkServiceContextChanged(String reason) {
     unawaited(
-      ObservabilityReportingService.instance
-          .reportPowerNetworkServiceContextSnapshot(
+      _observability.reportPowerNetworkServiceContextSnapshot(
         reason: reason,
         force: true,
       ),

--- a/lib/core/services/platform_alarm_service.dart
+++ b/lib/core/services/platform_alarm_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter/services.dart';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 
 final _log = LoggingService.instance.withTag('usernode/AlarmService');
@@ -275,6 +276,9 @@ class PlatformAlarmService {
       _log.info(
           'Permissions status - Notifications: $hasNotifications, Exact Alarm: $hasExactAlarm, Battery: $hasBatteryExemption');
 
+      _recordRuntimeContextChanged('permissions_changed');
+      _recordPowerNetworkServiceContextChanged('permissions_changed');
+
       return _permissionsGranted;
     } on PlatformException catch (e) {
       _log.error('Error requesting Android permissions: ${e.message}');
@@ -295,6 +299,8 @@ class PlatformAlarmService {
       } else {
         _log.warn('iOS notification permission denied');
       }
+
+      _recordRuntimeContextChanged('permissions_changed');
 
       return granted;
     } on PlatformException catch (e) {
@@ -537,6 +543,7 @@ class PlatformAlarmService {
 
       if (success) {
         _log.info('Foreground service started for slot $slotNumber');
+        _recordPowerNetworkServiceContextChanged('foreground_service_changed');
       } else {
         _log.warn('Failed to start foreground service');
       }
@@ -561,6 +568,7 @@ class PlatformAlarmService {
 
       if (success) {
         _log.info('Foreground service stopped');
+        _recordPowerNetworkServiceContextChanged('foreground_service_changed');
       } else {
         _log.warn('Failed to stop foreground service');
       }
@@ -590,6 +598,7 @@ class PlatformAlarmService {
 
       if (success) {
         _log.info('Persistent foreground service started');
+        _recordPowerNetworkServiceContextChanged('foreground_service_changed');
       } else {
         _log.warn('Failed to start persistent foreground service');
       }
@@ -615,6 +624,7 @@ class PlatformAlarmService {
 
       if (success) {
         _log.info('Persistent foreground service stopped');
+        _recordPowerNetworkServiceContextChanged('foreground_service_changed');
       } else {
         _log.warn('Failed to stop persistent foreground service');
       }
@@ -725,6 +735,8 @@ class PlatformAlarmService {
     if (!Platform.isAndroid) return false;
     try {
       await _channel.invokeMethod('acquireWakelock');
+      _recordRuntimeContextChanged('keep_alive_changed');
+      _recordPowerNetworkServiceContextChanged('foreground_service_changed');
       return true;
     } catch (e) {
       _log.error('Error acquiring wakelock: $e');
@@ -737,6 +749,8 @@ class PlatformAlarmService {
     if (!Platform.isAndroid) return false;
     try {
       await _channel.invokeMethod('releaseWakelock');
+      _recordRuntimeContextChanged('keep_alive_changed');
+      _recordPowerNetworkServiceContextChanged('foreground_service_changed');
       return true;
     } catch (e) {
       _log.error('Error releasing wakelock: $e');
@@ -799,6 +813,24 @@ class PlatformAlarmService {
     } catch (e) {
       _log.error('Error incrementing background task count: $e');
     }
+  }
+
+  void _recordRuntimeContextChanged(String reason) {
+    unawaited(
+      ObservabilityReportingService.instance.reportRuntimeMobileContextSnapshot(
+        reason: reason,
+      ),
+    );
+  }
+
+  void _recordPowerNetworkServiceContextChanged(String reason) {
+    unawaited(
+      ObservabilityReportingService.instance
+          .reportPowerNetworkServiceContextSnapshot(
+        reason: reason,
+        force: true,
+      ),
+    );
   }
 
   void resetForAppRestart() {

--- a/lib/core/services/slot_monitor_service.dart
+++ b/lib/core/services/slot_monitor_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/features/metrics/services/slot_outcome_recorder.dart';
 import '../../features/node/node_service.dart';
@@ -96,6 +97,14 @@ class SlotMonitorService {
       slotNumber: slot.slotNumber,
       timestamp: DateTime.now(),
     ));
+
+    unawaited(
+      ObservabilityReportingService.instance
+          .reportPowerNetworkServiceContextSnapshot(
+        reason: 'slot_monitoring_start',
+        force: true,
+      ),
+    );
 
     // Start polling timer (poll interval = 1 slot duration)
     _monitoringTimer = Timer.periodic(

--- a/lib/core/services/slot_monitor_service.dart
+++ b/lib/core/services/slot_monitor_service.dart
@@ -91,6 +91,15 @@ class SlotMonitorService {
     _lastBestTipSlot = null;
     _pollAttemptCount = 0;
 
+    ObservabilityReportingService.instance
+        .reportBlockProductionMonitoringStarted(
+      globalSlot: slot.slotNumber,
+      epoch: slot.epoch,
+      slotTimeMs: slot.slotTime.millisecondsSinceEpoch,
+      alarmTimeMs: slot.alarmTime.millisecondsSinceEpoch,
+      monitoringStartedAtMs: _monitoringStartTime!.millisecondsSinceEpoch,
+    );
+
     // Emit monitoring started event
     _eventController.add(SlotMonitoringEvent(
       type: MonitoringEventType.started,

--- a/lib/core/utils/lifecycle.dart
+++ b/lib/core/utils/lifecycle.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
+
 import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
-import 'package:flutter/widgets.dart';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:flutter/widgets.dart';
+
 import '../../features/metrics/metrics_collector_service.dart';
 
 final _log = LoggingService.instance.withTag('usernode/Lifecycle');
@@ -39,6 +42,9 @@ class AppLifecycleLogger with WidgetsBindingObserver {
     // Update metrics collector with new state
     MetricsCollectorService.instance.updateAppLifecycleState(state);
     await AppSleepService.instance.handleLifecycleStateChanged(state);
+    unawaited(
+      ObservabilityReportingService.instance.reportLifecycleStateChanged(state),
+    );
 
     switch (state) {
       case AppLifecycleState.resumed:

--- a/lib/features/metrics/metrics_collector_service.dart
+++ b/lib/features/metrics/metrics_collector_service.dart
@@ -7,6 +7,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/core/models/block_production_event.dart';
 import 'package:crypto_mobile_app/core/providers/leaderboard_participant_provider.dart';
+import 'package:crypto_mobile_app/features/metrics/mobile_context_snapshot_collector.dart';
 import 'package:crypto_mobile_app/features/metrics/models/metrics_payload.dart';
 import 'package:crypto_mobile_app/features/metrics/models/slot_outcome_report.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
@@ -37,7 +38,7 @@ String _hashDeviceId(String deviceId) {
 /// Service responsible for collecting all metrics from various sources
 ///
 /// Supports both periodic health checks and event-driven metric collection.
-class MetricsCollectorService {
+class MetricsCollectorService implements MobileContextSnapshotCollector {
   MetricsCollectorService._();
   static final MetricsCollectorService instance = MetricsCollectorService._();
 
@@ -110,6 +111,108 @@ class MetricsCollectorService {
   void updateAppLifecycleState(AppLifecycleState state) {
     _appLifecycleState = state;
   }
+
+  /// Collect per-run static mobile context used by observability.
+  ///
+  /// `device_id_hash` is the existing hashed identifier from [_collectDeviceMetrics],
+  /// not the raw platform device id.
+  @override
+  Future<Map<String, dynamic>> collectStaticMobileContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async {
+    final results = await Future.wait<Object?>([
+      _safeMobileContextField('runtime', _collectRuntimeMetrics),
+      _safeMobileContextField('platform', _collectPlatformMetrics),
+      _safeMobileContextField('device', _collectDeviceMetrics),
+    ]);
+
+    final runtime = results[0] as RuntimeMetrics?;
+    final platform = results[1] as PlatformMetrics?;
+    final device = results[2] as DeviceMetrics?;
+
+    return {
+      if (eventData != null && eventData.isNotEmpty) 'event_data': eventData,
+      if (runtime != null) 'runtime': _staticRuntimeJson(runtime),
+      if (platform != null) 'platform': platform.toJson(),
+      if (device != null) 'device': _staticDeviceJson(device),
+    };
+  }
+
+  /// Collect runtime/app-state mobile context used by observability.
+  @override
+  Future<Map<String, dynamic>> collectRuntimeMobileContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async {
+    final runtime = await _safeMobileContextField(
+      'runtime',
+      _collectRuntimeMetrics,
+    ) as RuntimeMetrics?;
+
+    return {
+      if (eventData != null && eventData.isNotEmpty) 'event_data': eventData,
+      if (runtime != null) 'runtime': _dynamicRuntimeJson(runtime),
+    };
+  }
+
+  /// Collect power, network, and foreground-service mobile context.
+  @override
+  Future<Map<String, dynamic>> collectPowerNetworkServiceContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async {
+    final results = await Future.wait<Object?>([
+      _safeMobileContextField('battery', _collectBatteryMetrics),
+      _safeMobileContextField('network', _collectNetworkMetrics),
+      Platform.isAndroid
+          ? _safeMobileContextField(
+              'foreground_service',
+              _collectForegroundServiceMetrics,
+            )
+          : Future<Object?>.value(null),
+    ]);
+
+    final battery = results[0] as BatteryMetrics?;
+    final network = results[1] as NetworkMetrics?;
+    final foregroundService = results[2] as ForegroundServiceMetrics?;
+
+    return {
+      if (eventData != null && eventData.isNotEmpty) 'event_data': eventData,
+      if (battery != null) 'battery': battery.toJson(),
+      if (network != null) 'network': network.toJson(),
+      if (foregroundService != null)
+        'foreground_service': foregroundService.toJson(),
+    };
+  }
+
+  Future<Object?> _safeMobileContextField(
+    String label,
+    Future<Object?> Function() collect,
+  ) async {
+    try {
+      return await collect();
+    } catch (e) {
+      _log.debug('mobile-context-snapshot field failed ($label): $e');
+      return null;
+    }
+  }
+
+  Map<String, dynamic> _staticRuntimeJson(RuntimeMetrics runtime) => {
+        'app_version': runtime.appVersion,
+        'app_build_number': runtime.appBuildNumber,
+      };
+
+  Map<String, dynamic> _dynamicRuntimeJson(RuntimeMetrics runtime) => {
+        'app_state': runtime.appState,
+        'app_uptime_ms': runtime.appUptimeMs,
+        'keep_alive_mode_active': runtime.keepAliveModeActive,
+        'notifications_enabled': runtime.notificationsEnabled,
+      };
+
+  Map<String, dynamic> _staticDeviceJson(DeviceMetrics device) => {
+        'device_id_hash': device.deviceId,
+        'device_manufacturer': device.deviceManufacturer,
+        'device_model': device.deviceModel,
+        'is_physical_device': device.isPhysicalDevice,
+      };
 
   /// Capture a focused snapshot of client-side context for slot outcome
   /// reports.

--- a/lib/features/metrics/mobile_context_snapshot_collector.dart
+++ b/lib/features/metrics/mobile_context_snapshot_collector.dart
@@ -1,0 +1,13 @@
+abstract class MobileContextSnapshotCollector {
+  Future<Map<String, dynamic>> collectStaticMobileContextSnapshot({
+    Map<String, dynamic>? eventData,
+  });
+
+  Future<Map<String, dynamic>> collectRuntimeMobileContextSnapshot({
+    Map<String, dynamic>? eventData,
+  });
+
+  Future<Map<String, dynamic>> collectPowerNetworkServiceContextSnapshot({
+    Map<String, dynamic>? eventData,
+  });
+}

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -21,6 +21,7 @@ import 'package:crypto_mobile_app/src/rust/node.dart';
 import 'package:crypto_mobile_app/src/rust/node/builder.dart';
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
 import 'package:crypto_mobile_app/core/models/backend_rpc_response.dart';
 import 'package:path_provider/path_provider.dart';
@@ -288,6 +289,11 @@ class RustBackendService {
     }
     if (_nodeRunning) {
       _log.trace('Node already running');
+      unawaited(
+        ObservabilityReportingService.instance.reportNodeInitialized(
+          resetStaticContext: false,
+        ),
+      );
       return true;
     }
 
@@ -340,6 +346,11 @@ class RustBackendService {
 
       await _configureWalletSigner(secretKey, account.id);
       _log.info('Reused previously started node');
+      unawaited(
+        ObservabilityReportingService.instance.reportNodeInitialized(
+          resetStaticContext: true,
+        ),
+      );
       return true;
     }
 
@@ -420,6 +431,11 @@ class RustBackendService {
       await _configureWalletSigner(secretKey, account.id);
 
       _log.info('Node started with user account block producer');
+      unawaited(
+        ObservabilityReportingService.instance.reportNodeInitialized(
+          resetStaticContext: true,
+        ),
+      );
       return true;
     } catch (e, st) {
       _log.error('Failed to start node with account ${account.id}',

--- a/test/core/services/observability_reporting_service_test.dart
+++ b/test/core/services/observability_reporting_service_test.dart
@@ -1,0 +1,282 @@
+import 'dart:convert';
+
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
+import 'package:crypto_mobile_app/features/metrics/mobile_context_snapshot_collector.dart';
+import 'package:crypto_mobile_app/src/rust/observability.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ObservabilityReportingService mobile context snapshots', () {
+    test('node initialization emits static context once for a node run',
+        () async {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records);
+
+      addTearDown(service.stopMobileContextSnapshotReporting);
+
+      await service.reportNodeInitialized(resetStaticContext: true);
+      await service.reportNodeInitialized();
+
+      final staticRecords = _staticRecords(records);
+      expect(staticRecords, hasLength(1));
+      final record = staticRecords.single;
+      expect(record.kind, FlutterObservabilityKind.event);
+      expect(record.event, 'app_mobile_context_snapshot');
+
+      final payload = record.payload;
+      expect(
+        payload.keys,
+        unorderedEquals(['event_data', 'runtime', 'platform', 'device']),
+      );
+      expect(payload['event_data'], {'snapshot_reason': 'node_initialized'});
+      expect(payload['runtime'], {
+        'app_version': '1.2.3',
+        'app_build_number': '45',
+      });
+      expect(payload['platform'], {
+        'platform': 'android',
+        'platform_version': '14',
+        'system_architecture': 'arm64-v8a',
+      });
+      expect(payload['device'], {
+        'device_id_hash': 'hashed-device-id',
+        'device_manufacturer': 'ExampleCo',
+        'device_model': 'Example Phone',
+        'is_physical_device': true,
+      });
+    });
+
+    test('static context emits again after a new node start signal', () async {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records);
+
+      addTearDown(service.stopMobileContextSnapshotReporting);
+
+      await service.reportNodeInitialized(resetStaticContext: true);
+      await service.reportNodeInitialized();
+      await service.reportNodeInitialized(resetStaticContext: true);
+
+      final staticRecords = _staticRecords(records);
+      expect(staticRecords, hasLength(2));
+      expect(
+        staticRecords.map((record) => record.payload['event_data']).toList(),
+        [
+          {'snapshot_reason': 'node_initialized'},
+          {'snapshot_reason': 'node_initialized'},
+        ],
+      );
+    });
+
+    test('dynamic updates omit static app, platform, and device sections',
+        () async {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records);
+
+      await service.reportRuntimeMobileContextSnapshot(
+        reason: 'foreground',
+        eventData: {'lifecycle_state': 'resumed'},
+      );
+      await service.reportPowerNetworkServiceContextSnapshot(
+        reason: 'network_changed',
+        force: true,
+      );
+
+      expect(records, hasLength(2));
+
+      final runtimePayload = records[0].payload;
+      expect(runtimePayload.keys, unorderedEquals(['event_data', 'runtime']));
+      expect(runtimePayload['event_data'], {
+        'snapshot_reason': 'foreground',
+        'lifecycle_state': 'resumed',
+      });
+      expect(runtimePayload['runtime'], {
+        'app_state': 'foreground',
+        'app_uptime_ms': 1200,
+        'keep_alive_mode_active': true,
+        'notifications_enabled': false,
+      });
+      expect(runtimePayload.containsKey('platform'), isFalse);
+      expect(runtimePayload.containsKey('device'), isFalse);
+      expect(runtimePayload.containsKey('battery'), isFalse);
+      expect(runtimePayload.containsKey('network'), isFalse);
+
+      final powerPayload = records[1].payload;
+      expect(
+        powerPayload.keys,
+        unorderedEquals([
+          'event_data',
+          'battery',
+          'network',
+          'foreground_service',
+        ]),
+      );
+      expect(powerPayload['event_data'], {
+        'snapshot_reason': 'network_changed',
+      });
+      expect(powerPayload['battery'], {
+        'battery_level': 88,
+        'battery_state': 'discharging',
+        'battery_optimization_disabled': true,
+        'power_save_mode': false,
+        'low_power_mode': false,
+      });
+      expect(powerPayload['network'], {
+        'network_type': 'wifi',
+        'network_connected': true,
+      });
+      expect(powerPayload['foreground_service'], {
+        'foreground_service_running': true,
+        'wakelock_held': true,
+      });
+      expect(powerPayload.containsKey('runtime'), isFalse);
+      expect(powerPayload.containsKey('platform'), isFalse);
+      expect(powerPayload.containsKey('device'), isFalse);
+    });
+
+    test('semantic record methods own observability kind selection', () {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records);
+
+      service.recordEvent(
+        event: 'app_mobile_context_snapshot',
+        details: {'source': 'event'},
+      );
+      service.recordMetricSample(
+        event: 'flutter_metric_sample',
+        details: {'source': 'metric'},
+      );
+      service.recordError(
+        event: 'flutter_error',
+        details: {'source': 'error'},
+      );
+
+      expect(
+        records.map((record) => record.kind).toList(),
+        [
+          FlutterObservabilityKind.event,
+          FlutterObservabilityKind.metrics,
+          FlutterObservabilityKind.error,
+        ],
+      );
+      expect(records.map((record) => record.event).toList(), [
+        'app_mobile_context_snapshot',
+        'flutter_metric_sample',
+        'flutter_error',
+      ]);
+    });
+  });
+}
+
+List<_CapturedObservabilityRecord> _staticRecords(
+  List<_CapturedObservabilityRecord> records,
+) {
+  return records.where((record) {
+    return record.payload.containsKey('platform') &&
+        record.payload.containsKey('device');
+  }).toList();
+}
+
+ObservabilityReportingService _service(
+  List<_CapturedObservabilityRecord> records,
+) {
+  return ObservabilityReportingService.test(
+    collector: _FakeMobileContextCollector(),
+    canRecord: () => true,
+    record: ({
+      required FlutterObservabilityKind kind,
+      required String event,
+      String? payloadJson,
+    }) {
+      records.add(
+        _CapturedObservabilityRecord(
+          kind: kind,
+          event: event,
+          payload: jsonDecode(payloadJson ?? '{}') as Map<String, dynamic>,
+        ),
+      );
+      return const FlutterObservabilityRecordResult(
+        queued: true,
+        discarded: false,
+      );
+    },
+  );
+}
+
+class _CapturedObservabilityRecord {
+  const _CapturedObservabilityRecord({
+    required this.kind,
+    required this.event,
+    required this.payload,
+  });
+
+  final FlutterObservabilityKind kind;
+  final String event;
+  final Map<String, dynamic> payload;
+}
+
+class _FakeMobileContextCollector implements MobileContextSnapshotCollector {
+  @override
+  Future<Map<String, dynamic>> collectStaticMobileContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async {
+    return {
+      if (eventData != null && eventData.isNotEmpty) 'event_data': eventData,
+      'runtime': {
+        'app_version': '1.2.3',
+        'app_build_number': '45',
+      },
+      'platform': {
+        'platform': 'android',
+        'platform_version': '14',
+        'system_architecture': 'arm64-v8a',
+      },
+      'device': {
+        'device_id_hash': 'hashed-device-id',
+        'device_manufacturer': 'ExampleCo',
+        'device_model': 'Example Phone',
+        'is_physical_device': true,
+      },
+    };
+  }
+
+  @override
+  Future<Map<String, dynamic>> collectRuntimeMobileContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async {
+    return {
+      if (eventData != null && eventData.isNotEmpty) 'event_data': eventData,
+      'runtime': {
+        'app_state': 'foreground',
+        'app_uptime_ms': 1200,
+        'keep_alive_mode_active': true,
+        'notifications_enabled': false,
+      },
+    };
+  }
+
+  @override
+  Future<Map<String, dynamic>> collectPowerNetworkServiceContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async {
+    return {
+      if (eventData != null && eventData.isNotEmpty) 'event_data': eventData,
+      'battery': {
+        'battery_level': 88,
+        'battery_state': 'discharging',
+        'battery_optimization_disabled': true,
+        'power_save_mode': false,
+        'low_power_mode': false,
+      },
+      'network': {
+        'network_type': 'wifi',
+        'network_connected': true,
+      },
+      'foreground_service': {
+        'foreground_service_running': true,
+        'wakelock_held': true,
+      },
+    };
+  }
+}

--- a/test/core/services/observability_reporting_service_test.dart
+++ b/test/core/services/observability_reporting_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
+import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/features/metrics/mobile_context_snapshot_collector.dart';
 import 'package:crypto_mobile_app/src/rust/observability.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -166,6 +167,234 @@ void main() {
         'flutter_error',
       ]);
     });
+
+    test('block production alarm scheduling is reported as an event', () {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records);
+
+      service.reportBlockProductionAlarmScheduled(
+        alarmId: 'slot_42',
+        purpose: 'slot_wake',
+        globalSlot: 42,
+        epoch: 7,
+        slotTimeMs: 1700000060000,
+        scheduledAtMs: 1700000000000,
+        alarmTimeMs: 1700000005000,
+        requestedDelayMs: 5000,
+        delayMs: 5000,
+        leadMs: 55000,
+        platform: 'android',
+        success: true,
+      );
+
+      expect(records, hasLength(1));
+      final record = records.single;
+      expect(record.kind, FlutterObservabilityKind.event);
+      expect(record.event, 'app_block_production_alarm_scheduled');
+      expect(record.payload, {
+        'alarm_id': 'slot_42',
+        'purpose': 'slot_wake',
+        'global_slot': 42,
+        'epoch': 7,
+        'slot_time_ms': 1700000060000,
+        'scheduled_at_ms': 1700000000000,
+        'alarm_time_ms': 1700000005000,
+        'requested_delay_ms': 5000,
+        'delay_ms': 5000,
+        'lead_ms': 55000,
+        'platform': 'android',
+        'success': true,
+      });
+    });
+
+    test('block production alarm fire is reported as an event', () {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records, nodeInitialized: false);
+
+      service.reportBlockProductionAlarmFired(
+        nativeEvent: 'android_alarm_fired',
+        alarmId: 'slot_42',
+        purpose: 'slot_wake',
+        globalSlot: 42,
+        alarmTimeMs: 1700000005000,
+        firedAtMs: 1700000005123,
+        latencyMs: 123,
+        platform: 'android',
+        nodeRunning: true,
+        batteryLevel: 88,
+        networkState: 'wifi',
+      );
+
+      expect(records, hasLength(1));
+      final record = records.single;
+      expect(record.kind, FlutterObservabilityKind.event);
+      expect(record.event, 'app_block_production_alarm_fired');
+      expect(record.payload, {
+        'native_event': 'android_alarm_fired',
+        'alarm_id': 'slot_42',
+        'purpose': 'slot_wake',
+        'global_slot': 42,
+        'alarm_time_ms': 1700000005000,
+        'fired_at_ms': 1700000005123,
+        'latency_ms': 123,
+        'platform': 'android',
+        'node_running': true,
+        'battery_level': 88,
+        'network_state': 'wifi',
+      });
+    });
+
+    test('non-alarm records remain gated before node initialization', () {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records, nodeInitialized: false);
+
+      final result = service.recordEvent(
+        event: 'ordinary_flutter_event',
+        details: {'source': 'test'},
+      );
+
+      expect(result.discarded, isTrue);
+      expect(result.reason, 'observability_disabled');
+      expect(records, isEmpty);
+    });
+
+    test('alarm fire is retained until node initialization when node is absent',
+        () async {
+      final records = <_CapturedObservabilityRecord>[];
+      var nodeRunning = false;
+      final service = _service(
+        records,
+        nodeInitialized: false,
+        record: ({
+          required FlutterObservabilityKind kind,
+          required String event,
+          String? payloadJson,
+        }) {
+          if (!nodeRunning) {
+            return const FlutterObservabilityRecordResult(
+              queued: false,
+              discarded: true,
+              reason: 'node_not_running',
+            );
+          }
+
+          records.add(
+            _CapturedObservabilityRecord(
+              kind: kind,
+              event: event,
+              payload: jsonDecode(payloadJson ?? '{}') as Map<String, dynamic>,
+            ),
+          );
+          return const FlutterObservabilityRecordResult(
+            queued: true,
+            discarded: false,
+          );
+        },
+      );
+
+      final result = service.reportBlockProductionAlarmFired(
+        nativeEvent: 'android_alarm_fired',
+        alarmId: 'slot_42',
+        purpose: 'slot_wake',
+        globalSlot: 42,
+        alarmTimeMs: 1700000005000,
+        firedAtMs: 1700000005123,
+        platform: 'android',
+      );
+
+      expect(result.queued, isTrue);
+      expect(records, isEmpty);
+
+      nodeRunning = true;
+      service.markNodeInitialized();
+
+      final firedRecords = records
+          .where((record) => record.event == 'app_block_production_alarm_fired')
+          .toList();
+      expect(firedRecords, hasLength(1));
+      expect(firedRecords.single.payload['global_slot'], 42);
+    });
+
+    test('native fired resume alarms report target global slot', () {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records, nodeInitialized: false);
+      final alarmService = PlatformAlarmService.test(observability: service);
+
+      alarmService.handleNativeEventForTest('android_alarm_fired', {
+        'alarmId': 'fg_resume',
+        'slotNumber': 0,
+        'globalSlot': 42,
+        'alarmTimeMs': 1700000005000,
+        'firedAtMs': 1700000005123,
+        'latencyMs': 123,
+        'reason': 'next_won_slot:42',
+      });
+
+      expect(records, hasLength(1));
+      expect(records.single.event, 'app_block_production_alarm_fired');
+      expect(records.single.payload['global_slot'], 42);
+      expect(records.single.payload['purpose'], 'foreground_resume');
+    });
+
+    test('native fired resume alarms derive target slot from reason', () {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records, nodeInitialized: false);
+      final alarmService = PlatformAlarmService.test(observability: service);
+
+      alarmService.handleNativeEventForTest('android_alarm_fired', {
+        'alarmId': 'fg_resume',
+        'slotNumber': 0,
+        'alarmTimeMs': 1700000005000,
+        'firedAtMs': 1700000005123,
+        'reason': 'next_won_slot:43',
+      });
+
+      expect(records, hasLength(1));
+      expect(records.single.payload['global_slot'], 43);
+    });
+
+    test('duplicate native fired events are suppressed', () {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records, nodeInitialized: false);
+      final alarmService = PlatformAlarmService.test(observability: service);
+      final eventData = {
+        'alarmId': 'fg_resume',
+        'slotNumber': 0,
+        'globalSlot': 42,
+        'alarmTimeMs': 1700000005000,
+        'firedAtMs': 1700000005123,
+      };
+
+      alarmService.handleNativeEventForTest('android_alarm_fired', eventData);
+      alarmService.handleNativeEventForTest('android_alarm_fired', eventData);
+
+      expect(records, hasLength(1));
+    });
+
+    test('block production monitoring start is reported as an event', () {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(records);
+
+      service.reportBlockProductionMonitoringStarted(
+        globalSlot: 42,
+        epoch: 7,
+        slotTimeMs: 1700000060000,
+        alarmTimeMs: 1700000005000,
+        monitoringStartedAtMs: 1700000005200,
+      );
+
+      expect(records, hasLength(1));
+      final record = records.single;
+      expect(record.kind, FlutterObservabilityKind.event);
+      expect(record.event, 'app_block_production_monitoring_started');
+      expect(record.payload, {
+        'global_slot': 42,
+        'epoch': 7,
+        'slot_time_ms': 1700000060000,
+        'alarm_time_ms': 1700000005000,
+        'monitoring_started_at_ms': 1700000005200,
+      });
+    });
   });
 }
 
@@ -179,29 +408,36 @@ List<_CapturedObservabilityRecord> _staticRecords(
 }
 
 ObservabilityReportingService _service(
-  List<_CapturedObservabilityRecord> records,
-) {
-  return ObservabilityReportingService.test(
+  List<_CapturedObservabilityRecord> records, {
+  bool nodeInitialized = true,
+  ObservabilityRecordClient? record,
+}) {
+  final service = ObservabilityReportingService.test(
     collector: _FakeMobileContextCollector(),
     canRecord: () => true,
-    record: ({
-      required FlutterObservabilityKind kind,
-      required String event,
-      String? payloadJson,
-    }) {
-      records.add(
-        _CapturedObservabilityRecord(
-          kind: kind,
-          event: event,
-          payload: jsonDecode(payloadJson ?? '{}') as Map<String, dynamic>,
-        ),
-      );
-      return const FlutterObservabilityRecordResult(
-        queued: true,
-        discarded: false,
-      );
-    },
+    record: record ??
+        ({
+          required FlutterObservabilityKind kind,
+          required String event,
+          String? payloadJson,
+        }) {
+          records.add(
+            _CapturedObservabilityRecord(
+              kind: kind,
+              event: event,
+              payload: jsonDecode(payloadJson ?? '{}') as Map<String, dynamic>,
+            ),
+          );
+          return const FlutterObservabilityRecordResult(
+            queued: true,
+            discarded: false,
+          );
+        },
   );
+  if (nodeInitialized) {
+    service.markNodeInitialized();
+  }
+  return service;
 }
 
 class _CapturedObservabilityRecord {

--- a/test/frb/frb_bindings_smoke_test.dart
+++ b/test/frb/frb_bindings_smoke_test.dart
@@ -11,6 +11,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:crypto_mobile_app/src/rust/lib.dart';
 import 'package:crypto_mobile_app/src/rust/frb_types.dart';
 import 'package:crypto_mobile_app/src/rust/node.dart';
+import 'package:crypto_mobile_app/src/rust/observability.dart';
+
+typedef ObservabilityRecordFn = FlutterObservabilityRecordResult Function({
+  required FlutterObservabilityKind kind,
+  required String event,
+  String? payloadJson,
+});
 
 @Tags(['frb', 'smoke'])
 void main() {
@@ -25,6 +32,11 @@ void main() {
       // Ensure we can refer to PeerId in signatures and call toString on it
       void accept(String Function(PeerId) f) {}
       accept((p) => p.toString());
+    });
+
+    test('observabilityRecord has expected signature', () {
+      ObservabilityRecordFn f = observabilityRecord;
+      expect(f, isNotNull);
     });
   });
 }


### PR DESCRIPTION
Paired with https://github.com/Usernode-Labs/usernode/pull/796

Tested on my phone, found no issues, the expected data shows up on the observability hub UI

**Summary**

Sends extra Flutter-side data through the backend observability API.

It reports mobile app context: app version/build, platform/device info, lifecycle state, uptime, battery level/state, battery optimization and power-save state, network state, foreground service status, wakelock status, and estimated battery drain.

It also reports block-production wake context: alarm scheduled, alarm fired, and slot monitoring started events, including global_slot where available so backend observability can correlate wakes with produced blocks.

Existing metrics reporting is left untouched.