### PR TITLE
feat(diagnostics): add opt-in HTTP debug mode

### DIFF
--- a/lib/core/bootstrap/app_bootstrap.dart
+++ b/lib/core/bootstrap/app_bootstrap.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/config/debug_mode.dart';
 import 'package:crypto_mobile_app/core/feature_flags.dart';
 import 'package:crypto_mobile_app/core/models/leaderboard_api_models.dart';
 import 'package:crypto_mobile_app/core/providers/leaderboard_bootstrap.dart';
@@ -56,6 +57,10 @@ class AppBootstrap {
     // Initialize logging with file output
     await LoggingService.initialize();
     final log = LoggingService.instance.withTag(logTag);
+
+    // Load the Debug Mode flag into its synchronous cache so the HTTP layer
+    // sees the correct value before the first request.
+    await DebugModeStorage.init();
 
     if (installErrorHandlers) {
       _installGlobalErrorHandlers(log);

--- a/lib/core/config/app_router.dart
+++ b/lib/core/config/app_router.dart
@@ -32,6 +32,7 @@ import 'package:crypto_mobile_app/features/perf/presentation/perf_benchmark_ui.d
 import 'package:crypto_mobile_app/features/perf/presentation/screens/device_benchmark_screen.dart';
 import 'package:crypto_mobile_app/features/perf/presentation/screens/device_benchmark_result_detail_screen.dart';
 import 'package:crypto_mobile_app/features/perf/presentation/screens/device_benchmark_run_screen.dart';
+import 'package:crypto_mobile_app/features/settings/screens/http_debug_logs_screen.dart';
 import 'package:crypto_mobile_app/features/wallet/screens/scan_screen.dart';
 import 'package:crypto_mobile_app/features/wallet/screens/send_screen.dart';
 import 'package:crypto_mobile_app/features/wallet/screens/transaction_success_screen.dart';
@@ -86,6 +87,7 @@ class AppRoutes {
   static const deviceBenchmarkRun = '/settings/device-benchmark/run';
   static const deviceBenchmarkResultDetail =
       '/settings/device-benchmark/result';
+  static const httpDebugLogs = '/settings/http-debug-logs';
 
   static String dappDetailFor(String slug) => '/dapps/$slug';
 
@@ -273,6 +275,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           final extra = state.extra as DeviceBenchmarkResultDetailArgs;
           return DeviceBenchmarkResultDetailScreen(args: extra);
         },
+      ),
+      GoRoute(
+        path: AppRoutes.httpDebugLogs,
+        builder: (context, state) => const HttpDebugLogsScreen(),
       ),
       GoRoute(
         path: AppRoutes.walletBurst,

--- a/lib/core/config/debug_mode.dart
+++ b/lib/core/config/debug_mode.dart
@@ -1,0 +1,48 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:crypto_mobile_app/core/utils/sentry.dart';
+
+/// Persistence and process-wide cache for the user-facing **Debug Mode** flag.
+///
+/// Debug Mode is off by default and, when enabled, opts the app into capturing
+/// HTTP traffic into an in-memory buffer (see `HttpDebugLogStore`).
+///
+/// The flag is read on the HTTP hot path by `LoggingHttpClient`, which cannot
+/// `await` SharedPreferences per request. To keep that read synchronous, the
+/// last-known value is mirrored into [isEnabled] (a plain `bool`). Call [init]
+/// once at startup so the cache reflects the persisted value before any request
+/// is made; [save] keeps it in sync afterwards.
+class DebugModeStorage {
+  DebugModeStorage._();
+
+  static const _key = 'app:debug_mode';
+
+  /// Synchronously-readable cache of the persisted flag. Defaults to `false`
+  /// until [init] or [load] resolves the stored value.
+  static bool isEnabled = false;
+
+  /// Load the persisted flag into [isEnabled]. Call once during bootstrap.
+  static Future<void> init() async {
+    isEnabled = await load();
+  }
+
+  static Future<bool> load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      isEnabled = prefs.getBool(_key) ?? false;
+      return isEnabled;
+    } catch (e, st) {
+      await SentryUtil.captureError(e, st, tag: 'debug_mode_load');
+      return isEnabled;
+    }
+  }
+
+  static Future<void> save(bool enabled) async {
+    isEnabled = enabled;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_key, enabled);
+    } catch (e, st) {
+      await SentryUtil.captureError(e, st, tag: 'debug_mode_save');
+    }
+  }
+}

