### PR TITLE
Add usernode app deep-link registration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,6 +55,15 @@
                     android:scheme="usernode-zk"
                     android:host="callback"/>
             </intent-filter>
+            <!-- In-app deep links: usernode://app/<path> routed via GoRouter. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="usernode"
+                    android:host="app"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,14 +55,25 @@
                     android:scheme="usernode-zk"
                     android:host="callback"/>
             </intent-filter>
-            <!-- In-app deep links: usernode://app/<path> routed via GoRouter. -->
+            <!-- In-app challenge deep links: usernode://app/challenges/... routed via GoRouter. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data
                     android:scheme="usernode"
-                    android:host="app"/>
+                    android:host="app"
+                    android:pathPrefix="/challenges"/>
+            </intent-filter>
+            <!-- In-app dApp deep links: usernode://app/dapps/... routed via GoRouter. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="usernode"
+                    android:host="app"
+                    android:pathPrefix="/dapps"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -70,6 +70,14 @@
 				<string>usernode-zk</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.usernode.app.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>usernode</string>
+			</array>
+		</dict>
 	</array>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>

--- a/lib/core/config/app_router.dart
+++ b/lib/core/config/app_router.dart
@@ -38,6 +38,7 @@ import 'package:crypto_mobile_app/features/wallet/screens/transaction_failed_scr
 import 'package:crypto_mobile_app/features/wallet/burst/burst_screen.dart';
 import 'package:crypto_mobile_app/core/providers/providers.dart';
 import 'package:crypto_mobile_app/core/providers/leaderboard_bootstrap.dart';
+import 'package:crypto_mobile_app/core/utils/app_deep_link_allowlist.dart';
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/status.dart';
@@ -386,9 +387,16 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       );
 
       final currentLocation = state.matchedLocation;
+      final requestUri = state.uri;
 
       _log.trace(
           'Redirect guard called - location: $currentLocation, hasAny: $hasAny, onboardingComplete: $hasCompletedOnboarding');
