### PR TITLE
feat(dapps): enable vibecoding via active TEST_VIBECODING_FRAMEWORK c…

### DIFF
--- a/lib/features/challenges/challenge_mappers.dart
+++ b/lib/features/challenges/challenge_mappers.dart
@@ -388,6 +388,13 @@ bool isProduceBlocksChallenge(ChallengeDto dto) {
   return dto.subCategory == kProduceBlocksSubCategory;
 }
 
+/// SubCategory identifier for the vibecoding-framework challenge.
+const String kVibecodingSubCategory = 'TEST_VIBECODING_FRAMEWORK';
+
+/// True when the challenge is the vibecoding-framework challenge.
+bool isVibecodingChallenge(ChallengeDto dto) =>
+    dto.subCategory == kVibecodingSubCategory;
+
 /// SubCategory identifier for the ZK Identity challenge.
 const String zkIdentitySubCategory = 'ZK_IDENTITY_VERIFICATION';
 

--- a/lib/features/dapps/dapps_screen.dart
+++ b/lib/features/dapps/dapps_screen.dart
@@ -44,7 +44,7 @@ class _DappsScreenState extends ConsumerState<DappsScreen> {
     // the bottom navigation bar; the choice persists across launches.
     // See [DappsTabModeNotifier].
     final overrideUrl = AppConfig.dappsTabUrl.trim();
-    final webviewMode = ref.watch(dappsTabModeProvider);
+    final webviewMode = ref.watch(dappsTabWebviewEnabledProvider);
     if (webviewMode && overrideUrl.isNotEmpty) {
       return DappWebViewScreen(
         url: overrideUrl,

--- a/lib/features/dapps/providers/dapps_tab_mode_provider.dart
+++ b/lib/features/dapps/providers/dapps_tab_mode_provider.dart
@@ -1,3 +1,5 @@
+import 'package:crypto_mobile_app/core/providers/categorized_challenges_provider.dart';
+import 'package:crypto_mobile_app/features/challenges/challenge_mappers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -52,3 +54,25 @@ class DappsTabModeNotifier extends Notifier<bool> {
 
 final dappsTabModeProvider =
     NotifierProvider<DappsTabModeNotifier, bool>(DappsTabModeNotifier.new);
+
+/// True when the user has an *active* vibecoding-framework challenge
+/// (enabled, schedule not expired, not completed — per the categorizer).
+///
+/// Reuses [categorizedChallengesProvider]'s `active` bucket so the
+/// schedule/completion rules stay in one place.
+final vibecodingChallengeActiveProvider = Provider<bool>((ref) {
+  final categorized = ref.watch(categorizedChallengesProvider);
+  final active = categorized?.active ?? const [];
+  return active.any((c) => isVibecodingChallenge(c.dto));
+});
+
+/// Effective webview mode for the dApps tab: the manual long-press toggle
+/// ([dappsTabModeProvider]) OR an active vibecoding challenge.
+///
+/// While such a challenge is active the tab stays in vibecoding mode
+/// regardless of the manual toggle.
+final dappsTabWebviewEnabledProvider = Provider<bool>((ref) {
+  final manual = ref.watch(dappsTabModeProvider);
+  final challenge = ref.watch(vibecodingChallengeActiveProvider);
+  return manual || challenge;
+});


### PR DESCRIPTION
…hallenge

Vibecoding mode on the dApps tab now turns on automatically when the user has an active challenge with sub-category TEST_VIBECODING_FRAMEWORK, in addition to the existing long-press toggle (OR semantics). Reuses the categorized challenges 'active' bucket for schedule/completion rules.