--- a/lib/core/config/l10n/app_en.arb
+++ b/lib/core/config/l10n/app_en.arb
@@ -2845,5 +2845,45 @@
   "walletScanCameraPermissionDenied": "Camera permission denied. Enable it in Settings to scan QR codes.",
   "@walletScanCameraPermissionDenied": {
     "description": "Message shown when camera permission is denied"
+  },
+  "settingsDebugMode": "Debug Mode",
+  "@settingsDebugMode": {
+    "description": "Diagnostics toggle that enables in-memory HTTP request logging"
+  },
+  "settingsDebugModeEnabled": "Capturing HTTP requests to memory",
+  "@settingsDebugModeEnabled": {
+    "description": "Subtitle for the debug mode toggle when enabled"
+  },
+  "settingsDebugModeDisabled": "Off · no network logging",
+  "@settingsDebugModeDisabled": {
+    "description": "Subtitle for the debug mode toggle when disabled"
+  },
+  "settingsHttpLogs": "HTTP Logs",
+  "@settingsHttpLogs": {
+    "description": "Diagnostics tile that opens the captured HTTP request log viewer"
+  },
+  "settingsHttpLogsSubtitle": "View captured network requests",
+  "@settingsHttpLogsSubtitle": {
+    "description": "Subtitle for the HTTP logs tile"
+  },
+  "httpLogsTitle": "HTTP Logs",
+  "@httpLogsTitle": {
+    "description": "App bar title of the HTTP debug log viewer"
+  },
+  "httpLogsEmpty": "No requests captured yet. Trigger some network activity to see logs here.",
+  "@httpLogsEmpty": {
+    "description": "Empty state shown when the HTTP log buffer has no entries"
+  },
+  "httpLogsCopy": "Copy all",
+  "@httpLogsCopy": {
+    "description": "Tooltip for the action that copies all captured logs"
+  },
+  "httpLogsClear": "Clear",
+  "@httpLogsClear": {
+    "description": "Tooltip for the action that clears the captured logs"
+  },
+  "httpLogsCopied": "Logs copied to clipboard",
+  "@httpLogsCopied": {
+    "description": "Snackbar shown after copying logs to the clipboard"
   }
 }

--- a/lib/core/config/l10n/app_localizations.dart
+++ b/lib/core/config/l10n/app_localizations.dart
@@ -3729,6 +3729,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Camera permission denied. Enable it in Settings to scan QR codes.'**
   String get walletScanCameraPermissionDenied;
+
+  /// Diagnostics toggle that enables in-memory HTTP request logging
+  ///
+  /// In en, this message translates to:
+  /// **'Debug Mode'**
+  String get settingsDebugMode;
+
+  /// Subtitle for the debug mode toggle when enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Capturing HTTP requests to memory'**
+  String get settingsDebugModeEnabled;
+
+  /// Subtitle for the debug mode toggle when disabled
+  ///
+  /// In en, this message translates to:
+  /// **'Off · no network logging'**
+  String get settingsDebugModeDisabled;
+
+  /// Diagnostics tile that opens the captured HTTP request log viewer
+  ///
+  /// In en, this message translates to:
+  /// **'HTTP Logs'**
+  String get settingsHttpLogs;
+
+  /// Subtitle for the HTTP logs tile
+  ///
+  /// In en, this message translates to:
+  /// **'View captured network requests'**
+  String get settingsHttpLogsSubtitle;
+
+  /// App bar title of the HTTP debug log viewer
+  ///
+  /// In en, this message translates to:
+  /// **'HTTP Logs'**
+  String get httpLogsTitle;
+
+  /// Empty state shown when the HTTP log buffer has no entries
+  ///
+  /// In en, this message translates to:
+  /// **'No requests captured yet. Trigger some network activity to see logs here.'**
+  String get httpLogsEmpty;
+
+  /// Tooltip for the action that copies all captured logs
+  ///
+  /// In en, this message translates to:
+  /// **'Copy all'**
+  String get httpLogsCopy;
+
+  /// Tooltip for the action that clears the captured logs
+  ///
+  /// In en, this message translates to:
+  /// **'Clear'**
+  String get httpLogsClear;
+
+  /// Snackbar shown after copying logs to the clipboard
+  ///
+  /// In en, this message translates to:
+  /// **'Logs copied to clipboard'**
+  String get httpLogsCopied;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/core/config/l10n/app_localizations_en.dart
+++ b/lib/core/config/l10n/app_localizations_en.dart
@@ -2100,4 +2100,35 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get walletScanCameraPermissionDenied =>
       'Camera permission denied. Enable it in Settings to scan QR codes.';
+
+  @override
+  String get settingsDebugMode => 'Debug Mode';
+
+  @override
+  String get settingsDebugModeEnabled => 'Capturing HTTP requests to memory';
+
+  @override
+  String get settingsDebugModeDisabled => 'Off · no network logging';
+
+  @override
+  String get settingsHttpLogs => 'HTTP Logs';
+
+  @override
+  String get settingsHttpLogsSubtitle => 'View captured network requests';
+
+  @override
+  String get httpLogsTitle => 'HTTP Logs';
+
+  @override
+  String get httpLogsEmpty =>
+      'No requests captured yet. Trigger some network activity to see logs here.';
+
+  @override
+  String get httpLogsCopy => 'Copy all';
+
+  @override
+  String get httpLogsClear => 'Clear';
+
+  @override
+  String get httpLogsCopied => 'Logs copied to clipboard';
 }

