### PR TITLE
perf(node): reduce node status auto-refresh interval to 1s

### DIFF
--- a/lib/core/providers/node_provider.dart
+++ b/lib/core/providers/node_provider.dart
@@ -189,11 +189,10 @@ class NodeStatusController extends AsyncNotifier<NodeStatusState?> {
   ///
   /// A periodic timer kept here makes the provider self-healing: as
   /// soon as the Rust node becomes reachable, the next tick picks up
-  /// fresh status and the whole UI catches up. 10s is a reasonable
-  /// balance — `getStatus()` is one FFI hop + one in-process RPC, so
-  /// the overhead is negligible, and most UI consumers don't need
-  /// sub-second freshness.
-  static const _autoRefreshInterval = Duration(seconds: 10);
+  /// fresh status and the whole UI catches up. `getStatus()` is one FFI
+  /// hop + one in-process RPC, so the overhead is negligible and a tight
+  /// 1s interval keeps the UI close to real-time.
+  static const _autoRefreshInterval = Duration(seconds: 1);
 
   @override
   Future<NodeStatusState?> build() async {


### PR DESCRIPTION
Tightens the nodeStatusProvider periodic refresh from 10s to 1s so the UI stays close to real-time. getStatus() is one FFI hop + in-process RPC, so the overhead is negligible and the in-flight guard prevents ticks from piling up.