### PR TITLE
feat(leaderboard): cta_type dispatcher + /dapps/:slug route

### DIFF
--- a/lib/core/config/app_router.dart
+++ b/lib/core/config/app_router.dart
@@ -24,6 +24,8 @@ import 'package:crypto_mobile_app/features/zk_identity/screens/zk_identity_detai
 import 'package:crypto_mobile_app/features/zk_identity/screens/zk_identity_flow_screen.dart';
 import 'package:crypto_mobile_app/features/challenges/screens/challenge_detail_screen.dart';
 import 'package:crypto_mobile_app/features/challenges/screens/epoch_performance_screen.dart';
+import 'package:crypto_mobile_app/features/dapps/dapp_webview_screen.dart';
+import 'package:crypto_mobile_app/features/dapps/providers/dapps_provider.dart';
 import 'package:crypto_mobile_app/features/leaderboard/screens/leaderboard_screen.dart';
 import 'package:crypto_mobile_app/features/perf/presentation/perf_benchmark_ui.dart';
 import 'package:crypto_mobile_app/features/perf/presentation/screens/device_benchmark_screen.dart';
@@ -76,10 +78,13 @@ class AppRoutes {
   static const challengeDetail = '/challenges/detail';
   static const epochPerformance = '/challenges/epoch-performance';
   static const leaderboard = '/challenges/leaderboard';
+  static const dappDetail = '/dapps/:slug';
   static const deviceBenchmark = '/settings/device-benchmark';
   static const deviceBenchmarkRun = '/settings/device-benchmark/run';
   static const deviceBenchmarkResultDetail =
       '/settings/device-benchmark/result';
+
+  static String dappDetailFor(String slug) => '/dapps/$slug';
 
   // ZK Identity
   static const zkIdentityDetail = '/challenges/zk-identity';
@@ -317,6 +322,57 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: AppRoutes.leaderboard,
         builder: (context, state) => const LeaderboardScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.dappDetail,
+        builder: (context, state) {
+          final slug = state.pathParameters['slug'];
+          return Consumer(
+            builder: (context, ref, _) {
+              final dappsAsync = ref.watch(dappsProvider);
+              return dappsAsync.when(
+                loading: () => const Scaffold(
+                  body: Center(child: CircularProgressIndicator()),
+                ),
+                error: (error, _) => Scaffold(
+                  appBar: AppBar(),
+                  body: Center(
+                    child: Text('Failed to load dApp: $error'),
+                  ),
+                ),
+                data: (_) {
+                  final dapp =
+                      slug == null ? null : ref.watch(dappBySlugProvider(slug));
+                  if (dapp == null) {
+                    return Scaffold(
+                      appBar: AppBar(),
+                      body: Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Text('dApp not found'),
+                            TextButton(
+                              onPressed: () {
+                                if (context.canPop()) {
+                                  context.pop();
+                                } else {
+                                  context.go(AppRoutes.home);
+                                }
+                              },
+                              child: const Text('Back'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  }
+
+                  return DappWebViewScreen(url: dapp.url, name: dapp.name);
+                },
+              );
+            },
+          );
+        },
       ),
     ],
     redirect: (context, state) {

--- a/lib/core/models/leaderboard_api_models.dart
+++ b/lib/core/models/leaderboard_api_models.dart
@@ -6,16 +6,46 @@
 // Safe JSON number helpers
 // ---------------------------------------------------------------------------
 
+enum CtaType { url, app }
+
 /// Coerces a JSON value that may be [int], [double], or numeric [String] → [int].
-/// Returns [raw] only when it is a non-empty `https://` URL with a host,
-/// otherwise null. Backend-provided links must not introduce non-https
-/// schemes (intent://, file://, javascript:, custom deep-links) into UI
-/// surfaces that launch URLs externally.
-String? _sanitizeHttpsUrl(dynamic raw) {
+/// Returns [raw] only when it is safe for the requested CTA type, otherwise
+/// null. Backend-provided links must not introduce unsafe schemes or internal
+/// paths into UI surfaces that launch URLs or navigate in-app.
+String? _sanitizeCtaLink(CtaType? type, dynamic raw) {
   if (raw is! String || raw.isEmpty) return null;
-  final uri = Uri.tryParse(raw);
-  if (uri == null || uri.scheme != 'https' || uri.host.isEmpty) return null;
-  return raw;
+  switch (type ?? CtaType.url) {
+    case CtaType.url:
+      final uri = Uri.tryParse(raw);
+      if (uri == null || uri.scheme != 'https' || uri.host.isEmpty) {
+        return null;
+      }
+      return raw;
+    case CtaType.app:
+      const allowedPrefixes = [
+        '/wallet',
+        '/challenges',
+        '/main/node',
+        '/settings',
+        '/dapps',
+      ];
+      if (!raw.startsWith('/')) return null;
+      for (final prefix in allowedPrefixes) {
+        if (raw == prefix || raw.startsWith('$prefix/')) {
+          return raw;
+        }
+      }
+      return null;
+  }
+}
+
+CtaType? _parseCtaType(dynamic raw) {
+  if (raw is! String) return null;
+  return switch (raw.toLowerCase()) {
+    'url' => CtaType.url,
+    'app' => CtaType.app,
+    _ => null,
+  };
 }
 
 int _jsonInt(dynamic v) => v is num ? v.toInt() : int.parse(v as String);
@@ -190,6 +220,7 @@ class ChallengeDto {
   final String? requirements;
   final String? rewardLogic;
   final String? ctaLabel;
+  final CtaType? ctaType;
   final String? ctaLink;
   final String? scheduleStart;
   final String? scheduleEnd;
@@ -210,6 +241,7 @@ class ChallengeDto {
     this.requirements,
     this.rewardLogic,
     this.ctaLabel,
+    this.ctaType,
     this.ctaLink,
     this.scheduleStart,
     this.scheduleEnd,
@@ -219,6 +251,7 @@ class ChallengeDto {
   });
 
   factory ChallengeDto.fromJson(Map<String, dynamic> json) {
+    final ctaType = _parseCtaType(json['cta_type']);
     return ChallengeDto(
       id: _jsonInt(json['id']),
       eventId: _jsonIntN(json['event_id']),
@@ -232,7 +265,8 @@ class ChallengeDto {
       requirements: json['requirements'] as String?,
       rewardLogic: json['reward_logic'] as String?,
       ctaLabel: json['cta_label'] as String?,
-      ctaLink: _sanitizeHttpsUrl(json['cta_link']),
+      ctaType: ctaType,
+      ctaLink: _sanitizeCtaLink(ctaType, json['cta_link']),
       scheduleStart: json['schedule_start'] as String?,
       scheduleEnd: json['schedule_end'] as String?,
       enabled: json['enabled'] as bool? ?? false,
@@ -254,6 +288,7 @@ class ChallengeDto {
         if (requirements != null) 'requirements': requirements,
         if (rewardLogic != null) 'reward_logic': rewardLogic,
         if (ctaLabel != null) 'cta_label': ctaLabel,
+        if (ctaType != null) 'cta_type': ctaType!.name,
         if (ctaLink != null) 'cta_link': ctaLink,
         if (scheduleStart != null) 'schedule_start': scheduleStart,
         if (scheduleEnd != null) 'schedule_end': scheduleEnd,

--- a/lib/core/utils/challenge_cta_dispatcher.dart
+++ b/lib/core/utils/challenge_cta_dispatcher.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:crypto_mobile_app/core/models/leaderboard_api_models.dart';
+import 'package:crypto_mobile_app/core/utils/url_launcher.dart';
+
+void handleChallengeCta(BuildContext context, ChallengeDto dto) {
+  final link = dto.ctaLink;
+  if (link == null || link.isEmpty) return;
+
+  switch (dto.ctaType ?? CtaType.url) {
+    case CtaType.url:
+      launchExternalUrl(link);
+    case CtaType.app:
+      context.push(link);
+  }
+}

--- a/lib/features/challenges/screens/challenge_detail_screen.dart
+++ b/lib/features/challenges/screens/challenge_detail_screen.dart
@@ -12,7 +12,7 @@ import 'package:crypto_mobile_app/core/providers/points_breakdown_provider.dart'
 import 'package:crypto_mobile_app/core/providers/syncing_text_provider.dart';
 import 'package:crypto_mobile_app/core/providers/produced_blocks_provider.dart';
 import 'package:crypto_mobile_app/core/utils/challenge_point_tracker.dart';
-import 'package:crypto_mobile_app/core/utils/url_launcher.dart';
+import 'package:crypto_mobile_app/core/utils/challenge_cta_dispatcher.dart';
 import 'package:crypto_mobile_app/design_system/src/block_production_status_card.dart';
 import 'package:crypto_mobile_app/design_system/src/challenge_card.dart';
 import 'package:crypto_mobile_app/design_system/src/challenge_detail_page.dart';
@@ -130,7 +130,7 @@ class ChallengeDetailScreen extends ConsumerWidget {
       totalRewardBody: showRewardCard ? null : (dto.rewardLogic ?? ''),
       onBackTap: () => context.pop(),
       ctaLabel: hasCta ? ctaLabel : null,
-      onCtaTap: hasCta ? () => launchExternalUrl(ctaLink) : null,
+      onCtaTap: hasCta ? () => handleChallengeCta(context, dto) : null,
     );
   }
 

--- a/lib/features/dapps/dapp_webview_screen.dart
+++ b/lib/features/dapps/dapp_webview_screen.dart
@@ -7,6 +7,7 @@ import 'package:crypto_mobile_app/core/widgets/node_status_icon.dart';
 import 'package:crypto_mobile_app/core/widgets/tx_confirmation_page.dart';
 import 'package:crypto_mobile_app/design_system/src/button.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_radii.dart';
+import 'package:crypto_mobile_app/design_system/tokens/app_sizing.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_spacing.dart';
 import 'package:crypto_mobile_app/design_system/tokens/app_typography.dart';
 import 'package:crypto_mobile_app/features/dapps/providers/dapps_provider.dart';
@@ -738,6 +739,7 @@ class _DappWebViewScreenState extends ConsumerState<DappWebViewScreen> {
         reverseTransitionDuration: const Duration(milliseconds: 250),
         pageBuilder: (ctx, _, __) {
           final spacing = Theme.of(ctx).extension<AppSpacing>()!;
+          final sizing = Theme.of(ctx).extension<AppSizing>()!;
           return Scaffold(
             appBar: AppBar(
               leading: IconButton(
@@ -754,7 +756,7 @@ class _DappWebViewScreenState extends ConsumerState<DappWebViewScreen> {
                 children: [
                   Icon(
                     Symbols.verified_user,
-                    size: 48,
+                    size: sizing.iconDisplay,
                     color: theme.colorScheme.primary,
                   ),
                   SizedBox(height: spacing.space16),

--- a/lib/features/dapps/models/dapp_item.dart
+++ b/lib/features/dapps/models/dapp_item.dart
@@ -22,6 +22,12 @@ class DappItem {
       description: json['description'] as String?,
     );
   }
+
+  // Provisional until the backend ships a stable slug with each dApp.
+  String get slug => name
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+      .replaceAll(RegExp(r'^-+|-+$'), '');
 }
 
 class DappStats {

--- a/lib/features/dapps/providers/dapps_provider.dart
+++ b/lib/features/dapps/providers/dapps_provider.dart
@@ -52,6 +52,27 @@ final dappByPubkeyProvider = Provider<Map<String, DappItem>>((ref) {
   };
 });
 
+final dappBySlugProvider = Provider.family<DappItem?, String>((ref, slug) {
+  final dapps = ref.watch(dappsProvider).valueOrNull;
+  if (dapps == null) return null;
+
+  assert(() {
+    final seen = <String>{};
+    for (final dapp in dapps) {
+      final dappSlug = dapp.slug;
+      if (!seen.add(dappSlug)) {
+        throw FlutterError('Duplicate dApp slug: $dappSlug');
+      }
+    }
+    return true;
+  }());
+
+  for (final dapp in dapps) {
+    if (dapp.slug == slug) return dapp;
+  }
+  return null;
+});
+
 const _statsRefreshInterval = Duration(seconds: 30);
 
 final dappStatsProvider = FutureProvider<Map<String, DappStats>>((ref) async {

--- a/test/core/models/leaderboard_api_models_test.dart
+++ b/test/core/models/leaderboard_api_models_test.dart
@@ -203,6 +203,7 @@ void main() {
         'requirements': 'Node must be running',
         'reward_logic': 'Fixed per completion',
         'cta_label': 'Start',
+        'cta_type': 'url',
         'cta_link': 'https://example.com',
         'schedule_start': '2025-01-01',
         'schedule_end': '2025-02-01',
@@ -220,6 +221,7 @@ void main() {
       expect(c.reward, '500');
       expect(c.description, 'Produce blocks to earn points');
       expect(c.ctaLabel, 'Start');
+      expect(c.ctaType, CtaType.url);
       expect(c.enabled, true);
       expect(c.completed, false);
     });
@@ -249,7 +251,8 @@ void main() {
     });
 
     group('cta_link sanitization', () {
-      ChallengeDto parseWithLink(dynamic link) => ChallengeDto.fromJson({
+      ChallengeDto parseWithLink(dynamic link, {String? ctaType}) =>
+          ChallengeDto.fromJson({
             'id': 1,
             'category': 'social',
             'goal': 'g',
@@ -257,6 +260,7 @@ void main() {
             'reward': 0,
             'enabled': true,
             'completed': false,
+            if (ctaType != null) 'cta_type': ctaType,
             'cta_link': link,
           });
 
@@ -300,6 +304,35 @@ void main() {
 
       test('rejects empty string', () {
         expect(parseWithLink('').ctaLink, isNull);
+      });
+
+      test('preserves whitelisted in-app paths for app CTAs', () {
+        expect(
+          parseWithLink('/challenges/zk-identity', ctaType: 'app').ctaLink,
+          '/challenges/zk-identity',
+        );
+        expect(
+          parseWithLink('/dapps/opinion-market', ctaType: 'app').ctaLink,
+          '/dapps/opinion-market',
+        );
+      });
+
+      test('rejects non-whitelisted in-app paths for app CTAs', () {
+        expect(parseWithLink('/admin', ctaType: 'app').ctaLink, isNull);
+        expect(parseWithLink('/dappsevil', ctaType: 'app').ctaLink, isNull);
+      });
+
+      test('rejects external URLs for app CTAs', () {
+        expect(
+          parseWithLink('https://example.com', ctaType: 'app').ctaLink,
+          isNull,
+        );
+      });
+
+      test('falls back to URL sanitization when cta_type is absent', () {
+        expect(parseWithLink('https://example.com').ctaLink,
+            'https://example.com');
+        expect(parseWithLink('/challenges/zk-identity').ctaLink, isNull);
       });
 
       test('rejects non-string types', () {
@@ -990,6 +1023,7 @@ void main() {
         'requirements': 'Node must be running',
         'reward_logic': 'Fixed per completion',
         'cta_label': 'Start',
+        'cta_type': 'url',
         'cta_link': 'https://example.com',
         'schedule_start': '2025-01-01',
         'schedule_end': '2025-02-01',
@@ -1011,6 +1045,7 @@ void main() {
       expect(c2.requirements, c.requirements);
       expect(c2.rewardLogic, c.rewardLogic);
       expect(c2.ctaLabel, c.ctaLabel);
+      expect(c2.ctaType, c.ctaType);
       expect(c2.ctaLink, c.ctaLink);
       expect(c2.scheduleStart, c.scheduleStart);
       expect(c2.scheduleEnd, c.scheduleEnd);


### PR DESCRIPTION
## Summary

- Introduce `cta_type` discriminator on `ChallengeDto` (`'url' | 'app'`) so challenge CTAs can either open an external URL (today's behaviour) or navigate to an in-app GoRouter path.
- Add `/dapps/:slug` route that resolves a dApp via the existing `dappsProvider` and pushes `DappWebViewScreen`. Provisional client-side slug (kebab-cased name) until backend supplies one.
- Swap the call site in `challenge_detail_screen.dart:133` from `launchExternalUrl(ctaLink)` to `handleChallengeCta(context, dto)`.

## Back-compat guarantee

Every existing challenge continues to behave exactly as today. Existing payloads have `cta_link: 'https://…'` with no `cta_type` field:

- `_parseCtaType(null)` → null
- `_sanitizeCtaLink(null, raw)` → falls to URL branch → existing https link passes through
- `handleChallengeCta` reads `dto.ctaType ?? CtaType.url` → calls `launchExternalUrl` exactly as before

Regression guard: new sanitizer test `falls back to URL sanitization when cta_type is absent` in `test/core/models/leaderboard_api_models_test.dart`. If this guarantee ever breaks, the test fails before merge.

**Production effect today: zero.** Until backend opts in by emitting `cta_type='app'` or dApp `slug` values, the new `app`-branch code paths sit dormant.

## Files

| File | Change |
|---|---|
| `lib/core/models/leaderboard_api_models.dart` | `CtaType` enum, `ctaType` field, type-aware `_sanitizeCtaLink`, `_parseCtaType` |
| `lib/core/utils/challenge_cta_dispatcher.dart` (new) | `handleChallengeCta(BuildContext, ChallengeDto)` |
| `lib/features/challenges/screens/challenge_detail_screen.dart` | Call-site swap at line 133 |
| `lib/core/config/app_router.dart` | New `/dapps/:slug` `GoRoute` |
| `lib/features/dapps/providers/dapps_provider.dart` | `dappBySlugProvider` family + debug-mode duplicate-slug assertion |
| `lib/features/dapps/models/dapp_item.dart` | Provisional computed `slug` getter |
| `lib/features/dapps/dapp_webview_screen.dart` | Minor token cleanup (`sizing.iconDisplay`) |
| `test/core/models/leaderboard_api_models_test.dart` | Sanitizer tests for url/app branches + legacy fall-through |

Mock layer (3 synthetic challenges, one per scenario) lives on a separate non-merged scaffolding branch `mocks/cta-fixtures` — not in this PR. It'll be used to re-test once backend ships.

## Test plan

- [x] `dart format` clean
- [x] `flutter analyze` clean
- [x] `flutter test test/core/models/leaderboard_api_models_test.dart` — 78 passed (including 4 new sanitizer tests)
- [x] Manual smoke on Android Seeker — real challenge \"Share zkPassport Feedback\" CTA still opens the Google Form via system browser (`docs.google.com/forms/...`). The new code paths (in-app deep-link + dApp webview) were verified locally using the `mocks/cta-fixtures` branch.

## Related

- Tracker: #434 — Challenge CTAs (full rollout plan, Stages 1–3)
- Discussion source: #421
- Initiative tracker: #388 (leaderboard sunset)
- Cross-cuts `init:dapps` via `/dapps/:slug` route → #382
- **Backend prerequisite (for `cta_type='app'` to fire in production):** [Usernode-Labs/topochain#81](https://github.com/Usernode-Labs/topochain/issues/81). This PR is back-compat-safe and can merge independently — backend cutover is separate.

Relates to #434 #388 #421