--- a/lib/core/network/logging_http_client.dart
+++ b/lib/core/network/logging_http_client.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:crypto_mobile_app/core/config/debug_mode.dart';
+import 'package:crypto_mobile_app/core/services/http_debug_log_store.dart';
+
+/// An [http.Client] that records each exchange into [HttpDebugLogStore] when
+/// Debug Mode is on, and is otherwise a transparent pass-through.
+///
+/// The Debug Mode check ([DebugModeStorage.isEnabled]) is a synchronous field
+/// read, so the disabled path adds no measurable overhead — it forwards to the
+/// inner client untouched. When enabled, the streamed response is buffered so
+/// it can be logged and then re-emitted to the caller unchanged.
+///
+/// Captured headers/bodies are redacted/truncated by [HttpLogEntry] before
+/// storage; see `http_debug_log_store.dart`.
+class LoggingHttpClient extends http.BaseClient {
+  LoggingHttpClient(this._inner);
+
+  final http.Client _inner;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (!DebugModeStorage.isEnabled) {
+      return _inner.send(request);
+    }
+
+    // Only plain (non-streamed/non-multipart) requests expose a readable body.
+    final requestBody = request is http.Request ? request.body : null;
+    final sw = Stopwatch()..start();
+
+    try {
+      final response = await _inner.send(request);
+      // Buffer the body so we can both log it and hand it back to the caller.
+      final bytes = await response.stream.toBytes();
+      sw.stop();
+
+      HttpDebugLogStore.instance.add(
+        HttpLogEntry(
+          timestamp: DateTime.now(),
+          method: request.method,
+          url: request.url.toString(),
+          statusCode: response.statusCode,
+          durationMs: sw.elapsedMilliseconds,
+          requestHeaders: request.headers,
+          requestBody: truncateBody(requestBody),
+          responseHeaders: response.headers,
+          responseBody: truncateBody(_decodeBody(bytes)),
+        ),
+      );
+
+      return http.StreamedResponse(
+        Stream.value(bytes),
+        response.statusCode,
+        contentLength: bytes.length,
+        request: response.request,
+        headers: response.headers,
+        isRedirect: response.isRedirect,
+        persistentConnection: response.persistentConnection,
+        reasonPhrase: response.reasonPhrase,
+      );
+    } catch (e) {
+      sw.stop();
+      HttpDebugLogStore.instance.add(
+        HttpLogEntry(
+          timestamp: DateTime.now(),
+          method: request.method,
+          url: request.url.toString(),
+          durationMs: sw.elapsedMilliseconds,
+          requestHeaders: request.headers,
+          requestBody: truncateBody(requestBody),
+          error: e.toString(),
+        ),
+      );
+      rethrow;
+    }
+  }
+
+  /// Best-effort decode for display. Binary payloads are tolerated via
+  /// [utf8.decode]'s `allowMalformed`; [truncateBody] caps the result later.
+  String _decodeBody(List<int> bytes) {
+    if (bytes.isEmpty) return '';
+    try {
+      return utf8.decode(bytes, allowMalformed: true);
+    } catch (_) {
+      return '<${bytes.length} bytes>';
+    }
+  }
+
+  @override
+  void close() => _inner.close();
+}
+
+/// Build the app's standard HTTP client.
+///
+/// Always returns a [LoggingHttpClient]; capture is gated at request time by
+/// [DebugModeStorage.isEnabled], so this is safe (and cheap) to use everywhere
+/// a plain `http.Client()` was previously constructed.
+http.Client createAppHttpClient() => LoggingHttpClient(http.Client());

--- a/lib/core/providers/providers.dart
+++ b/lib/core/providers/providers.dart
@@ -5,6 +5,8 @@ import 'package:crypto_mobile_app/core/providers/accounts_provider.dart';
 import 'package:crypto_mobile_app/features/node/node_service.dart';
 import 'package:crypto_mobile_app/src/rust/lib.dart' as rust;
 import 'package:crypto_mobile_app/core/config/theme_mode.dart';
+import 'package:crypto_mobile_app/core/config/debug_mode.dart';
+import 'package:crypto_mobile_app/core/services/http_debug_log_store.dart';
 import 'package:flutter/material.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
@@ -94,6 +96,32 @@ final themeModeProvider =
     StateNotifierProvider<ThemeModeController, ThemeMode>((ref) {
   return ThemeModeController();
 });