+
+      if (isUsernodeAppDeepLink(requestUri) &&
+          !isAllowedUsernodeAppDeepLink(requestUri)) {
+        _log.warn('Blocked unsupported app deep link: $requestUri');
+        return AppRoutes.home;
+      }
 
       // Still loading state
       if (hasAny == null || hasCompletedOnboarding == null) {

--- a/lib/core/config/app_router.dart
+++ b/lib/core/config/app_router.dart
@@ -26,6 +26,7 @@ import 'package:crypto_mobile_app/features/challenges/screens/challenge_detail_s
 import 'package:crypto_mobile_app/features/challenges/screens/epoch_performance_screen.dart';
 import 'package:crypto_mobile_app/features/dapps/dapp_webview_screen.dart';
 import 'package:crypto_mobile_app/features/dapps/providers/dapps_provider.dart';
+import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/features/leaderboard/screens/leaderboard_screen.dart';
 import 'package:crypto_mobile_app/features/perf/presentation/perf_benchmark_ui.dart';
 import 'package:crypto_mobile_app/features/perf/presentation/screens/device_benchmark_screen.dart';
@@ -79,6 +80,7 @@ class AppRoutes {
   static const challengeDetail = '/challenges/detail';
   static const epochPerformance = '/challenges/epoch-performance';
   static const leaderboard = '/challenges/leaderboard';
+  static const dapps = '/dapps';
   static const dappDetail = '/dapps/:slug';
   static const deviceBenchmark = '/settings/device-benchmark';
   static const deviceBenchmarkRun = '/settings/device-benchmark/run';
@@ -325,6 +327,12 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         builder: (context, state) => const LeaderboardScreen(),
       ),
       GoRoute(
+        path: AppRoutes.dapps,
+        builder: (context, state) => const HomeScreen(
+          initialTab: HomeTab.dapps,
+        ),
+      ),
+      GoRoute(
         path: AppRoutes.dappDetail,
         builder: (context, state) {
           final slug = state.pathParameters['slug'];
@@ -392,8 +400,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       _log.trace(
           'Redirect guard called - location: $currentLocation, hasAny: $hasAny, onboardingComplete: $hasCompletedOnboarding');
 
-      if (isUsernodeAppDeepLink(requestUri) &&
-          !isAllowedUsernodeAppDeepLink(requestUri)) {
+      if (shouldBlockUsernodeDeepLink(requestUri)) {
         _log.warn('Blocked unsupported app deep link: $requestUri');
         return AppRoutes.home;
       }

--- a/lib/core/models/leaderboard_api_models.dart
+++ b/lib/core/models/leaderboard_api_models.dart
@@ -48,6 +48,11 @@ CtaType? _parseCtaType(dynamic raw) {
   };
 }
 
+String? _nonEmptyString(dynamic raw) {
+  if (raw is! String || raw.isEmpty) return null;
+  return raw;
+}
+
 int _jsonInt(dynamic v) => v is num ? v.toInt() : int.parse(v as String);
 
 /// Nullable variant.
@@ -251,7 +256,21 @@ class ChallengeDto {
   });
 
   factory ChallengeDto.fromJson(Map<String, dynamic> json) {
-    final ctaType = _parseCtaType(json['cta_type']);
+    final baseCtaType = _parseCtaType(json['cta_type']);
+    final mobileCtaType = _parseCtaType(json['mobile_cta_type']);
+    final mobileCtaLabel = _nonEmptyString(json['mobile_cta_label']);
+    final mobileCtaLink = _nonEmptyString(json['mobile_cta_link']);
+    final hasMobileCtaOverride = mobileCtaType != null ||
+        mobileCtaLabel != null ||
+        mobileCtaLink != null;
+    final ctaType =
+        hasMobileCtaOverride ? mobileCtaType ?? baseCtaType : baseCtaType;
+    final ctaLabel = hasMobileCtaOverride
+        ? mobileCtaLabel ?? json['cta_label'] as String?
+        : json['cta_label'] as String?;
+    final ctaLinkRaw = hasMobileCtaOverride
+        ? mobileCtaLink ?? json['cta_link']
+        : json['cta_link'];
     return ChallengeDto(
       id: _jsonInt(json['id']),
       eventId: _jsonIntN(json['event_id']),
@@ -264,9 +283,9 @@ class ChallengeDto {
       description: json['description'] as String?,
       requirements: json['requirements'] as String?,
       rewardLogic: json['reward_logic'] as String?,
-      ctaLabel: json['cta_label'] as String?,
+      ctaLabel: ctaLabel,
       ctaType: ctaType,
-      ctaLink: _sanitizeCtaLink(ctaType, json['cta_link']),
+      ctaLink: _sanitizeCtaLink(ctaType, ctaLinkRaw),
       scheduleStart: json['schedule_start'] as String?,
       scheduleEnd: json['schedule_end'] as String?,
       enabled: json['enabled'] as bool? ?? false,

--- a/lib/core/models/leaderboard_api_models.dart
+++ b/lib/core/models/leaderboard_api_models.dart
@@ -2,6 +2,8 @@
 //
 // Base URL: https://leaderboard.usernodelabs.org/api/v2/mobile/
 
+import 'package:crypto_mobile_app/core/utils/app_deep_link_allowlist.dart';
+
 // ---------------------------------------------------------------------------
 // Safe JSON number helpers
 // ---------------------------------------------------------------------------
@@ -22,20 +24,7 @@ String? _sanitizeCtaLink(CtaType? type, dynamic raw) {
       }
       return raw;
     case CtaType.app:
-      const allowedPrefixes = [
-        '/wallet',
-        '/challenges',
-        '/main/node',
-        '/settings',
-        '/dapps',
-      ];
-      if (!raw.startsWith('/')) return null;
-      for (final prefix in allowedPrefixes) {
-        if (raw == prefix || raw.startsWith('$prefix/')) {
-          return raw;
-        }
-      }
-      return null;
+      return isAllowedAppDeepLinkPath(raw) ? raw : null;
   }
 }
 
@@ -257,20 +246,23 @@ class ChallengeDto {
 
   factory ChallengeDto.fromJson(Map<String, dynamic> json) {
     final baseCtaType = _parseCtaType(json['cta_type']);
+    final baseCtaLabel = json['cta_label'] as String?;
+    final baseCtaLink = _sanitizeCtaLink(baseCtaType, json['cta_link']);
     final mobileCtaType = _parseCtaType(json['mobile_cta_type']);
     final mobileCtaLabel = _nonEmptyString(json['mobile_cta_label']);
     final mobileCtaLink = _nonEmptyString(json['mobile_cta_link']);
     final hasMobileCtaOverride = mobileCtaType != null ||
         mobileCtaLabel != null ||
         mobileCtaLink != null;
-    final ctaType =
-        hasMobileCtaOverride ? mobileCtaType ?? baseCtaType : baseCtaType;
-    final ctaLabel = hasMobileCtaOverride
-        ? mobileCtaLabel ?? json['cta_label'] as String?
-        : json['cta_label'] as String?;
-    final ctaLinkRaw = hasMobileCtaOverride
-        ? mobileCtaLink ?? json['cta_link']
-        : json['cta_link'];
+    final effectiveMobileCtaType = mobileCtaType ?? baseCtaType;
+    final sanitizedMobileCtaLink = hasMobileCtaOverride
+        ? _sanitizeCtaLink(effectiveMobileCtaType, mobileCtaLink)
+        : null;
+    final useMobileCta = sanitizedMobileCtaLink != null;
+    final ctaType = useMobileCta ? effectiveMobileCtaType : baseCtaType;
+    final ctaLabel =
+        useMobileCta ? mobileCtaLabel ?? baseCtaLabel : baseCtaLabel;
+    final ctaLink = useMobileCta ? sanitizedMobileCtaLink : baseCtaLink;
     return ChallengeDto(
       id: _jsonInt(json['id']),
       eventId: _jsonIntN(json['event_id']),
@@ -285,7 +277,7 @@ class ChallengeDto {
       rewardLogic: json['reward_logic'] as String?,
       ctaLabel: ctaLabel,
       ctaType: ctaType,
-      ctaLink: _sanitizeCtaLink(ctaType, ctaLinkRaw),
+      ctaLink: ctaLink,
       scheduleStart: json['schedule_start'] as String?,
       scheduleEnd: json['schedule_end'] as String?,
       enabled: json['enabled'] as bool? ?? false,

--- a/lib/core/models/leaderboard_api_models.dart
+++ b/lib/core/models/leaderboard_api_models.dart
@@ -255,9 +255,14 @@ class ChallengeDto {
         mobileCtaLabel != null ||
         mobileCtaLink != null;
     final effectiveMobileCtaType = mobileCtaType ?? baseCtaType;
-    final sanitizedMobileCtaLink = hasMobileCtaOverride
-        ? _sanitizeCtaLink(effectiveMobileCtaType, mobileCtaLink)
-        : null;
+    final canInheritBaseCtaLink =
+        mobileCtaLink == null && mobileCtaType == null;
+    String? sanitizedMobileCtaLink;
+    if (hasMobileCtaOverride) {
+      sanitizedMobileCtaLink = canInheritBaseCtaLink
+          ? baseCtaLink
+          : _sanitizeCtaLink(effectiveMobileCtaType, mobileCtaLink);
+    }
     final useMobileCta = sanitizedMobileCtaLink != null;
     final ctaType = useMobileCta ? effectiveMobileCtaType : baseCtaType;
     final ctaLabel =

--- a/lib/core/utils/app_deep_link_allowlist.dart
+++ b/lib/core/utils/app_deep_link_allowlist.dart
@@ -19,3 +19,7 @@ bool isUsernodeAppDeepLink(Uri uri) {
 bool isAllowedUsernodeAppDeepLink(Uri uri) {
   return isUsernodeAppDeepLink(uri) && isAllowedAppDeepLinkPath(uri.path);
 }
+
+bool shouldBlockUsernodeDeepLink(Uri uri) {
+  return uri.scheme == 'usernode' && !isAllowedUsernodeAppDeepLink(uri);
+}

--- a/lib/core/utils/app_deep_link_allowlist.dart
+++ b/lib/core/utils/app_deep_link_allowlist.dart
@@ -1,0 +1,21 @@
+/// Routes that may be opened from backend-provided app CTAs or external
+/// `usernode://app/...` links.
+bool isAllowedAppDeepLinkPath(String path) {
+  if (path == '/challenges/leaderboard' ||
+      path == '/challenges/zk-identity' ||
+      path == '/challenges/zk-identity/flow' ||
+      path == '/dapps') {
+    return true;
+  }
+
+  final dappMatch = RegExp(r'^/dapps/[a-z0-9-]+$').hasMatch(path);
+  return dappMatch;
+}
+
+bool isUsernodeAppDeepLink(Uri uri) {
+  return uri.scheme == 'usernode' && uri.host == 'app';
+}
+
+bool isAllowedUsernodeAppDeepLink(Uri uri) {
+  return isUsernodeAppDeepLink(uri) && isAllowedAppDeepLinkPath(uri.path);
+}

--- a/lib/features/challenges/challenge_mappers.dart
+++ b/lib/features/challenges/challenge_mappers.dart
@@ -391,11 +391,6 @@ bool isProduceBlocksChallenge(ChallengeDto dto) {
 /// SubCategory identifier for the ZK Identity challenge.
 const String zkIdentitySubCategory = 'ZK_IDENTITY_VERIFICATION';
 
-/// Returns true when the challenge is the ZK Identity challenge.
-bool isZkIdentityChallenge(ChallengeDto dto) {
-  return dto.subCategory == zkIdentitySubCategory;
-}
-
 /// True when the aggregator hasn't yet tallied earned points for a
 /// produce-blocks challenge that already has block activity.
 bool isProduceBlocksSyncing({

--- a/lib/features/challenges/screens/challenges_screen.dart
+++ b/lib/features/challenges/screens/challenges_screen.dart
@@ -583,11 +583,7 @@ class _ChallengesScreenState extends ConsumerState<ChallengesScreen>
       variant: variant,
       earnedPoints: points,
       onTap: () {
-        if (isZkIdentityChallenge(dto)) {
-          context.push(AppRoutes.zkIdentityDetail);
-        } else {
-          context.push(AppRoutes.challengeDetail, extra: enriched);
-        }
+        context.push(AppRoutes.challengeDetail, extra: enriched);
       },
     );
   }
@@ -680,11 +676,7 @@ class _ChallengesScreenState extends ConsumerState<ChallengesScreen>
           : null,
       completedPoints: completedPoints,
       onTap: () {
-        if (isZkIdentityChallenge(dto)) {
-          context.push(AppRoutes.zkIdentityDetail);
-        } else {
-          context.push(AppRoutes.challengeDetail, extra: enriched);
-        }
+        context.push(AppRoutes.challengeDetail, extra: enriched);
       },
     );
   }

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -20,7 +20,12 @@ import 'package:crypto_mobile_app/features/zk_identity/providers/zk_identity_pro
 import 'package:crypto_mobile_app/features/zk_identity/zk_identity_status_mapper.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
-  const HomeScreen({super.key});
+  const HomeScreen({
+    super.key,
+    this.initialTab = HomeTab.challenges,
+  });
+
+  final int initialTab;
 
   @override
   ConsumerState<HomeScreen> createState() => _HomeScreenState();
@@ -38,7 +43,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     // Initialize current tab
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        ref.read(currentHomeTabProvider.notifier).state = 0;
+        ref.read(currentHomeTabProvider.notifier).state = widget.initialTab;
       }
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/test/core/models/leaderboard_api_models_test.dart
+++ b/test/core/models/leaderboard_api_models_test.dart
@@ -308,9 +308,18 @@ void main() {
 
       test('preserves whitelisted in-app paths for app CTAs', () {
         expect(
+          parseWithLink('/challenges/leaderboard', ctaType: 'app').ctaLink,
+          '/challenges/leaderboard',
+        );
+        expect(
           parseWithLink('/challenges/zk-identity', ctaType: 'app').ctaLink,
           '/challenges/zk-identity',
         );
+        expect(
+          parseWithLink('/challenges/zk-identity/flow', ctaType: 'app').ctaLink,
+          '/challenges/zk-identity/flow',
+        );
+        expect(parseWithLink('/dapps', ctaType: 'app').ctaLink, '/dapps');
         expect(
           parseWithLink('/dapps/opinion-market', ctaType: 'app').ctaLink,
           '/dapps/opinion-market',
@@ -320,6 +329,18 @@ void main() {
       test('rejects non-whitelisted in-app paths for app CTAs', () {
         expect(parseWithLink('/admin', ctaType: 'app').ctaLink, isNull);
         expect(parseWithLink('/dappsevil', ctaType: 'app').ctaLink, isNull);
+        expect(parseWithLink('/wallet/send', ctaType: 'app').ctaLink, isNull);
+        expect(parseWithLink('/settings', ctaType: 'app').ctaLink, isNull);
+        expect(parseWithLink('/main/node', ctaType: 'app').ctaLink, isNull);
+        expect(
+          parseWithLink('/challenges/not-yet-shipped', ctaType: 'app').ctaLink,
+          isNull,
+        );
+        expect(
+          parseWithLink('/dapps/opinion-market/settings', ctaType: 'app')
+              .ctaLink,
+          isNull,
+        );
       });
 
       test('rejects external URLs for app CTAs', () {
@@ -355,6 +376,28 @@ void main() {
         expect(c.ctaType, CtaType.app);
         expect(c.ctaLabel, 'Open Opinion Market');
         expect(c.ctaLink, '/dapps/opinion-market');
+      });
+
+      test('falls back to default CTA when mobile override is invalid', () {
+        final c = ChallengeDto.fromJson({
+          'id': 52,
+          'category': 'community',
+          'goal': 'Master the Opinion Market',
+          'task': 'Vote on markets',
+          'reward': '1/2 of your final credits',
+          'cta_type': null,
+          'cta_label': 'Get Started',
+          'cta_link': 'https://play.google.com/apps/internaltest/123',
+          'mobile_cta_type': 'app',
+          'mobile_cta_label': 'Open Admin',
+          'mobile_cta_link': '/admin',
+          'enabled': true,
+          'completed': false,
+        });
+
+        expect(c.ctaType, isNull);
+        expect(c.ctaLabel, 'Get Started');
+        expect(c.ctaLink, 'https://play.google.com/apps/internaltest/123');
       });
 
       test('falls back to default CTA when mobile override is absent', () {

--- a/test/core/models/leaderboard_api_models_test.dart
+++ b/test/core/models/leaderboard_api_models_test.dart
@@ -400,6 +400,26 @@ void main() {
         expect(c.ctaLink, 'https://play.google.com/apps/internaltest/123');
       });
 
+      test('allows label-only mobile override to inherit default CTA', () {
+        final c = ChallengeDto.fromJson({
+          'id': 52,
+          'category': 'community',
+          'goal': 'Master the Opinion Market',
+          'task': 'Vote on markets',
+          'reward': '1/2 of your final credits',
+          'cta_type': null,
+          'cta_label': 'Get Started',
+          'cta_link': 'https://play.google.com/apps/internaltest/123',
+          'mobile_cta_label': 'Open on Mobile',
+          'enabled': true,
+          'completed': false,
+        });
+
+        expect(c.ctaType, isNull);
+        expect(c.ctaLabel, 'Open on Mobile');
+        expect(c.ctaLink, 'https://play.google.com/apps/internaltest/123');
+      });
+
       test('falls back to default CTA when mobile override is absent', () {
         final c = ChallengeDto.fromJson({
           'id': 52,

--- a/test/core/models/leaderboard_api_models_test.dart
+++ b/test/core/models/leaderboard_api_models_test.dart
@@ -335,6 +335,71 @@ void main() {
         expect(parseWithLink('/challenges/zk-identity').ctaLink, isNull);
       });
 
+      test('prefers mobile app CTA override when present', () {
+        final c = ChallengeDto.fromJson({
+          'id': 52,
+          'category': 'community',
+          'goal': 'Master the Opinion Market',
+          'task': 'Vote on markets',
+          'reward': '1/2 of your final credits',
+          'cta_type': null,
+          'cta_label': 'Get Started',
+          'cta_link': 'https://play.google.com/apps/internaltest/123',
+          'mobile_cta_type': 'app',
+          'mobile_cta_label': 'Open Opinion Market',
+          'mobile_cta_link': '/dapps/opinion-market',
+          'enabled': true,
+          'completed': false,
+        });
+
+        expect(c.ctaType, CtaType.app);
+        expect(c.ctaLabel, 'Open Opinion Market');
+        expect(c.ctaLink, '/dapps/opinion-market');
+      });
+
+      test('falls back to default CTA when mobile override is absent', () {
+        final c = ChallengeDto.fromJson({
+          'id': 52,
+          'category': 'community',
+          'goal': 'Master the Opinion Market',
+          'task': 'Vote on markets',
+          'reward': '1/2 of your final credits',
+          'cta_type': null,
+          'cta_label': 'Get Started',
+          'cta_link': 'https://play.google.com/apps/internaltest/123',
+          'mobile_cta_type': null,
+          'mobile_cta_label': null,
+          'mobile_cta_link': null,
+          'enabled': true,
+          'completed': false,
+        });
+
+        expect(c.ctaType, isNull);
+        expect(c.ctaLabel, 'Get Started');
+        expect(c.ctaLink, 'https://play.google.com/apps/internaltest/123');
+      });
+
+      test('ignores empty mobile override fields', () {
+        final c = ChallengeDto.fromJson({
+          'id': 52,
+          'category': 'community',
+          'goal': 'Master the Opinion Market',
+          'task': 'Vote on markets',
+          'reward': '1/2 of your final credits',
+          'cta_type': null,
+          'cta_label': 'Get Started',
+          'cta_link': 'https://play.google.com/apps/internaltest/123',
+          'mobile_cta_label': '',
+          'mobile_cta_link': '',
+          'enabled': true,
+          'completed': false,
+        });
+
+        expect(c.ctaType, isNull);
+        expect(c.ctaLabel, 'Get Started');
+        expect(c.ctaLink, 'https://play.google.com/apps/internaltest/123');
+      });
+
       test('rejects non-string types', () {
         expect(parseWithLink(null).ctaLink, isNull);
         expect(parseWithLink(42).ctaLink, isNull);

--- a/test/core/utils/app_deep_link_allowlist_test.dart
+++ b/test/core/utils/app_deep_link_allowlist_test.dart
@@ -55,6 +55,40 @@ void main() {
         isAllowedUsernodeAppDeepLink(Uri.parse('usernode://app/wallet/send')),
         false,
       );
+      expect(
+        isAllowedUsernodeAppDeepLink(Uri.parse('usernode:/wallet/send')),
+        false,
+      );
+    });
+  });
+
+  group('shouldBlockUsernodeDeepLink', () {
+    test('blocks any unsupported usernode scheme URI', () {
+      expect(
+        shouldBlockUsernodeDeepLink(Uri.parse('usernode://app/wallet/send')),
+        true,
+      );
+      expect(
+        shouldBlockUsernodeDeepLink(Uri.parse('usernode:/wallet/send')),
+        true,
+      );
+      expect(
+        shouldBlockUsernodeDeepLink(Uri.parse('usernode://other/wallet/send')),
+        true,
+      );
+    });
+
+    test('allows safe usernode app links and ignores non-usernode links', () {
+      expect(
+        shouldBlockUsernodeDeepLink(
+          Uri.parse('usernode://app/challenges/leaderboard'),
+        ),
+        false,
+      );
+      expect(
+        shouldBlockUsernodeDeepLink(Uri.parse('https://usernode.example')),
+        false,
+      );
     });
   });
 }

--- a/test/core/utils/app_deep_link_allowlist_test.dart
+++ b/test/core/utils/app_deep_link_allowlist_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:crypto_mobile_app/core/utils/app_deep_link_allowlist.dart';
+
+void main() {
+  group('isAllowedAppDeepLinkPath', () {
+    test('allows shipped challenge and dApp routes', () {
+      expect(isAllowedAppDeepLinkPath('/challenges/leaderboard'), true);
+      expect(isAllowedAppDeepLinkPath('/challenges/zk-identity'), true);
+      expect(isAllowedAppDeepLinkPath('/challenges/zk-identity/flow'), true);
+      expect(isAllowedAppDeepLinkPath('/dapps'), true);
+      expect(isAllowedAppDeepLinkPath('/dapps/opinion-market'), true);
+    });
+
+    test('rejects sensitive or unknown routes', () {
+      expect(isAllowedAppDeepLinkPath('/wallet/send'), false);
+      expect(isAllowedAppDeepLinkPath('/settings'), false);
+      expect(isAllowedAppDeepLinkPath('/main/node'), false);
+      expect(isAllowedAppDeepLinkPath('/challenges/not-yet-shipped'), false);
+      expect(isAllowedAppDeepLinkPath('/dapps/opinion-market/settings'), false);
+      expect(isAllowedAppDeepLinkPath('/dappsevil'), false);
+    });
+  });
+
+  group('isAllowedUsernodeAppDeepLink', () {
+    test('allows usernode app links for allowlisted paths', () {
+      expect(
+        isAllowedUsernodeAppDeepLink(
+          Uri.parse('usernode://app/challenges/leaderboard'),
+        ),
+        true,
+      );
+      expect(
+        isAllowedUsernodeAppDeepLink(
+          Uri.parse('usernode://app/dapps/opinion-market'),
+        ),
+        true,
+      );
+    });
+
+    test('rejects wrong scheme, host, or path', () {
+      expect(
+        isAllowedUsernodeAppDeepLink(
+          Uri.parse('https://app/challenges/leaderboard'),
+        ),
+        false,
+      );
+      expect(
+        isAllowedUsernodeAppDeepLink(
+          Uri.parse('usernode://other/challenges/leaderboard'),
+        ),
+        false,
+      );
+      expect(
+        isAllowedUsernodeAppDeepLink(Uri.parse('usernode://app/wallet/send')),
+        false,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the minimal Stage 2 deep-link receiver from #434 and moves challenge CTA routing to the backend-owned mobile CTA contract:

- Registers Android `usernode://app/challenges/...` and `usernode://app/dapps/...` with `pathPrefix` filters instead of a catch-all `usernode://app` receiver.
- Registers the `usernode` custom URL scheme on iOS.
- Keeps the existing `usernode-zk://callback` flow intact.
- Uses Flutter/go_router's default platform deep-link routing instead of adding a custom `app_links` listener/parser; warm and cold Android links were smoke-tested through the default path.
- Resolves `mobile_cta_type` / `mobile_cta_label` / `mobile_cta_link` from the Topochain mobile challenges API into the existing effective `cta_type` / `cta_label` / `cta_link` DTO fields when present.
- Treats mobile CTA overrides as an atomic candidate: use the mobile CTA only when its link sanitizes successfully; otherwise fall back to the base CTA.
- Allows label-only mobile CTA overrides to inherit the already-sanitized base CTA link.
- Shares a narrow app deep-link allowlist across backend-provided app CTAs and incoming `usernode://app/...` links.
- Fail-closes all unsupported `usernode:` URIs in the router guard, including non-`app` hosts / no-authority iOS forms.
- Removes wallet/settings/main broad app CTA prefixes; currently allowed app paths are `/challenges/leaderboard`, `/challenges/zk-identity`, `/challenges/zk-identity/flow`, `/dapps`, and `/dapps/<slug>`.
- Adds a bare `/dapps` route that opens the dApps tab, so every allowlisted path is routable.
- Removes the ZK identity challenge-card special case so `Prove you're a unique human` opens the same generic leaderboard-backed challenge detail as other challenges; its CTA is now controlled by backend/admin.

This keeps Flutter's routing surface small while allowing Topochain/admin to define different CTA targets for web leaderboard vs mobile app.

## Current Backend/Admin State Tested

- `Master the Opinion Market` emits `mobile_cta_type=app`, `mobile_cta_label=Open Opinion Market`, `mobile_cta_link=/dapps/opinion-market`.
- `Prove you're a unique human` emits `mobile_cta_type=app`, `mobile_cta_label=Get Started`, `mobile_cta_link=/challenges/zk-identity/flow`.
- Current production challenge payloads were checked for app CTAs: only `/dapps/opinion-market` and `/challenges/zk-identity/flow` are present, so the removed wallet/settings/main prefixes are not used by live mobile CTAs.

## Validation

- `flutter analyze`
- `flutter test test/core/models/leaderboard_api_models_test.dart test/core/utils/app_deep_link_allowlist_test.dart`
- `flutter test`
- `cd packages/ds_lints && dart run bin/lint.dart ../..`
- `flutter build apk --debug`

Android Seeker manual smoke:

- Warm app: `usernode://app/challenges/leaderboard` opens Leaderboard via default Flutter routing; hardware Back exits to launcher.
- Cold app: `usernode://app/challenges/leaderboard` opens Leaderboard via default Flutter routing; hardware Back exits to launcher.
- Active `Master the Opinion Market` opens generic challenge detail, shows `Open Opinion Market`, and tapping it opens the in-app `Opinion Market` dApp screen.
- Completed `Prove you're a unique human` opens generic leaderboard-backed challenge detail, shows `Get Started`, and tapping it opens the in-app ZK identity flow screen.
- Hardened Android build: `usernode://app/challenges/leaderboard`, `usernode://app/dapps/opinion-market`, and `usernode://app/challenges/zk-identity/flow` open expected app screens.
- Hardened Android build: `usernode://app/dapps` cold-starts into the dApps tab.
- Hardened Android build: `usernode://app/dapps/opinion-market` warm-opens the Opinion Market dApp screen.
- Hardened Android build: `usernode://app/wallet/send` does not resolve at the Android intent layer.
- Hardened Android build: `usernode://app/dapps/opinion-market/settings` is accepted by Android's `/dapps` prefix but blocked by the Dart allowlist and redirected to the app home/challenges surface.

Relates to #434.