+
+// Debug mode controller with persistence. When enabled, the app captures HTTP
+// traffic into [HttpDebugLogStore] (off by default).
+class DebugModeController extends StateNotifier<bool> {
+  DebugModeController() : super(DebugModeStorage.isEnabled) {
+    _init();
+  }
+
+  Future<void> _init() async {
+    state = await DebugModeStorage.load();
+  }
+
+  Future<void> set(bool enabled) async {
+    state = enabled;
+    await DebugModeStorage.save(enabled);
+  }
+}
+
+final debugModeProvider =
+    StateNotifierProvider<DebugModeController, bool>((ref) {
+  return DebugModeController();
+});
+
+/// Exposes the in-memory HTTP debug log buffer to the viewer UI.
+final httpDebugLogStoreProvider =
+    Provider<HttpDebugLogStore>((ref) => HttpDebugLogStore.instance);
 
 // Current network provider for reactive network state tracking
 class CurrentNetworkController extends StateNotifier<String> {

--- a/lib/core/services/explorer_service.dart
+++ b/lib/core/services/explorer_service.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/core/network/logging_http_client.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 
 final _log = LoggingService.instance.withTag('ExplorerService');
@@ -19,7 +19,7 @@ enum DataSource {
 /// Explorer API service with multi-tier fallback strategy
 class ExplorerService {
   final Ref _ref;
-  final _client = http.Client();
+  final _client = createAppHttpClient();
 
   ExplorerService(this._ref);
 

--- a/lib/core/services/http_debug_log_store.dart
+++ b/lib/core/services/http_debug_log_store.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/foundation.dart';
+
+/// Header names whose values are masked before an entry is stored or shared.
+/// Lower-cased; matching is case-insensitive.
+const _sensitiveHeaders = <String>{
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-auth-token',
+  'api-key',
+};
+
+/// Per-body capture cap. Bodies longer than this are truncated so a single
+/// large response can't dominate (or blow past) the buffer's byte budget.
+const int _maxBodyChars = 8 * 1024;
+
+const String _redactedMarker = '***';
+const String _truncatedSuffix = '…[truncated]';
+
+/// Redact sensitive header values in [headers], returning a new map.
+Map<String, String> redactHeaders(Map<String, String> headers) {
+  return headers.map(
+    (k, v) => MapEntry(
+        k, _sensitiveHeaders.contains(k.toLowerCase()) ? _redactedMarker : v),
+  );
+}
+
+/// Truncate [body] to [_maxBodyChars], appending a marker when shortened.
+/// `null` (e.g. a streamed/unknown body) is passed through unchanged.
+String? truncateBody(String? body) {
+  if (body == null) return null;
+  if (body.length <= _maxBodyChars) return body;
+  return body.substring(0, _maxBodyChars) + _truncatedSuffix;
+}
+
+/// One captured HTTP exchange. All fields are already redacted/truncated; this
+/// type holds presentation-ready data only.
+@immutable
+class HttpLogEntry {
+  HttpLogEntry({
+    required this.timestamp,
+    required this.method,
+    required this.url,
+    this.statusCode,
+    this.durationMs,
+    Map<String, String> requestHeaders = const {},
+    this.requestBody,
+    Map<String, String> responseHeaders = const {},
+    this.responseBody,
+    this.error,
+  })  : requestHeaders = redactHeaders(requestHeaders),
+        responseHeaders = redactHeaders(responseHeaders);
+
+  final DateTime timestamp;
+  final String method;
+  final String url;
+
+  /// Null while the request is in flight or when it threw before a response.
+  final int? statusCode;
+  final int? durationMs;
+
+  final Map<String, String> requestHeaders;
+  final String? requestBody;
+  final Map<String, String> responseHeaders;
+  final String? responseBody;
+
+  /// Set when the request threw (timeout, socket error, …) instead of returning.
+  final String? error;
+
+  bool get isError =>
+      error != null || (statusCode != null && statusCode! >= 400);
+
+  /// Approximate in-memory footprint, used by [HttpDebugLogStore] for its byte
+  /// budget. UTF-16 code units (2 bytes each) overestimate slightly, which is
+  /// the safe direction for a cap.
+  late final int approxBytes = _computeBytes();
+
+  int _computeBytes() {
+    var chars = method.length + url.length + (error?.length ?? 0);
+    chars += requestBody?.length ?? 0;
+    chars += responseBody?.length ?? 0;
+    for (final e in requestHeaders.entries) {
+      chars += e.key.length + e.value.length;
+    }
+    for (final e in responseHeaders.entries) {
+      chars += e.key.length + e.value.length;
+    }
+    return chars * 2;
+  }
+
+  /// Multi-line, human-readable form used for copy/share.
+  String toLogText() {
+    final b = StringBuffer()
+      ..writeln('[${timestamp.toIso8601String()}] $method $url')
+      ..writeln(
+        'status: ${statusCode ?? '-'}'
+        '${durationMs != null ? '  (${durationMs}ms)' : ''}',
+      );
+    if (error != null) b.writeln('error: $error');
+    if (requestHeaders.isNotEmpty) {
+      b.writeln('> request headers:');
+      requestHeaders.forEach((k, v) => b.writeln('>   $k: $v'));
+    }
+    if (requestBody != null && requestBody!.isNotEmpty) {
+      b
+        ..writeln('> request body:')
+        ..writeln(requestBody);
+    }
+    if (responseHeaders.isNotEmpty) {
+      b.writeln('< response headers:');
+      responseHeaders.forEach((k, v) => b.writeln('<   $k: $v'));
+    }
+    if (responseBody != null && responseBody!.isNotEmpty) {
+      b
+        ..writeln('< response body:')
+        ..writeln(responseBody);
+    }
+    return b.toString();
+  }
+}
+
+/// In-memory ring buffer of recent [HttpLogEntry]s, capped by total bytes.
+///
+/// **Ephemeral**: entries live in RAM only and are lost on app restart — this
+/// is a debugging aid, not persisted telemetry. When [add]ing would push the
+/// total over [maxBytes], the oldest entries are evicted (FIFO) until it fits;
+/// a single oversized entry is still kept (it has already been body-truncated).
+///
+/// A [ChangeNotifier] so the viewer rebuilds live as requests arrive.
+class HttpDebugLogStore extends ChangeNotifier {
+  HttpDebugLogStore._();
+  static final HttpDebugLogStore instance = HttpDebugLogStore._();
+
+  /// 1 MB byte budget (matches the product requirement).
+  static const int maxBytes = 1024 * 1024;
+
+  final List<HttpLogEntry> _entries = [];
+  int _totalBytes = 0;
+
+  /// Newest-first snapshot for display.
+  List<HttpLogEntry> get entries => _entries.reversed.toList(growable: false);
+
+  int get totalBytes => _totalBytes;
+
+  void add(HttpLogEntry entry) {
+    _entries.add(entry);
+    _totalBytes += entry.approxBytes;
+    // Evict oldest until within budget, but always keep the just-added entry.
+    while (_totalBytes > maxBytes && _entries.length > 1) {
+      final removed = _entries.removeAt(0);
+      _totalBytes -= removed.approxBytes;
+    }
+    notifyListeners();
+  }
+
+  void clear() {
+    if (_entries.isEmpty) return;
+    _entries.clear();
+    _totalBytes = 0;
+    notifyListeners();
+  }
+
+  /// Whole buffer rendered as text, newest first, for copy/share.
+  String toExportText() => entries.map((e) => e.toLogText()).join('\n');
+}

--- a/lib/core/services/leaderboard_api_service.dart
+++ b/lib/core/services/leaderboard_api_service.dart
@@ -6,6 +6,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/models/leaderboard_api_models.dart';
+import 'package:crypto_mobile_app/core/network/logging_http_client.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
 
@@ -19,7 +20,7 @@ class LeaderboardApiService {
     http.Client? httpClient,
     bool? writesEnabled,
   })  : _baseUrl = baseUrl ?? AppConfig.leaderboardApiBaseUrl,
-        _http = httpClient ?? http.Client(),
+        _http = httpClient ?? createAppHttpClient(),
         _writesEnabled = writesEnabled ?? !AppConfig.viewOnly;
 
   final String _baseUrl;

--- a/lib/features/metrics/metrics_reporting_service.dart
+++ b/lib/features/metrics/metrics_reporting_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/network/logging_http_client.dart';
 import 'package:crypto_mobile_app/core/services/app_reset_service.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/models/block_production_event.dart';
@@ -180,7 +181,7 @@ class MetricsReportingService {
     );
 
     // Initialize HTTP client
-    _httpClient = http.Client();
+    _httpClient = createAppHttpClient();
 
     // Test connection
     final connected = await _testConnection();
@@ -312,7 +313,7 @@ class MetricsReportingService {
     // closes [_httpClient] in [stop]).
     var client = _httpClient;
     final ownedClient = client == null;
-    client ??= http.Client();
+    client ??= createAppHttpClient();
 
     try {
       final response = await client

--- a/lib/features/onboarding/data/repositories/registration_repository.dart
+++ b/lib/features/onboarding/data/repositories/registration_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/network/logging_http_client.dart';
 import 'package:crypto_mobile_app/core/providers/leaderboard_participant_provider.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/sentry.dart';
@@ -25,7 +26,7 @@ class RegistrationRepository {
     http.Client? httpClient,
     bool? writesEnabled,
   })  : _endpoint = endpoint ?? AppConfig.registrationEndpoint,
-        _http = httpClient ?? http.Client(),
+        _http = httpClient ?? createAppHttpClient(),
         _writesEnabled = writesEnabled ?? !AppConfig.viewOnly;
 
   final String _endpoint;

--- a/lib/features/settings/screens/http_debug_logs_screen.dart
+++ b/lib/features/settings/screens/http_debug_logs_screen.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
+import 'package:crypto_mobile_app/core/providers/providers.dart';
+import 'package:crypto_mobile_app/core/services/http_debug_log_store.dart';
+import 'package:crypto_mobile_app/design_system/design_system.dart';
+
+/// Viewer for HTTP traffic captured while Debug Mode is on.
+///
+/// Reads the in-memory [HttpDebugLogStore] and rebuilds live as requests
+/// arrive (the store is a [ChangeNotifier]). Entries are already redacted and
+/// truncated. The app bar offers copy-all-to-clipboard and clear.
+class HttpDebugLogsScreen extends ConsumerWidget {
+  const HttpDebugLogsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final store = ref.watch(httpDebugLogStoreProvider);
+    final l10n = AppLocalizations.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.httpLogsTitle),
+        actions: [
+          IconButton(
+            icon: const Icon(Symbols.content_copy_sharp),
+            tooltip: l10n.httpLogsCopy,
+            onPressed: () async {
+              final text = store.toExportText();
+              if (text.isEmpty) return;
+              await Clipboard.setData(ClipboardData(text: text));
+              if (!context.mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text(l10n.httpLogsCopied)),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Symbols.delete_sharp),
+            tooltip: l10n.httpLogsClear,
+            onPressed: store.clear,
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: ListenableBuilder(
+          listenable: store,
+          builder: (context, _) {
+            final entries = store.entries;
+            if (entries.isEmpty) {
+              return _EmptyState(message: l10n.httpLogsEmpty);
+            }
+            return ListView.separated(
+              itemCount: entries.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, i) => _HttpLogTile(entry: entries[i]),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final spacing = theme.extension<AppSpacing>()!;
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(spacing.space24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Symbols.cloud_off_sharp,
+              size: spacing.space48,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            SizedBox(height: spacing.space16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HttpLogTile extends StatelessWidget {
+  const _HttpLogTile({required this.entry});
+
+  final HttpLogEntry entry;
+
+  static const _monoStyle =
+      TextStyle(fontFamily: kMonoFontFamily, fontSize: 12);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final spacing = theme.extension<AppSpacing>()!;
+    final semantic = theme.extension<AppSemanticColors>()!;
+
+    final statusColor =
+        entry.isError ? theme.colorScheme.error : semantic.success.color;
+    final statusLabel = entry.statusCode?.toString() ?? 'ERR';
+    final uri = Uri.tryParse(entry.url);
+    final pathLabel = uri == null
+        ? entry.url
+        : '${uri.host}${uri.path}${uri.hasQuery ? '?${uri.query}' : ''}';
+
+    return ExpansionTile(
+      tilePadding: EdgeInsets.symmetric(horizontal: spacing.space16),
+      childrenPadding: EdgeInsets.fromLTRB(
+        spacing.space16,
+        0,
+        spacing.space16,
+        spacing.space16,
+      ),
+      leading: Text(
+        statusLabel,
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: statusColor,
+          fontFamily: kMonoFontFamily,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      title: Text(
+        '${entry.method}  $pathLabel',
+        style: _monoStyle,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        '${_formatTime(entry.timestamp)}'
+        '${entry.durationMs != null ? '  ·  ${entry.durationMs}ms' : ''}',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      children: [
+        SelectableText(entry.toLogText(), style: _monoStyle),
+      ],
+    );
+  }
+
+  String _formatTime(DateTime t) => '${t.hour.toString().padLeft(2, '0')}:'
+      '${t.minute.toString().padLeft(2, '0')}:'
+      '${t.second.toString().padLeft(2, '0')}';
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -460,6 +460,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final l10n = AppLocalizations.of(context);
 
     final themeMode = ref.watch(themeModeProvider);
+    final debugModeEnabled = ref.watch(debugModeProvider);
     final zkSettings = ref.watch(zkPassportSettingsProvider);
     final perfState = ref.watch(perfBenchmarkProvider);
     final facematchStrict =
@@ -510,6 +511,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                       ? AppRoutes.deviceBenchmarkRun
                       : AppRoutes.deviceBenchmark,
                 ),
+                debugModeEnabled: debugModeEnabled,
+                onDebugModeChanged: (value) =>
+                    ref.read(debugModeProvider.notifier).set(value),
+                onHttpLogsTap: () => context.push(AppRoutes.httpDebugLogs),
               ),
 
               SizedBox(height: spacing.space24),

--- a/lib/features/settings/widgets/diagnostics_settings_section.dart
+++ b/lib/features/settings/widgets/diagnostics_settings_section.dart
@@ -7,9 +7,20 @@ class DiagnosticsSettingsSection extends StatelessWidget {
   const DiagnosticsSettingsSection({
     super.key,
     required this.onDeviceBenchmarkTap,
+    required this.debugModeEnabled,
+    required this.onDebugModeChanged,
+    required this.onHttpLogsTap,
   });
 
   final VoidCallback onDeviceBenchmarkTap;
+
+  /// Whether Debug Mode (in-memory HTTP capture) is on.
+  final bool debugModeEnabled;
+  final ValueChanged<bool> onDebugModeChanged;
+
+  /// Opens the captured HTTP log viewer. Only reachable while
+  /// [debugModeEnabled] is true.
+  final VoidCallback onHttpLogsTap;
 
   @override
   Widget build(BuildContext context) {
@@ -17,6 +28,10 @@ class DiagnosticsSettingsSection extends StatelessWidget {
     final radii = theme.extension<AppRadii>()!;
     final sizing = theme.extension<AppSizing>()!;
     final l10n = AppLocalizations.of(context);
+
+    final tileShape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(radii.large)),
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -31,12 +46,36 @@ class DiagnosticsSettingsSection extends StatelessWidget {
               Symbols.chevron_right_sharp,
               size: sizing.iconSmall,
             ),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(
-                Radius.circular(radii.large),
-              ),
-            ),
+            shape: tileShape,
             onTap: onDeviceBenchmarkTap,
+          ),
+        ),
+        Card(
+          child: Column(
+            children: [
+              SwitchListTile(
+                secondary: const Icon(Symbols.bug_report_sharp),
+                title: Text(l10n.settingsDebugMode),
+                subtitle: Text(
+                  debugModeEnabled
+                      ? l10n.settingsDebugModeEnabled
+                      : l10n.settingsDebugModeDisabled,
+                ),
+                value: debugModeEnabled,
+                onChanged: onDebugModeChanged,
+              ),
+              if (debugModeEnabled)
+                ListTile(
+                  leading: const Icon(Symbols.terminal_sharp),
+                  title: Text(l10n.settingsHttpLogs),
+                  subtitle: Text(l10n.settingsHttpLogsSubtitle),
+                  trailing: Icon(
+                    Symbols.chevron_right_sharp,
+                    size: sizing.iconSmall,
+                  ),
+                  onTap: onHttpLogsTap,
+                ),
+            ],
           ),
         ),
       ],

--- a/lib/features/zkpassport/data/repositories/zkpassport_repositories.dart
+++ b/lib/features/zkpassport/data/repositories/zkpassport_repositories.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/network/logging_http_client.dart';
 import 'package:crypto_mobile_app/core/providers/accounts_provider.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/core/utils/network_prefs.dart';
@@ -246,7 +247,7 @@ class ZkPassportSessionServerRepository {
     http.Client? httpClient,
     bool? writesEnabled,
   })  : _baseUrl = _normalizeBaseUrl(baseUrl),
-        _http = httpClient ?? http.Client(),
+        _http = httpClient ?? createAppHttpClient(),
         _writesEnabled = writesEnabled ?? !AppConfig.viewOnly;
 
   final String _baseUrl;

--- a/test/core/network/logging_http_client_test.dart
+++ b/test/core/network/logging_http_client_test.dart
@@ -1,0 +1,81 @@
+import 'package:crypto_mobile_app/core/config/debug_mode.dart';
+import 'package:crypto_mobile_app/core/network/logging_http_client.dart';
+import 'package:crypto_mobile_app/core/services/http_debug_log_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  final store = HttpDebugLogStore.instance;
+
+  setUp(() {
+    store.clear();
+    DebugModeStorage.isEnabled = false;
+  });
+  tearDown(() {
+    store.clear();
+    DebugModeStorage.isEnabled = false;
+  });
+
+  test(
+      'does not capture when Debug Mode is off, but still returns the response',
+      () async {
+    final client = LoggingHttpClient(
+      MockClient((_) async => http.Response('{"ok":true}', 200)),
+    );
+
+    final res = await client.get(Uri.parse('https://example.com/api'));
+
+    expect(res.body, '{"ok":true}');
+    expect(store.entries, isEmpty);
+  });
+
+  test('captures a redacted entry when Debug Mode is on', () async {
+    DebugModeStorage.isEnabled = true;
+    final client = LoggingHttpClient(
+      MockClient((req) async {
+        // Body is preserved end-to-end.
+        return http.Response('{"value":42}', 200,
+            headers: {'content-type': 'application/json'});
+      }),
+    );
+
+    final res = await client.post(
+      Uri.parse('https://example.com/api'),
+      headers: {'Authorization': 'Bearer super-secret'},
+      body: 'request-payload',
+    );
+
+    // Caller still receives the untouched response.
+    expect(res.statusCode, 200);
+    expect(res.body, '{"value":42}');
+
+    expect(store.entries, hasLength(1));
+    final entry = store.entries.first;
+    expect(entry.method, 'POST');
+    expect(entry.statusCode, 200);
+    expect(entry.requestBody, 'request-payload');
+    expect(entry.responseBody, '{"value":42}');
+    // The secret must be redacted.
+    expect(entry.requestHeaders['Authorization'], '***');
+    expect(entry.toLogText(), isNot(contains('super-secret')));
+  });
+
+  test('records an error entry and rethrows when the request throws', () async {
+    DebugModeStorage.isEnabled = true;
+    final client = LoggingHttpClient(
+      MockClient((_) async => throw Exception('boom')),
+    );
+
+    await expectLater(
+      client.get(Uri.parse('https://example.com/fail')),
+      throwsA(isA<Exception>()),
+    );
+
+    expect(store.entries, hasLength(1));
+    final entry = store.entries.first;
+    expect(entry.isError, isTrue);
+    expect(entry.error, contains('boom'));
+    expect(entry.statusCode, isNull);
+  });
+}

--- a/test/core/services/http_debug_log_store_test.dart
+++ b/test/core/services/http_debug_log_store_test.dart
@@ -1,0 +1,141 @@
+import 'package:crypto_mobile_app/core/services/http_debug_log_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+HttpLogEntry _entry({
+  String method = 'GET',
+  String url = 'https://example.com/api',
+  int? statusCode = 200,
+  Map<String, String> requestHeaders = const {},
+  String? responseBody,
+}) {
+  return HttpLogEntry(
+    timestamp: DateTime(2026, 1, 1),
+    method: method,
+    url: url,
+    statusCode: statusCode,
+    requestHeaders: requestHeaders,
+    responseBody: responseBody,
+  );
+}
+
+void main() {
+  group('redactHeaders', () {
+    test('masks sensitive headers case-insensitively, keeps the rest', () {
+      final redacted = redactHeaders({
+        'Authorization': 'Bearer secret-token',
+        'COOKIE': 'session=abc',
+        'X-Api-Key': 'key123',
+        'Content-Type': 'application/json',
+      });
+
+      expect(redacted['Authorization'], '***');
+      expect(redacted['COOKIE'], '***');
+      expect(redacted['X-Api-Key'], '***');
+      // Non-sensitive headers pass through untouched.
+      expect(redacted['Content-Type'], 'application/json');
+    });
+
+    test('entry construction redacts request and response headers', () {
+      final entry = HttpLogEntry(
+        timestamp: DateTime(2026, 1, 1),
+        method: 'POST',
+        url: 'https://example.com',
+        requestHeaders: const {'authorization': 'Bearer x'},
+        responseHeaders: const {'set-cookie': 'a=b'},
+      );
+
+      expect(entry.requestHeaders['authorization'], '***');
+      expect(entry.responseHeaders['set-cookie'], '***');
+      expect(entry.toLogText(), isNot(contains('Bearer x')));
+      expect(entry.toLogText(), isNot(contains('a=b')));
+    });
+  });
+
+  group('truncateBody', () {
+    test('passes through null and short bodies', () {
+      expect(truncateBody(null), isNull);
+      expect(truncateBody('short'), 'short');
+    });
+
+    test('truncates bodies over the cap and marks them', () {
+      final long = 'x' * (9 * 1024);
+      final result = truncateBody(long)!;
+
+      expect(result.length, lessThan(long.length));
+      expect(result, endsWith('…[truncated]'));
+    });
+  });
+
+  group('HttpDebugLogStore', () {
+    final store = HttpDebugLogStore.instance;
+
+    setUp(store.clear);
+    tearDown(store.clear);
+
+    test('returns entries newest-first', () {
+      store
+        ..add(_entry(url: 'https://example.com/first'))
+        ..add(_entry(url: 'https://example.com/second'));
+
+      final entries = store.entries;
+      expect(entries.first.url, 'https://example.com/second');
+      expect(entries.last.url, 'https://example.com/first');
+    });
+
+    test('clear empties the buffer and resets the byte total', () {
+      store.add(_entry(responseBody: 'some body'));
+      expect(store.entries, isNotEmpty);
+      expect(store.totalBytes, greaterThan(0));
+
+      store.clear();
+      expect(store.entries, isEmpty);
+      expect(store.totalBytes, 0);
+    });
+
+    test('evicts oldest entries to stay within the byte cap', () {
+      // Each entry carries a ~200KB body, so ~6 exceed the 1MB cap.
+      final bigBody = 'y' * (200 * 1024);
+      for (var i = 0; i < 12; i++) {
+        store.add(_entry(url: 'https://example.com/$i', responseBody: bigBody));
+      }
+
+      expect(store.totalBytes, lessThanOrEqualTo(HttpDebugLogStore.maxBytes));
+      // The oldest entry must have been evicted; the newest must survive.
+      final urls = store.entries.map((e) => e.url).toList();
+      expect(urls, contains('https://example.com/11'));
+      expect(urls, isNot(contains('https://example.com/0')));
+    });
+
+    test('keeps a single entry even if it alone exceeds the cap', () {
+      final huge = HttpLogEntry(
+        timestamp: DateTime(2026, 1, 1),
+        method: 'GET',
+        url: 'https://example.com/huge',
+        statusCode: 200,
+        // approxBytes counts UTF-16 (2 bytes/char), so this clears 1MB alone.
+        responseBody: 'z' * (HttpDebugLogStore.maxBytes),
+      );
+      store.add(huge);
+
+      expect(store.entries.length, 1);
+      expect(store.entries.first.url, 'https://example.com/huge');
+    });
+  });
+
+  group('HttpLogEntry.isError', () {
+    test('is true for >=400 status and for thrown errors', () {
+      expect(_entry(statusCode: 500).isError, isTrue);
+      expect(_entry(statusCode: 404).isError, isTrue);
+      expect(_entry(statusCode: 200).isError, isFalse);
+
+      final errored = HttpLogEntry(
+        timestamp: DateTime(2026, 1, 1),
+        method: 'GET',
+        url: 'https://example.com',
+        statusCode: null,
+        error: 'TimeoutException',
+      );
+      expect(errored.isError, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Add a Debug Mode toggle (off by default) under Settings → Diagnostics that captures HTTP request/response activity into a capped in-memory ring buffer (≤ 1MB) for inspection and copy/export.

- DebugModeStorage: persisted flag with a synchronous cache for the HTTP hot path; loaded at bootstrap.
- HttpDebugLogStore: ChangeNotifier singleton, 1MB FIFO eviction, with header redaction + body truncation helpers.
- LoggingHttpClient (http.BaseClient): transparent when off; when on, times the call, buffers/re-emits the response, records a redacted entry (and error entries on throw). createAppHttpClient() factory routes the 6 existing http.Client() sites through it.
- HttpDebugLogsScreen: live viewer (newest-first, expandable) with copy-all and clear; reachable only while Debug Mode is on.
- l10n strings + route. Tests cover redaction, truncation, eviction, clear, and the client wrapper (capture/pass-through/error).

Capture is RAM-only and ephemeral; Rust/FFI RPC traffic is out of scope.