### PR TITLE
fix: recover block production alarms after restart

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -113,6 +113,7 @@
                 <action android:name="com.usernode.app.SLOT_ALARM" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.app.action.SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED" />
             </intent-filter>
         </receiver>
 

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmMethodChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmMethodChannelHandler.kt
@@ -40,6 +40,7 @@ class AlarmMethodChannelHandler(context: Context) {
 
     private var methodChannel: MethodChannel? = null
     private val flutterAlarmEventBuffer = FlutterAlarmEventBuffer()
+    private var lastKnownExactAlarmPermission: Boolean? = null
 
     companion object {
         private const val TAG = "usernode/AlarmMethodChannelHandler"
@@ -179,6 +180,15 @@ class AlarmMethodChannelHandler(context: Context) {
                 val success = alarmScheduler.cancelAllAlarms()
                 result.success(success)
             }
+            "hasScheduledAlarm" -> {
+                val alarmId = call.argument<String>("alarmId")
+                if (alarmId == null) {
+                    result.error("INVALID_ARGS", "Missing alarmId", null)
+                    return
+                }
+
+                result.success(alarmScheduler.hasScheduledAlarm(alarmId))
+            }
             "startForegroundService" -> {
                 val title = call.argument<String>("title")
                 val message = call.argument<String>("message")
@@ -277,6 +287,9 @@ class AlarmMethodChannelHandler(context: Context) {
             "restartActivity" -> {
                 result.success(restartActivity())
             }
+            "wasForceStoppedOnStartup" -> {
+                result.success(wasForceStoppedOnStartup())
+            }
             else -> {
                 result.notImplemented()
             }
@@ -309,11 +322,13 @@ class AlarmMethodChannelHandler(context: Context) {
     }
 
     private fun hasExactAlarmPermission(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        val hasPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             alarmManager.canScheduleExactAlarms()
         } else {
             true // No permission needed before Android 12
         }
+        lastKnownExactAlarmPermission = hasPermission
+        return hasPermission
     }
 
     private fun requestExactAlarmPermission(): Boolean {
@@ -329,7 +344,14 @@ class AlarmMethodChannelHandler(context: Context) {
             } else {
                 // Permission already granted
                 Log.d(TAG, "Exact alarm permission already granted")
-                sendEventToFlutter("android_exact_alarm_permission_granted", emptyMap())
+                lastKnownExactAlarmPermission = true
+                sendEventToFlutter(
+                    "android_exact_alarm_permission_granted",
+                    mapOf(
+                        "source" to "request_already_granted",
+                        "stateChanged" to false
+                    )
+                )
             }
         }
         return true
@@ -339,11 +361,26 @@ class AlarmMethodChannelHandler(context: Context) {
     fun checkAndNotifyExactAlarmPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             val hasPermission = alarmManager.canScheduleExactAlarms()
+            val previous = lastKnownExactAlarmPermission
+            val stateChanged = previous != null && previous != hasPermission
+            lastKnownExactAlarmPermission = hasPermission
             Log.d(TAG, "Exact alarm permission check: $hasPermission")
             if (hasPermission) {
-                sendEventToFlutter("android_exact_alarm_permission_granted", emptyMap())
+                sendEventToFlutter(
+                    "android_exact_alarm_permission_granted",
+                    mapOf(
+                        "source" to "resume_permission_check",
+                        "stateChanged" to stateChanged
+                    )
+                )
             } else {
-                sendEventToFlutter("android_exact_alarm_permission_denied", emptyMap())
+                sendEventToFlutter(
+                    "android_exact_alarm_permission_denied",
+                    mapOf(
+                        "source" to "resume_permission_check",
+                        "stateChanged" to stateChanged
+                    )
+                )
             }
         }
     }
@@ -524,6 +561,34 @@ class AlarmMethodChannelHandler(context: Context) {
             putInt("execution_count", currentCount + 1)
             putLong("last_execution_time", System.currentTimeMillis())
             apply()
+        }
+    }
+
+    private fun wasForceStoppedOnStartup(): Boolean {
+        if (Build.VERSION.SDK_INT < 35) {
+            return false
+        }
+
+        return try {
+            val activityManager = appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            val method = activityManager.javaClass.getMethod(
+                "getHistoricalProcessStartReasons",
+                Int::class.javaPrimitiveType!!
+            )
+            val startReasons = method.invoke(activityManager, 0) as? List<*> ?: return false
+            startReasons.any { info ->
+                try {
+                    val wasForceStopped = info?.javaClass
+                        ?.getMethod("wasForceStopped")
+                        ?.invoke(info) as? Boolean
+                    wasForceStopped == true
+                } catch (e: Exception) {
+                    false
+                }
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "Unable to inspect ApplicationStartInfo.wasForceStopped", e)
+            false
         }
     }
 

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
@@ -1,5 +1,6 @@
 package com.usernode_labs.usernode.alarm
 
+import android.app.AlarmManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -15,6 +16,8 @@ import com.usernode_labs.usernode.R
 class AlarmReceiver : BroadcastReceiver() {
     companion object {
         private const val TAG = "usernode/AlarmReceiver"
+        private const val ACTION_EXACT_ALARM_PERMISSION_CHANGED =
+            "android.app.action.SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED"
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -29,6 +32,9 @@ class AlarmReceiver : BroadcastReceiver() {
             }
             Intent.ACTION_MY_PACKAGE_REPLACED -> {
                 handlePackageReplaced(context)
+            }
+            ACTION_EXACT_ALARM_PERMISSION_CHANGED -> {
+                handleExactAlarmPermissionStateChanged(context)
             }
             else -> {
                 Log.w(TAG, "[AlarmReceiver] Unknown action received: ${intent.action}")
@@ -121,6 +127,7 @@ class AlarmReceiver : BroadcastReceiver() {
 
     private fun handleBootCompleted(context: Context) {
         Log.i(TAG, "Device boot completed - starting monitoring")
+        sendAuditRecoveryEvent(context, "boot_completed")
         startMonitoringService(
             context = context,
             alarmId = "boot_completed",
@@ -131,12 +138,61 @@ class AlarmReceiver : BroadcastReceiver() {
 
     private fun handlePackageReplaced(context: Context) {
         Log.i(TAG, "App updated - starting monitoring")
+        sendAuditRecoveryEvent(context, "package_replaced")
         startMonitoringService(
             context = context,
             alarmId = "package_replaced",
             slotNumber = 0,
             nodeRunning = false
         )
+    }
+
+    private fun handleExactAlarmPermissionStateChanged(context: Context) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            alarmManager.canScheduleExactAlarms()
+        } else {
+            true
+        }
+
+        val eventType = if (granted) {
+            "android_exact_alarm_permission_granted"
+        } else {
+            "android_exact_alarm_permission_denied"
+        }
+        sendFlutterEvent(
+            context = context,
+            eventType = eventType,
+            eventData = mapOf(
+                "source" to "permission_state_changed_broadcast",
+                "stateChanged" to true
+            )
+        )
+    }
+
+    private fun sendAuditRecoveryEvent(context: Context, reason: String) {
+        sendFlutterEvent(
+            context = context,
+            eventType = "android_alarm_recovery_requested",
+            eventData = mapOf(
+                "reason" to reason,
+                "source" to "alarm_receiver"
+            )
+        )
+    }
+
+    private fun sendFlutterEvent(
+        context: Context,
+        eventType: String,
+        eventData: Map<String, Any?>
+    ) {
+        val handler = AlarmMethodChannelHandler.getInstance()
+        if (handler != null && handler.isActivityAttached()) {
+            handler.sendEventToFlutter(eventType, eventData)
+            return
+        }
+
+        BackgroundAlarmEngine.sendAlarmEvent(context, eventType, eventData)
     }
 
     private fun startMonitoringService(

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmScheduler.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmScheduler.kt
@@ -159,6 +159,28 @@ class AlarmScheduler(
         }
     }
 
+    fun hasScheduledAlarm(alarmId: String): Boolean {
+        return try {
+            val intent = Intent(context, AlarmReceiver::class.java).apply {
+                action = "com.usernode.app.SLOT_ALARM"
+            }
+
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                alarmId.hashCode(),
+                intent,
+                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+            )
+
+            val exists = pendingIntent != null
+            Log.d(TAG, "[AlarmScheduler] PendingIntent exists for $alarmId: $exists")
+            exists
+        } catch (e: Exception) {
+            Log.e(TAG, "[AlarmScheduler] Error checking alarm existence for $alarmId", e)
+            false
+        }
+    }
+
     private fun saveScheduledAlarm(alarmId: String, slotNumber: Int) {
         val alarms = getScheduledAlarms().toMutableMap()
         alarms[alarmId] = slotNumber

--- a/lib/core/bootstrap/app_bootstrap.dart
+++ b/lib/core/bootstrap/app_bootstrap.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
@@ -12,6 +13,7 @@ import 'package:crypto_mobile_app/core/providers/leaderboard_participant_provide
 import 'package:crypto_mobile_app/core/providers/providers.dart';
 import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
 import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
+import 'package:crypto_mobile_app/core/services/block_production_alarm_audit_service.dart';
 import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/core/utils/lifecycle.dart';
@@ -70,10 +72,35 @@ class AppBootstrap {
     await PlatformAlarmService.instance.initialize();
     PlatformAlarmService.instance.setNativeEventCallback(
       (eventType, eventData) {
-        AppSleepService.instance.handleNativeEvent(eventType, eventData);
-        AndroidForegroundTaskController.instance.handleNativeEvent(
-          eventType,
-          eventData,
+        if (eventType == 'android_alarm_recovery_requested') {
+          log.warn(
+            'Native alarm recovery event delivered',
+            context: eventData,
+          );
+        }
+        _dispatchNativeEvent(
+          log: log,
+          handlerName: 'app_sleep',
+          eventType: eventType,
+          eventData: eventData,
+          handler: () =>
+              AppSleepService.instance.handleNativeEvent(eventType, eventData),
+        );
+        _dispatchNativeEvent(
+          log: log,
+          handlerName: 'android_foreground_task',
+          eventType: eventType,
+          eventData: eventData,
+          handler: () => AndroidForegroundTaskController.instance
+              .handleNativeEvent(eventType, eventData),
+        );
+        _dispatchNativeEvent(
+          log: log,
+          handlerName: 'alarm_audit',
+          eventType: eventType,
+          eventData: eventData,
+          handler: () => BlockProductionAlarmAuditService.instance
+              .handleNativeEvent(eventType, eventData),
         );
       },
     );
@@ -114,7 +141,12 @@ class AppBootstrap {
 
     if (registerLifecycleObserver) {
       AppLifecycleLogger.register();
-      AppLifecycleLogger.onForegroundResume = recoverZkSession;
+      AppLifecycleLogger.onForegroundResume = () {
+        recoverZkSession();
+        BlockProductionAlarmAuditService.instance.auditBestEffort(
+          reason: 'foreground_resume',
+        );
+      };
     }
 
     _bootstrapBackendAsync(
@@ -128,6 +160,29 @@ class AppBootstrap {
       hasAnyAccounts: hasAnyAccounts,
       activeAccountId: activeId,
     );
+  }
+
+  static void _dispatchNativeEvent({
+    required TaggedLogger log,
+    required String handlerName,
+    required String eventType,
+    required Map<String, dynamic> eventData,
+    required void Function() handler,
+  }) {
+    try {
+      handler();
+    } catch (e, st) {
+      log.warn(
+        'Native event handler failed',
+        context: {
+          'handler': handlerName,
+          'event_type': eventType,
+          'error': e,
+          ...eventData,
+        },
+      );
+      log.debug('$st');
+    }
   }
 
   static Future<void> _applyBootstrapIdentity({
@@ -289,12 +344,28 @@ class AppBootstrap {
       if (Platform.isAndroid) {
         log.info('Starting Android foreground VRF monitoring');
         await AndroidForegroundTaskController.instance.onNodeStarted();
+        unawaited(_runStartupAlarmAudit(log));
       }
 
       log.debug('Bootstrap end');
     } catch (e, st) {
       log.error('Bootstrap failed: $e', error: e, stackTrace: st);
       await SentryUtil.captureError(e, st, tag: 'bootstrap');
+    }
+  }
+
+  static Future<void> _runStartupAlarmAudit(TaggedLogger log) async {
+    try {
+      final forceStopRecovery = await BlockProductionAlarmAuditService.instance
+          .auditForceStopRecoveryIfNeeded();
+      if (!forceStopRecovery && RustBackendService.instance.isRunning) {
+        await BlockProductionAlarmAuditService.instance.audit(
+          reason: 'cold_start',
+        );
+      }
+    } catch (e, st) {
+      log.warn('Startup alarm audit failed: $e');
+      log.debug('$st');
     }
   }
 

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -24,6 +24,7 @@ class AndroidForegroundTaskController {
   static const Duration _pollInterval = Duration(seconds: 30);
   static const Duration _alarmLead = Duration(minutes: 1);
   static const Duration _alarmEventDedupWindow = Duration(seconds: 10);
+  static const foregroundResumeAlarmId = 'fg_resume';
 
   Timer? _pollTimer;
   bool _initialized = false;
@@ -376,19 +377,41 @@ class AndroidForegroundTaskController {
     int? targetGlobalSlot,
     int? targetSlotTimeMs,
   }) async {
+    await scheduleResumeAlarm(
+      rustWakeTimeMs: rustWakeTimeMs,
+      reason: reason,
+      targetGlobalSlot: targetGlobalSlot,
+      targetSlotTimeMs: targetSlotTimeMs,
+      stopMonitoringAfterSchedule: true,
+    );
+  }
+
+  Future<ForegroundResumeAlarmScheduleResult> scheduleResumeAlarm({
+    required int rustWakeTimeMs,
+    required String reason,
+    int? targetGlobalSlot,
+    int? targetSlotTimeMs,
+    bool stopMonitoringAfterSchedule = false,
+  }) async {
     if (await _shouldHoldForOtherProducerBlock()) {
       final height = _awaitingOtherProducerState?.height;
       _log.info(
         'Keeping wakelock: waiting for another producer block after height ${height ?? 'unknown'}',
       );
-      return;
+      return const ForegroundResumeAlarmScheduleResult(
+        success: false,
+        failureReason: 'holding_for_other_producer_block',
+      );
     }
 
     final clockDriftMs =
         await RustBackendService.instance.resolveNodeClockDriftMs();
     if (clockDriftMs == null) {
       _log.warn('Skipping resume alarm: node clock drift unavailable');
-      return;
+      return const ForegroundResumeAlarmScheduleResult(
+        success: false,
+        failureReason: 'clock_drift_unavailable',
+      );
     }
     final localWakeTimeMs =
         RustBackendService.instance.localTimeMsFromRustTimeMs(
@@ -398,7 +421,7 @@ class AndroidForegroundTaskController {
     final nowMs = DateTime.now().millisecondsSinceEpoch;
     final delayMs = localWakeTimeMs - nowMs;
     final success = await PlatformAlarmService.instance.scheduleAlarm(
-      alarmId: 'fg_resume',
+      alarmId: foregroundResumeAlarmId,
       delayMs: delayMs,
       slotNumber: 0,
       data: {
@@ -419,7 +442,17 @@ class AndroidForegroundTaskController {
       '(success=$success, rustWakeTimeMs=$rustWakeTimeMs, '
       'clockDriftMs=$clockDriftMs)',
     );
-    await stopMonitoring(reason: reason);
+    if (stopMonitoringAfterSchedule) {
+      await stopMonitoring(reason: reason);
+    }
+
+    return ForegroundResumeAlarmScheduleResult(
+      success: success,
+      alarmTimeMs: localWakeTimeMs,
+      delayMs: delayMs,
+      clockDriftMs: clockDriftMs,
+      failureReason: success ? null : 'platform_schedule_failed',
+    );
   }
 
   RpcEpochWonSlot? _nextWonSlot(List<RpcEpochWonSlot> slots, int rustNowMs) {
@@ -502,7 +535,7 @@ class AndroidForegroundTaskController {
     }
 
     final alarmId = data['alarmId'] as String? ?? '';
-    if (alarmId == 'fg_resume') {
+    if (alarmId == foregroundResumeAlarmId) {
       final alarmKey = _alarmEventKey(data);
       unawaited(
         handleAlarmFire(
@@ -558,6 +591,22 @@ class AndroidForegroundTaskController {
       ),
     );
   }
+}
+
+class ForegroundResumeAlarmScheduleResult {
+  const ForegroundResumeAlarmScheduleResult({
+    required this.success,
+    this.alarmTimeMs,
+    this.delayMs,
+    this.clockDriftMs,
+    this.failureReason,
+  });
+
+  final bool success;
+  final int? alarmTimeMs;
+  final int? delayMs;
+  final int? clockDriftMs;
+  final String? failureReason;
 }
 
 // Foreground service lifecycle is handled natively via PlatformAlarmService.

--- a/lib/core/services/block_production_alarm_audit_service.dart
+++ b/lib/core/services/block_production_alarm_audit_service.dart
@@ -1,0 +1,978 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+
+import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
+import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
+import 'package:crypto_mobile_app/core/utils/logger.dart';
+import 'package:crypto_mobile_app/features/node/node_service.dart';
+
+final _log = LoggingService.instance.withTag('usernode/AlarmAudit');
+
+typedef AlarmAuditScheduleAlarm = Future<bool> Function({
+  required String alarmId,
+  required int slotNumber,
+  required int delayMs,
+  Map<String, dynamic>? data,
+});
+
+typedef AlarmAuditScheduleForegroundResume
+    = Future<ForegroundResumeAlarmScheduleResult> Function({
+  required int rustWakeTimeMs,
+  required String schedulerReason,
+  required int globalSlot,
+  required int slotTimeMs,
+});
+
+typedef AlarmAuditRecoveryRetryScheduler = void Function(
+  Duration delay,
+  void Function() callback,
+);
+
+class BlockProductionAlarmAuditService {
+  BlockProductionAlarmAuditService._({
+    Future<bool> Function()? initializeAlarmService,
+    Future<bool> Function()? refreshPermissions,
+    Future<bool> Function()? hasExactAlarmPermission,
+    Future<bool> Function(String alarmId)? hasScheduledAlarm,
+    AlarmAuditScheduleAlarm? scheduleAlarm,
+    AlarmAuditScheduleForegroundResume? scheduleForegroundResume,
+    Future<AlarmAuditEpochSnapshot?> Function()? loadEpochSnapshot,
+    Future<int?> Function()? resolveClockDriftMs,
+    Future<bool> Function()? ensureNodeRunning,
+    bool Function()? isNodeRunning,
+    Future<bool> Function()? wasForceStoppedOnStartup,
+    int Function()? nowMs,
+    int Function(int rustTimeMs, int clockDriftMs)? rustToLocalTimeMs,
+    bool Function()? isAndroid,
+    String Function()? appState,
+    String Function()? platformVersion,
+    ObservabilityReportingService? observability,
+    Duration? slotWakeLead,
+    Duration? foregroundResumeLead,
+    List<Duration>? recoveryRetryDelays,
+    AlarmAuditRecoveryRetryScheduler? scheduleRecoveryRetry,
+  })  : _initializeAlarmService =
+            initializeAlarmService ?? PlatformAlarmService.instance.initialize,
+        _refreshPermissions = refreshPermissions ??
+            PlatformAlarmService.instance.refreshPermissions,
+        _hasExactAlarmPermission = hasExactAlarmPermission ??
+            PlatformAlarmService.instance.hasExactAlarmPermission,
+        _hasScheduledAlarm = hasScheduledAlarm ??
+            PlatformAlarmService.instance.hasScheduledAlarm,
+        _scheduleAlarm =
+            scheduleAlarm ?? PlatformAlarmService.instance.scheduleAlarm,
+        _scheduleForegroundResume =
+            scheduleForegroundResume ?? _scheduleDefaultForegroundResume,
+        _loadEpochSnapshot = loadEpochSnapshot ?? _loadDefaultEpochSnapshot,
+        _resolveClockDriftMs = resolveClockDriftMs ??
+            RustBackendService.instance.resolveNodeClockDriftMs,
+        _ensureNodeRunning = ensureNodeRunning ?? _ensureDefaultNodeRunning,
+        _isNodeRunning =
+            isNodeRunning ?? (() => RustBackendService.instance.isRunning),
+        _wasForceStoppedOnStartup = wasForceStoppedOnStartup ??
+            PlatformAlarmService.instance.wasForceStoppedOnStartup,
+        _nowMs = nowMs ?? (() => DateTime.now().millisecondsSinceEpoch),
+        _rustToLocalTimeMs = rustToLocalTimeMs ??
+            ((rustTimeMs, clockDriftMs) =>
+                RustBackendService.instance.localTimeMsFromRustTimeMs(
+                  rustTimeMs,
+                  clockDriftMs: clockDriftMs,
+                )),
+        _isAndroid = isAndroid ?? (() => Platform.isAndroid),
+        _appState = appState ?? _defaultAppState,
+        _platformVersion =
+            platformVersion ?? (() => Platform.operatingSystemVersion),
+        _observability =
+            observability ?? ObservabilityReportingService.instance,
+        _slotWakeLead = slotWakeLead ?? AppConfig.blockProductionWakeBeforeSlot,
+        _foregroundResumeLead =
+            foregroundResumeLead ?? const Duration(minutes: 1),
+        _recoveryRetryDelays = recoveryRetryDelays ??
+            const [
+              Duration(seconds: 5),
+              Duration(seconds: 15),
+              Duration(seconds: 30),
+              Duration(seconds: 60),
+            ],
+        _scheduleRecoveryRetry = scheduleRecoveryRetry ??
+            ((delay, callback) => Timer(delay, callback));
+
+  @visibleForTesting
+  BlockProductionAlarmAuditService.test({
+    Future<bool> Function()? initializeAlarmService,
+    Future<bool> Function()? refreshPermissions,
+    Future<bool> Function()? hasExactAlarmPermission,
+    Future<bool> Function(String alarmId)? hasScheduledAlarm,
+    AlarmAuditScheduleAlarm? scheduleAlarm,
+    AlarmAuditScheduleForegroundResume? scheduleForegroundResume,
+    Future<AlarmAuditEpochSnapshot?> Function()? loadEpochSnapshot,
+    Future<int?> Function()? resolveClockDriftMs,
+    Future<bool> Function()? ensureNodeRunning,
+    bool Function()? isNodeRunning,
+    Future<bool> Function()? wasForceStoppedOnStartup,
+    int Function()? nowMs,
+    int Function(int rustTimeMs, int clockDriftMs)? rustToLocalTimeMs,
+    bool Function()? isAndroid,
+    String Function()? appState,
+    String Function()? platformVersion,
+    required ObservabilityReportingService observability,
+    Duration? slotWakeLead,
+    Duration? foregroundResumeLead,
+    List<Duration>? recoveryRetryDelays,
+    AlarmAuditRecoveryRetryScheduler? scheduleRecoveryRetry,
+  }) : this._(
+          initializeAlarmService: initializeAlarmService,
+          refreshPermissions: refreshPermissions,
+          hasExactAlarmPermission: hasExactAlarmPermission,
+          hasScheduledAlarm: hasScheduledAlarm,
+          scheduleAlarm: scheduleAlarm,
+          scheduleForegroundResume: scheduleForegroundResume,
+          loadEpochSnapshot: loadEpochSnapshot,
+          resolveClockDriftMs: resolveClockDriftMs,
+          ensureNodeRunning: ensureNodeRunning,
+          isNodeRunning: isNodeRunning,
+          wasForceStoppedOnStartup: wasForceStoppedOnStartup,
+          nowMs: nowMs,
+          rustToLocalTimeMs: rustToLocalTimeMs,
+          isAndroid: isAndroid,
+          appState: appState,
+          platformVersion: platformVersion,
+          observability: observability,
+          slotWakeLead: slotWakeLead,
+          foregroundResumeLead: foregroundResumeLead,
+          recoveryRetryDelays: recoveryRetryDelays,
+          scheduleRecoveryRetry: scheduleRecoveryRetry,
+        );
+
+  static final BlockProductionAlarmAuditService instance =
+      BlockProductionAlarmAuditService._();
+
+  final Future<bool> Function() _initializeAlarmService;
+  final Future<bool> Function() _refreshPermissions;
+  final Future<bool> Function() _hasExactAlarmPermission;
+  final Future<bool> Function(String alarmId) _hasScheduledAlarm;
+  final AlarmAuditScheduleAlarm _scheduleAlarm;
+  final AlarmAuditScheduleForegroundResume _scheduleForegroundResume;
+  final Future<AlarmAuditEpochSnapshot?> Function() _loadEpochSnapshot;
+  final Future<int?> Function() _resolveClockDriftMs;
+  final Future<bool> Function() _ensureNodeRunning;
+  final bool Function() _isNodeRunning;
+  final Future<bool> Function() _wasForceStoppedOnStartup;
+  final int Function() _nowMs;
+  final int Function(int rustTimeMs, int clockDriftMs) _rustToLocalTimeMs;
+  final bool Function() _isAndroid;
+  final String Function() _appState;
+  final String Function() _platformVersion;
+  final ObservabilityReportingService _observability;
+  final Duration _slotWakeLead;
+  final Duration _foregroundResumeLead;
+  final List<Duration> _recoveryRetryDelays;
+  final AlarmAuditRecoveryRetryScheduler _scheduleRecoveryRetry;
+
+  Future<AlarmAuditResult>? _inFlight;
+  bool _forceStopChecked = false;
+  String? _pendingRecoveryReason;
+  var _recoveryRetryAttempt = 0;
+  var _recoveryRetryGeneration = 0;
+
+  void auditBestEffort({required String reason}) {
+    _auditBestEffort(reason: reason);
+  }
+
+  Future<bool> auditForceStopRecoveryIfNeeded() async {
+    if (_forceStopChecked || !_isAndroid()) {
+      return false;
+    }
+
+    _forceStopChecked = true;
+    final detected = await _wasForceStoppedOnStartup();
+    if (!detected) {
+      return false;
+    }
+
+    _report(
+      'app_restarted_after_force_stop',
+      {
+        'platform_version': _platformVersion(),
+        'app_state': _appState(),
+      },
+    );
+    _auditBestEffort(
+      reason: 'force_stop_recovery',
+      retryTransientRecovery: true,
+    );
+    return true;
+  }
+
+  void handleNativeEvent(String eventType, Map<String, dynamic> eventData) {
+    switch (eventType) {
+      case 'android_alarm_recovery_requested':
+        final reason = _stringValue(eventData['reason']) ?? 'native_recovery';
+        _log.warn('Alarm audit received native recovery request', context: {
+          'reason': reason,
+          ...eventData,
+        });
+        _auditBestEffort(reason: reason, retryTransientRecovery: true);
+        break;
+      case 'android_exact_alarm_permission_granted':
+        final stateChanged = eventData['stateChanged'] == true;
+        final source = _stringValue(eventData['source']);
+        if (stateChanged || source == 'permission_state_changed_broadcast') {
+          _auditBestEffort(
+            reason: 'exact_alarm_permission_granted',
+            retryTransientRecovery: true,
+          );
+        }
+        break;
+    }
+  }
+
+  void _auditBestEffort({
+    required String reason,
+    bool retryTransientRecovery = false,
+  }) {
+    if (retryTransientRecovery) {
+      _pendingRecoveryReason = reason;
+    }
+
+    unawaited(
+      audit(reason: reason).then((result) {
+        if (retryTransientRecovery) {
+          _handleRecoveryAuditResult(reason: reason, result: result);
+        }
+      }),
+    );
+  }
+
+  void _handleRecoveryAuditResult({
+    required String reason,
+    required AlarmAuditResult result,
+  }) {
+    if (_pendingRecoveryReason != reason) {
+      return;
+    }
+
+    final skippedReason = result.skippedReason;
+    if (skippedReason == null || !_isTransientRecoverySkip(skippedReason)) {
+      _log.warn('Alarm recovery audit finished without retry', context: {
+        'reason': reason,
+        if (skippedReason != null) 'skipped_reason': skippedReason,
+        'expected_slot_wake_count': result.expectedSlotWakeCount,
+        'rescheduled_count': result.rescheduledCount,
+        'fg_resume_status': result.fgResumeStatus,
+      });
+      _clearPendingRecovery(reason);
+      return;
+    }
+
+    if (_recoveryRetryAttempt >= _recoveryRetryDelays.length) {
+      _log.warn('Alarm recovery audit retries exhausted', context: {
+        'reason': reason,
+        'skipped_reason': skippedReason,
+        'attempts': _recoveryRetryAttempt,
+      });
+      _clearPendingRecovery(reason);
+      return;
+    }
+
+    final delay = _recoveryRetryDelays[_recoveryRetryAttempt];
+    _recoveryRetryAttempt += 1;
+    final generation = ++_recoveryRetryGeneration;
+    _log.warn('Alarm recovery audit will retry after transient skip', context: {
+      'reason': reason,
+      'skipped_reason': skippedReason,
+      'attempt': _recoveryRetryAttempt,
+      'delay_ms': delay.inMilliseconds,
+    });
+
+    _scheduleRecoveryRetry(delay, () {
+      if (_pendingRecoveryReason != reason ||
+          _recoveryRetryGeneration != generation) {
+        return;
+      }
+      _auditBestEffort(reason: reason, retryTransientRecovery: true);
+    });
+  }
+
+  void _clearPendingRecovery(String reason) {
+    if (_pendingRecoveryReason != reason) {
+      return;
+    }
+
+    _pendingRecoveryReason = null;
+    _recoveryRetryAttempt = 0;
+    _recoveryRetryGeneration += 1;
+  }
+
+  bool _isTransientRecoverySkip(String skippedReason) {
+    return skippedReason == 'node_not_running' ||
+        skippedReason == 'clock_drift_unavailable' ||
+        skippedReason == 'epoch_info_unavailable' ||
+        skippedReason == 'no_won_slots';
+  }
+
+  Future<AlarmAuditResult> audit({required String reason}) {
+    final active = _inFlight;
+    if (active != null) {
+      return active;
+    }
+
+    late final Future<AlarmAuditResult> future;
+    future = _runAudit(reason).whenComplete(() {
+      if (identical(_inFlight, future)) {
+        _inFlight = null;
+      }
+    });
+    _inFlight = future;
+    return future;
+  }
+
+  Future<AlarmAuditResult> _runAudit(String reason) async {
+    try {
+      if (!_isAndroid()) {
+        return _skip(reason, 'unsupported_platform');
+      }
+
+      await _initializeAlarmService();
+      await _refreshPermissions();
+
+      final exactAlarmPermission = await _hasExactAlarmPermission();
+      _reportStarted(
+        reason: reason,
+        exactAlarmPermission: exactAlarmPermission,
+      );
+
+      if (!exactAlarmPermission) {
+        return _skip(
+          reason,
+          'no_exact_alarm_permission',
+          fgResumeStatus: 'skipped:no_exact_alarm_permission',
+        );
+      }
+
+      final nodeRunning = await _ensureNodeRunning();
+      if (!nodeRunning) {
+        return _skip(
+          reason,
+          'node_not_running',
+          fgResumeStatus: 'skipped:node_not_running',
+        );
+      }
+
+      final clockDriftMs = await _resolveClockDriftMs();
+      if (clockDriftMs == null) {
+        return _skip(
+          reason,
+          'clock_drift_unavailable',
+          fgResumeStatus: 'skipped:clock_drift_unavailable',
+        );
+      }
+
+      final epoch = await _loadEpochSnapshot();
+      if (epoch == null) {
+        return _skip(
+          reason,
+          'epoch_info_unavailable',
+          fgResumeStatus: 'skipped:epoch_info_unavailable',
+        );
+      }
+
+      if (epoch.wonSlots.isEmpty) {
+        return _skip(
+          reason,
+          'no_won_slots',
+          fgResumeStatus: 'no_won_slots',
+        );
+      }
+
+      final built = _buildExpectedAlarms(
+        reason: reason,
+        epoch: epoch,
+        clockDriftMs: clockDriftMs,
+        nowMs: _nowMs(),
+      );
+      final counts = _AlarmAuditCounts()..tooLateCount = built.tooLateCount;
+
+      for (final alarm in built.futureSlotWakeAlarms) {
+        await _auditSlotWakeAlarm(
+          reason: reason,
+          alarm: alarm,
+          counts: counts,
+          clockDriftMs: clockDriftMs,
+        );
+      }
+
+      final fgResumeStatus = await _auditForegroundResume(
+        reason: reason,
+        epoch: epoch,
+        clockDriftMs: clockDriftMs,
+      );
+
+      _reportCompleted(
+        reason: reason,
+        expectedSlotWakeCount: built.futureSlotWakeAlarms.length,
+        counts: counts,
+        fgResumeStatus: fgResumeStatus,
+      );
+
+      return AlarmAuditResult(
+        reason: reason,
+        expectedSlotWakeCount: built.futureSlotWakeAlarms.length,
+        presentCount: counts.presentCount,
+        missingCount: counts.missingCount,
+        rescheduledCount: counts.rescheduledCount,
+        failedCount: counts.failedCount,
+        tooLateCount: counts.tooLateCount,
+        fgResumeStatus: fgResumeStatus,
+      );
+    } catch (e, st) {
+      _log.error('Alarm audit failed: $e', error: e, stackTrace: st);
+      return _skip(
+        reason,
+        'audit_exception',
+        failureReason: e.toString(),
+        fgResumeStatus: 'skipped:audit_exception',
+      );
+    }
+  }
+
+  _ExpectedAlarmBuildResult _buildExpectedAlarms({
+    required String reason,
+    required AlarmAuditEpochSnapshot epoch,
+    required int clockDriftMs,
+    required int nowMs,
+  }) {
+    final futureSlotWakeAlarms = <AlarmAuditExpectedAlarm>[];
+    var tooLateCount = 0;
+    final wakeLeadMs = _slotWakeLead.inMilliseconds;
+
+    final wonSlots = List<AlarmAuditWonSlot>.of(epoch.wonSlots)
+      ..sort((a, b) => a.expectedTimeMs.compareTo(b.expectedTimeMs));
+
+    for (final wonSlot in wonSlots) {
+      final slotTimeMs = _rustToLocalTimeMs(
+        wonSlot.expectedTimeMs,
+        clockDriftMs,
+      );
+      final alarmTimeMs = slotTimeMs - wakeLeadMs;
+      final alarm = AlarmAuditExpectedAlarm(
+        alarmId: 'slot_${wonSlot.globalSlot}',
+        purpose: 'slot_wake',
+        globalSlot: wonSlot.globalSlot,
+        epoch: epoch.epoch,
+        rustSlotTimeMs: wonSlot.expectedTimeMs,
+        slotTimeMs: slotTimeMs,
+        alarmTimeMs: alarmTimeMs,
+      );
+
+      if (alarmTimeMs <= nowMs) {
+        tooLateCount++;
+        _reportTooLate(
+          reason: reason,
+          alarm: alarm,
+          nowMs: nowMs,
+        );
+        continue;
+      }
+
+      futureSlotWakeAlarms.add(alarm);
+    }
+
+    return _ExpectedAlarmBuildResult(
+      futureSlotWakeAlarms: futureSlotWakeAlarms,
+      tooLateCount: tooLateCount,
+    );
+  }
+
+  Future<void> _auditSlotWakeAlarm({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+    required _AlarmAuditCounts counts,
+    required int clockDriftMs,
+  }) async {
+    final present = await _hasScheduledAlarm(alarm.alarmId);
+    if (present) {
+      counts.presentCount++;
+      _reportPresent(reason: reason, alarm: alarm);
+      return;
+    }
+
+    counts.missingCount++;
+    final nowMs = _nowMs();
+    final delayMs = alarm.alarmTimeMs - nowMs;
+    if (delayMs <= 0) {
+      counts.tooLateCount++;
+      _reportTooLate(reason: reason, alarm: alarm, nowMs: nowMs);
+      return;
+    }
+
+    final success = await _scheduleAlarm(
+      alarmId: alarm.alarmId,
+      slotNumber: alarm.globalSlot,
+      delayMs: delayMs,
+      data: {
+        'epoch': alarm.epoch,
+        'slotTime': DateTime.fromMillisecondsSinceEpoch(alarm.slotTimeMs)
+            .toIso8601String(),
+        'slotTimeMs': alarm.slotTimeMs,
+        'alarmTimeMs': alarm.alarmTimeMs,
+        'purpose': alarm.purpose,
+        'reason': 'alarm_audit:$reason',
+        'nodeRunning': _isNodeRunning(),
+        'rustWakeTimeMs': alarm.rustSlotTimeMs - _slotWakeLead.inMilliseconds,
+        'localWakeTimeMs': alarm.alarmTimeMs,
+        'clockDriftMs': clockDriftMs,
+      },
+    );
+
+    if (success) {
+      counts.rescheduledCount++;
+      _reportMissingRescheduled(
+        reason: reason,
+        alarm: alarm,
+        scheduleSuccess: true,
+      );
+      return;
+    }
+
+    counts.failedCount++;
+    _reportMissingRescheduleFailed(
+      reason: reason,
+      alarm: alarm,
+      failureReason: 'platform_schedule_failed',
+    );
+  }
+
+  Future<String> _auditForegroundResume({
+    required String reason,
+    required AlarmAuditEpochSnapshot epoch,
+    required int clockDriftMs,
+  }) async {
+    final nowMs = _nowMs();
+    final nextWonSlot = _nextFutureWonSlot(
+      epoch.wonSlots,
+      clockDriftMs: clockDriftMs,
+      nowMs: nowMs,
+    );
+    if (nextWonSlot == null) {
+      return 'no_future_won_slots';
+    }
+
+    final fgLeadMs = _foregroundResumeLead.inMilliseconds;
+    if (nextWonSlot.slotTimeMs - nowMs <= fgLeadMs) {
+      _report(
+        'foreground_resume_not_scheduled_slot_too_close',
+        {
+          'reason': reason,
+          'global_slot': nextWonSlot.globalSlot,
+          'slot_time_ms': nextWonSlot.slotTimeMs,
+          'now_ms': nowMs,
+        },
+      );
+      return 'slot_too_close';
+    }
+
+    final alarm = AlarmAuditExpectedAlarm(
+      alarmId: AndroidForegroundTaskController.foregroundResumeAlarmId,
+      purpose: 'foreground_resume',
+      globalSlot: nextWonSlot.globalSlot,
+      epoch: epoch.epoch,
+      rustSlotTimeMs: nextWonSlot.rustSlotTimeMs,
+      slotTimeMs: nextWonSlot.slotTimeMs,
+      alarmTimeMs: nextWonSlot.slotTimeMs - fgLeadMs,
+    );
+
+    final present = await _hasScheduledAlarm(alarm.alarmId);
+    if (present) {
+      _reportPresent(reason: reason, alarm: alarm);
+      _report(
+        'foreground_resume_present',
+        {
+          'reason': reason,
+          'global_slot': alarm.globalSlot,
+          'alarm_time_ms': alarm.alarmTimeMs,
+          'slot_time_ms': alarm.slotTimeMs,
+        },
+      );
+      return 'present';
+    }
+
+    final schedulerReason = 'next_won_slot:${alarm.globalSlot}';
+    final result = await _scheduleForegroundResume(
+      rustWakeTimeMs: alarm.rustSlotTimeMs - fgLeadMs,
+      schedulerReason: schedulerReason,
+      globalSlot: alarm.globalSlot,
+      slotTimeMs: alarm.slotTimeMs,
+    );
+    final scheduledAlarm = alarm.copyWith(
+      alarmTimeMs: result.alarmTimeMs ?? alarm.alarmTimeMs,
+    );
+
+    if (result.success) {
+      _reportMissingRescheduled(
+        reason: reason,
+        alarm: scheduledAlarm,
+        scheduleSuccess: true,
+      );
+      _report(
+        'foreground_resume_recreated',
+        {
+          'reason': reason,
+          'global_slot': scheduledAlarm.globalSlot,
+          'alarm_time_ms': scheduledAlarm.alarmTimeMs,
+          'slot_time_ms': scheduledAlarm.slotTimeMs,
+        },
+      );
+      return 'recreated';
+    }
+
+    _reportMissingRescheduleFailed(
+      reason: reason,
+      alarm: scheduledAlarm,
+      failureReason: result.failureReason ?? 'platform_schedule_failed',
+    );
+    return 'reschedule_failed';
+  }
+
+  _FutureWonSlot? _nextFutureWonSlot(
+    List<AlarmAuditWonSlot> slots, {
+    required int clockDriftMs,
+    required int nowMs,
+  }) {
+    final futureSlots = slots
+        .map((slot) {
+          final slotTimeMs = _rustToLocalTimeMs(
+            slot.expectedTimeMs,
+            clockDriftMs,
+          );
+          return _FutureWonSlot(
+            globalSlot: slot.globalSlot,
+            rustSlotTimeMs: slot.expectedTimeMs,
+            slotTimeMs: slotTimeMs,
+          );
+        })
+        .where((slot) => slot.slotTimeMs > nowMs)
+        .toList()
+      ..sort((a, b) => a.slotTimeMs.compareTo(b.slotTimeMs));
+
+    return futureSlots.isEmpty ? null : futureSlots.first;
+  }
+
+  void _reportStarted({
+    required String reason,
+    required bool exactAlarmPermission,
+  }) {
+    _report(
+      'alarm_audit_started',
+      {
+        'reason': reason,
+        'app_state': _appState(),
+        'platform_version': _platformVersion(),
+        'exact_alarm_permission': exactAlarmPermission,
+        'node_running': _isNodeRunning(),
+      },
+    );
+  }
+
+  AlarmAuditResult _skip(
+    String reason,
+    String skippedReason, {
+    String fgResumeStatus = 'skipped',
+    String? failureReason,
+  }) {
+    _log.info('Alarm audit skipped', context: {
+      'reason': reason,
+      'skipped_reason': skippedReason,
+      if (failureReason != null) 'failure_reason': failureReason,
+    });
+    _report(
+      'alarm_audit_skipped',
+      {
+        'reason': reason,
+        'skipped_reason': skippedReason,
+        if (failureReason != null) 'failure_reason': failureReason,
+      },
+    );
+    final counts = _AlarmAuditCounts();
+    _reportCompleted(
+      reason: reason,
+      expectedSlotWakeCount: 0,
+      counts: counts,
+      fgResumeStatus: fgResumeStatus,
+    );
+
+    return AlarmAuditResult(
+      reason: reason,
+      skippedReason: skippedReason,
+      expectedSlotWakeCount: 0,
+      presentCount: 0,
+      missingCount: 0,
+      rescheduledCount: 0,
+      failedCount: 0,
+      tooLateCount: 0,
+      fgResumeStatus: fgResumeStatus,
+    );
+  }
+
+  void _reportCompleted({
+    required String reason,
+    required int expectedSlotWakeCount,
+    required _AlarmAuditCounts counts,
+    required String fgResumeStatus,
+  }) {
+    _log.info('Alarm audit completed', context: {
+      'reason': reason,
+      'expected_slot_wake_count': expectedSlotWakeCount,
+      'present_count': counts.presentCount,
+      'missing_count': counts.missingCount,
+      'rescheduled_count': counts.rescheduledCount,
+      'failed_count': counts.failedCount,
+      'too_late_count': counts.tooLateCount,
+      'fg_resume_status': fgResumeStatus,
+    });
+    _report(
+      'alarm_audit_completed',
+      {
+        'reason': reason,
+        'expected_slot_wake_count': expectedSlotWakeCount,
+        'present_count': counts.presentCount,
+        'missing_count': counts.missingCount,
+        'rescheduled_count': counts.rescheduledCount,
+        'failed_count': counts.failedCount,
+        'too_late_count': counts.tooLateCount,
+        'fg_resume_status': fgResumeStatus,
+      },
+    );
+  }
+
+  void _reportPresent({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+  }) {
+    _report('alarm_audit_present', {
+      'reason': reason,
+      ...alarm.telemetryDetails,
+    });
+  }
+
+  void _reportMissingRescheduled({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+    required bool scheduleSuccess,
+  }) {
+    _report('alarm_audit_missing_rescheduled', {
+      'reason': reason,
+      ...alarm.telemetryDetails,
+      'schedule_success': scheduleSuccess,
+    });
+  }
+
+  void _reportMissingRescheduleFailed({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+    required String failureReason,
+  }) {
+    _report('alarm_audit_missing_reschedule_failed', {
+      'reason': reason,
+      ...alarm.telemetryDetails,
+      'failure_reason': failureReason,
+    });
+  }
+
+  void _reportTooLate({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+    required int nowMs,
+  }) {
+    _report('alarm_audit_missing_too_late', {
+      'reason': reason,
+      ...alarm.telemetryDetails,
+      'now_ms': nowMs,
+      'lateness_ms': nowMs - alarm.alarmTimeMs,
+    });
+  }
+
+  void _report(String event, Map<String, dynamic> details) {
+    _observability.reportBlockProductionAlarmAuditEvent(
+      event: event,
+      details: details,
+    );
+  }
+
+  static Future<AlarmAuditEpochSnapshot?> _loadDefaultEpochSnapshot() async {
+    final info = await RustBackendService.instance.getEpochInfo();
+    if (info == null) {
+      return null;
+    }
+
+    return AlarmAuditEpochSnapshot(
+      epoch: info.currentEpoch,
+      wonSlots: info.wonSlots
+          .map(
+            (slot) => AlarmAuditWonSlot(
+              globalSlot: slot.globalSlot,
+              expectedTimeMs: slot.expectedTimeMs.toInt(),
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+
+  static Future<bool> _ensureDefaultNodeRunning() async {
+    if (RustBackendService.instance.isRunning) {
+      return true;
+    }
+
+    return false;
+  }
+
+  static Future<ForegroundResumeAlarmScheduleResult>
+      _scheduleDefaultForegroundResume({
+    required int rustWakeTimeMs,
+    required String schedulerReason,
+    required int globalSlot,
+    required int slotTimeMs,
+  }) {
+    return AndroidForegroundTaskController.instance.scheduleResumeAlarm(
+      rustWakeTimeMs: rustWakeTimeMs,
+      reason: schedulerReason,
+      targetGlobalSlot: globalSlot,
+      targetSlotTimeMs: slotTimeMs,
+      stopMonitoringAfterSchedule: false,
+    );
+  }
+
+  static String _defaultAppState() {
+    try {
+      return WidgetsBinding.instance.lifecycleState?.name ?? 'unknown';
+    } catch (_) {
+      return 'unknown';
+    }
+  }
+
+  String? _stringValue(Object? value) {
+    return value is String && value.isNotEmpty ? value : null;
+  }
+}
+
+class AlarmAuditEpochSnapshot {
+  const AlarmAuditEpochSnapshot({
+    required this.epoch,
+    required this.wonSlots,
+  });
+
+  final int epoch;
+  final List<AlarmAuditWonSlot> wonSlots;
+}
+
+class AlarmAuditWonSlot {
+  const AlarmAuditWonSlot({
+    required this.globalSlot,
+    required this.expectedTimeMs,
+  });
+
+  final int globalSlot;
+  final int expectedTimeMs;
+}
+
+class AlarmAuditExpectedAlarm {
+  const AlarmAuditExpectedAlarm({
+    required this.alarmId,
+    required this.purpose,
+    required this.globalSlot,
+    required this.epoch,
+    required this.rustSlotTimeMs,
+    required this.slotTimeMs,
+    required this.alarmTimeMs,
+  });
+
+  final String alarmId;
+  final String purpose;
+  final int globalSlot;
+  final int epoch;
+  final int rustSlotTimeMs;
+  final int slotTimeMs;
+  final int alarmTimeMs;
+
+  Map<String, dynamic> get telemetryDetails => {
+        'alarm_id': alarmId,
+        'purpose': purpose,
+        'global_slot': globalSlot,
+        'alarm_time_ms': alarmTimeMs,
+        'slot_time_ms': slotTimeMs,
+      };
+
+  AlarmAuditExpectedAlarm copyWith({
+    int? alarmTimeMs,
+  }) {
+    return AlarmAuditExpectedAlarm(
+      alarmId: alarmId,
+      purpose: purpose,
+      globalSlot: globalSlot,
+      epoch: epoch,
+      rustSlotTimeMs: rustSlotTimeMs,
+      slotTimeMs: slotTimeMs,
+      alarmTimeMs: alarmTimeMs ?? this.alarmTimeMs,
+    );
+  }
+}
+
+class AlarmAuditResult {
+  const AlarmAuditResult({
+    required this.reason,
+    required this.expectedSlotWakeCount,
+    required this.presentCount,
+    required this.missingCount,
+    required this.rescheduledCount,
+    required this.failedCount,
+    required this.tooLateCount,
+    required this.fgResumeStatus,
+    this.skippedReason,
+  });
+
+  final String reason;
+  final String? skippedReason;
+  final int expectedSlotWakeCount;
+  final int presentCount;
+  final int missingCount;
+  final int rescheduledCount;
+  final int failedCount;
+  final int tooLateCount;
+  final String fgResumeStatus;
+}
+
+class _ExpectedAlarmBuildResult {
+  const _ExpectedAlarmBuildResult({
+    required this.futureSlotWakeAlarms,
+    required this.tooLateCount,
+  });
+
+  final List<AlarmAuditExpectedAlarm> futureSlotWakeAlarms;
+  final int tooLateCount;
+}
+
+class _AlarmAuditCounts {
+  _AlarmAuditCounts();
+
+  int presentCount = 0;
+  int missingCount = 0;
+  int rescheduledCount = 0;
+  int failedCount = 0;
+  int tooLateCount = 0;
+}
+
+class _FutureWonSlot {
+  const _FutureWonSlot({
+    required this.globalSlot,
+    required this.rustSlotTimeMs,
+    required this.slotTimeMs,
+  });
+
+  final int globalSlot;
+  final int rustSlotTimeMs;
+  final int slotTimeMs;
+}

--- a/lib/core/services/observability_reporting_service.dart
+++ b/lib/core/services/observability_reporting_service.dart
@@ -302,6 +302,19 @@ class ObservabilityReportingService {
     );
   }
 
+  FlutterObservabilityRecordResult reportBlockProductionAlarmAuditEvent({
+    required String event,
+    Map<String, dynamic>? details,
+  }) {
+    return _recordStructured(
+      kind: FlutterObservabilityKind.event,
+      event: event,
+      details: details,
+      requireNodeInitialized: false,
+      retainUntilNodeInitialized: true,
+    );
+  }
+
   FlutterObservabilityRecordResult reportBlockProductionMonitoringStarted({
     required int globalSlot,
     required int monitoringStartedAtMs,

--- a/lib/core/services/platform_alarm_service.dart
+++ b/lib/core/services/platform_alarm_service.dart
@@ -280,6 +280,28 @@ class PlatformAlarmService {
   /// Check if necessary permissions are granted
   bool get hasPermissions => _permissionsGranted;
 
+  Future<bool> refreshPermissions() async {
+    if (!_initialized) {
+      _log.debug('Cannot refresh permissions: service not initialized');
+      return false;
+    }
+
+    if (Platform.isAndroid) {
+      final hasNotifications = await hasPostNotificationsPermission();
+      final hasExactAlarm = await hasExactAlarmPermission();
+      _permissionsGranted = hasNotifications && hasExactAlarm;
+      return _permissionsGranted;
+    }
+
+    if (Platform.isIOS) {
+      _permissionsGranted = true;
+      return true;
+    }
+
+    _permissionsGranted = false;
+    return false;
+  }
+
   /// Request platform-specific permissions
   ///
   /// Android: Opens system settings for exact alarm permission
@@ -408,6 +430,7 @@ class PlatformAlarmService {
       // Do not force notifications here; just update combined flag conservatively
       if (hasExact) {
         _log.info('Exact alarm permission granted');
+        await refreshPermissions();
       } else {
         _log.warn('Exact alarm permission still not granted');
       }
@@ -442,6 +465,44 @@ class PlatformAlarmService {
           false;
     } on PlatformException catch (e) {
       _log.error('Error checking exact alarm permission: ${e.message}');
+      return false;
+    }
+  }
+
+  Future<bool> hasScheduledAlarm(String alarmId) async {
+    if (!Platform.isAndroid) return false;
+    if (!_initialized) {
+      _log.debug('Cannot check scheduled alarm: service not initialized');
+      return false;
+    }
+
+    try {
+      return await _channel.invokeMethod<bool>(
+            'hasScheduledAlarm',
+            {'alarmId': alarmId},
+          ) ??
+          false;
+    } on PlatformException catch (e) {
+      _log.warn('Error checking scheduled alarm $alarmId: ${e.message}');
+      return false;
+    } catch (e) {
+      _log.warn('Error checking scheduled alarm $alarmId: $e');
+      return false;
+    }
+  }
+
+  Future<bool> wasForceStoppedOnStartup() async {
+    if (!Platform.isAndroid) return false;
+    if (!_initialized) return false;
+
+    try {
+      return await _channel.invokeMethod<bool>('wasForceStoppedOnStartup') ??
+          false;
+    } on PlatformException catch (e) {
+      _log.debug('Force-stop startup check unavailable: ${e.message}');
+      return false;
+    } catch (e) {
+      _log.debug('Force-stop startup check failed: $e');
       return false;
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 
 import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/services/app_reset_service.dart';
+import 'package:crypto_mobile_app/core/services/block_production_alarm_audit_service.dart';
 import 'package:crypto_mobile_app/core/services/app_sleep_service.dart';
 import 'package:crypto_mobile_app/core/services/app_sleep_state_store.dart';
 import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
@@ -210,6 +211,12 @@ Future<void> _startHeadlessServices(
 
     // Initialize backend lifecycle provider manually
     container.read(backendLifecycleProvider);
+
+    if (Platform.isAndroid) {
+      BlockProductionAlarmAuditService.instance.auditBestEffort(
+        reason: 'headless_start',
+      );
+    }
 
     log.info('Headless services started successfully');
   } catch (e, st) {

--- a/test/core/services/block_production_alarm_audit_service_test.dart
+++ b/test/core/services/block_production_alarm_audit_service_test.dart
@@ -1,0 +1,418 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
+import 'package:crypto_mobile_app/core/services/block_production_alarm_audit_service.dart';
+import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
+import 'package:crypto_mobile_app/features/metrics/mobile_context_snapshot_collector.dart';
+import 'package:crypto_mobile_app/src/rust/observability.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('BlockProductionAlarmAuditService', () {
+    test('skips when exact alarm permission is missing', () async {
+      final harness = _AuditHarness(exactAlarmPermission: false);
+
+      final result = await harness.service.audit(reason: 'cold_start');
+
+      expect(result.skippedReason, 'no_exact_alarm_permission');
+      expect(harness.ensureNodeRunningCalls, 0);
+      expect(harness.scheduledAlarms, isEmpty);
+      expect(
+        harness.events('alarm_audit_skipped').single['skipped_reason'],
+        'no_exact_alarm_permission',
+      );
+    });
+
+    test('reschedules a missing future slot_wake alarm', () async {
+      final harness = _AuditHarness(
+        presentAlarms: {'fg_resume'},
+        epoch: const AlarmAuditEpochSnapshot(
+          epoch: 7,
+          wonSlots: [
+            AlarmAuditWonSlot(globalSlot: 42, expectedTimeMs: 20000),
+          ],
+        ),
+      );
+
+      final result = await harness.service.audit(reason: 'cold_start');
+
+      expect(result.expectedSlotWakeCount, 1);
+      expect(result.missingCount, 1);
+      expect(result.rescheduledCount, 1);
+      expect(harness.scheduledAlarms.single.alarmId, 'slot_42');
+      expect(harness.scheduledAlarms.single.slotNumber, 42);
+      expect(
+        harness.events('alarm_audit_missing_rescheduled').single['purpose'],
+        'slot_wake',
+      );
+    });
+
+    test('does not reschedule past slot_wake alarms and emits too_late',
+        () async {
+      final harness = _AuditHarness(
+        epoch: const AlarmAuditEpochSnapshot(
+          epoch: 7,
+          wonSlots: [
+            AlarmAuditWonSlot(globalSlot: 42, expectedTimeMs: 10500),
+          ],
+        ),
+      );
+
+      final result = await harness.service.audit(reason: 'foreground_resume');
+
+      expect(result.expectedSlotWakeCount, 0);
+      expect(result.tooLateCount, 1);
+      expect(harness.scheduledAlarms, isEmpty);
+      final tooLate = harness.events('alarm_audit_missing_too_late').single;
+      expect(tooLate['alarm_id'], 'slot_42');
+      expect(tooLate['lateness_ms'], 500);
+    });
+
+    test('handles no won slots', () async {
+      final harness = _AuditHarness(
+        epoch: const AlarmAuditEpochSnapshot(epoch: 7, wonSlots: []),
+      );
+
+      final result = await harness.service.audit(reason: 'headless_start');
+
+      expect(result.skippedReason, 'no_won_slots');
+      expect(result.fgResumeStatus, 'no_won_slots');
+      expect(harness.scheduledAlarms, isEmpty);
+    });
+
+    test('collapses overlapping audits', () async {
+      final epochCompleter = Completer<AlarmAuditEpochSnapshot?>();
+      final harness = _AuditHarness(epochCompleter: epochCompleter);
+
+      final first = harness.service.audit(reason: 'boot_completed');
+      final second = harness.service.audit(reason: 'package_replaced');
+
+      expect(identical(first, second), isTrue);
+      epochCompleter.complete(
+        const AlarmAuditEpochSnapshot(epoch: 7, wonSlots: []),
+      );
+
+      await first;
+      expect(harness.loadEpochCalls, 1);
+    });
+
+    test('native recovery retries when node is not ready yet', () async {
+      final retryDelays = <Duration>[];
+      final retryCallbacks = <void Function()>[];
+      final harness = _AuditHarness(
+        nodeRunning: false,
+        recoveryRetryDelays: const [Duration(milliseconds: 1)],
+        scheduleRecoveryRetry: (delay, callback) {
+          retryDelays.add(delay);
+          retryCallbacks.add(callback);
+        },
+      );
+
+      harness.service.handleNativeEvent(
+        'android_alarm_recovery_requested',
+        {'reason': 'boot_completed'},
+      );
+      await pumpEventQueue(times: 20);
+
+      expect(
+        harness.events('alarm_audit_skipped').single['skipped_reason'],
+        'node_not_running',
+      );
+      expect(retryDelays.single, const Duration(milliseconds: 1));
+      expect(retryCallbacks, hasLength(1));
+
+      harness.nodeRunning = true;
+      retryCallbacks.single();
+      await pumpEventQueue(times: 20);
+
+      expect(harness.scheduledAlarms.single.alarmId, 'slot_42');
+      final slotWakeEvents = harness
+          .events('alarm_audit_missing_rescheduled')
+          .where((event) => event['purpose'] == 'slot_wake');
+      expect(slotWakeEvents, hasLength(1));
+    });
+
+    test('native recovery retries when won slots are not available yet',
+        () async {
+      final retryCallbacks = <void Function()>[];
+      final harness = _AuditHarness(
+        epoch: const AlarmAuditEpochSnapshot(epoch: 7, wonSlots: []),
+        recoveryRetryDelays: const [Duration(milliseconds: 1)],
+        scheduleRecoveryRetry: (_, callback) {
+          retryCallbacks.add(callback);
+        },
+      );
+
+      harness.service.handleNativeEvent(
+        'android_alarm_recovery_requested',
+        {'reason': 'boot_completed'},
+      );
+      await pumpEventQueue(times: 20);
+
+      expect(
+        harness.events('alarm_audit_skipped').single['skipped_reason'],
+        'no_won_slots',
+      );
+      expect(retryCallbacks, hasLength(1));
+    });
+
+    test('foreground resume present emits present telemetry', () async {
+      final harness = _AuditHarness(
+        presentAlarms: {'slot_42', 'fg_resume'},
+        epoch: const AlarmAuditEpochSnapshot(
+          epoch: 7,
+          wonSlots: [
+            AlarmAuditWonSlot(globalSlot: 42, expectedTimeMs: 20000),
+          ],
+        ),
+      );
+
+      final result = await harness.service.audit(reason: 'foreground_resume');
+
+      expect(result.fgResumeStatus, 'present');
+      expect(harness.foregroundResumeSchedules, isEmpty);
+      expect(harness.events('foreground_resume_present'), hasLength(1));
+    });
+
+    test('foreground resume missing recreates fg_resume', () async {
+      final harness = _AuditHarness(
+        presentAlarms: {'slot_42'},
+        epoch: const AlarmAuditEpochSnapshot(
+          epoch: 7,
+          wonSlots: [
+            AlarmAuditWonSlot(globalSlot: 42, expectedTimeMs: 20000),
+          ],
+        ),
+      );
+
+      final result = await harness.service.audit(reason: 'cold_start');
+
+      expect(result.fgResumeStatus, 'recreated');
+      expect(harness.foregroundResumeSchedules.single.globalSlot, 42);
+      expect(harness.events('foreground_resume_recreated'), hasLength(1));
+    });
+
+    test('foreground resume skips when next slot is too close', () async {
+      final harness = _AuditHarness(
+        epoch: const AlarmAuditEpochSnapshot(
+          epoch: 7,
+          wonSlots: [
+            AlarmAuditWonSlot(globalSlot: 42, expectedTimeMs: 10500),
+          ],
+        ),
+      );
+
+      final result = await harness.service.audit(reason: 'foreground_resume');
+
+      expect(result.fgResumeStatus, 'slot_too_close');
+      expect(harness.foregroundResumeSchedules, isEmpty);
+      expect(
+        harness.events('foreground_resume_not_scheduled_slot_too_close'),
+        hasLength(1),
+      );
+    });
+  });
+}
+
+class _AuditHarness {
+  _AuditHarness({
+    this.exactAlarmPermission = true,
+    this.epoch = const AlarmAuditEpochSnapshot(
+      epoch: 7,
+      wonSlots: [
+        AlarmAuditWonSlot(globalSlot: 42, expectedTimeMs: 20000),
+      ],
+    ),
+    this.epochCompleter,
+    Set<String>? presentAlarms,
+    this.nodeRunning = true,
+    this.recoveryRetryDelays,
+    this.scheduleRecoveryRetry,
+  }) : presentAlarms = presentAlarms ?? <String>{} {
+    service = BlockProductionAlarmAuditService.test(
+      initializeAlarmService: () async => true,
+      refreshPermissions: () async => exactAlarmPermission,
+      hasExactAlarmPermission: () async => exactAlarmPermission,
+      hasScheduledAlarm: (alarmId) async =>
+          this.presentAlarms.contains(alarmId),
+      scheduleAlarm: ({
+        required alarmId,
+        required slotNumber,
+        required delayMs,
+        data,
+      }) async {
+        scheduledAlarms.add(
+          _ScheduledAlarm(
+            alarmId: alarmId,
+            slotNumber: slotNumber,
+            delayMs: delayMs,
+            data: data ?? const {},
+          ),
+        );
+        return true;
+      },
+      scheduleForegroundResume: ({
+        required rustWakeTimeMs,
+        required schedulerReason,
+        required globalSlot,
+        required slotTimeMs,
+      }) async {
+        foregroundResumeSchedules.add(
+          _ForegroundResumeSchedule(
+            rustWakeTimeMs: rustWakeTimeMs,
+            schedulerReason: schedulerReason,
+            globalSlot: globalSlot,
+            slotTimeMs: slotTimeMs,
+          ),
+        );
+        return ForegroundResumeAlarmScheduleResult(
+          success: true,
+          alarmTimeMs: slotTimeMs - foregroundResumeLead.inMilliseconds,
+          delayMs: slotTimeMs - foregroundResumeLead.inMilliseconds - nowMs,
+          clockDriftMs: clockDriftMs,
+        );
+      },
+      loadEpochSnapshot: () async {
+        loadEpochCalls++;
+        if (epochCompleter != null) {
+          return epochCompleter!.future;
+        }
+        return epoch;
+      },
+      resolveClockDriftMs: () async => clockDriftMs,
+      ensureNodeRunning: () async {
+        ensureNodeRunningCalls++;
+        return nodeRunning;
+      },
+      isNodeRunning: () => nodeRunning,
+      wasForceStoppedOnStartup: () async => false,
+      nowMs: () => nowMs,
+      rustToLocalTimeMs: (rustTimeMs, clockDriftMs) =>
+          rustTimeMs + clockDriftMs,
+      isAndroid: () => true,
+      appState: () => 'foreground',
+      platformVersion: () => 'android-test',
+      observability: _observability(records),
+      slotWakeLead: slotWakeLead,
+      foregroundResumeLead: foregroundResumeLead,
+      recoveryRetryDelays: recoveryRetryDelays,
+      scheduleRecoveryRetry: scheduleRecoveryRetry,
+    );
+  }
+
+  static const slotWakeLead = Duration(milliseconds: 1000);
+  static const foregroundResumeLead = Duration(milliseconds: 1000);
+
+  final bool exactAlarmPermission;
+  bool nodeRunning;
+  final int clockDriftMs = 0;
+  final int nowMs = 10000;
+  final AlarmAuditEpochSnapshot? epoch;
+  final Completer<AlarmAuditEpochSnapshot?>? epochCompleter;
+  final List<Duration>? recoveryRetryDelays;
+  final AlarmAuditRecoveryRetryScheduler? scheduleRecoveryRetry;
+  final Set<String> presentAlarms;
+  final records = <_CapturedObservabilityRecord>[];
+  final scheduledAlarms = <_ScheduledAlarm>[];
+  final foregroundResumeSchedules = <_ForegroundResumeSchedule>[];
+  var loadEpochCalls = 0;
+  var ensureNodeRunningCalls = 0;
+
+  late final BlockProductionAlarmAuditService service;
+
+  List<Map<String, dynamic>> events(String event) => records
+      .where((record) => record.event == event)
+      .map((record) => record.payload)
+      .toList(growable: false);
+}
+
+ObservabilityReportingService _observability(
+  List<_CapturedObservabilityRecord> records,
+) {
+  final service = ObservabilityReportingService.test(
+    collector: _NoopMobileContextCollector(),
+    canRecord: () => true,
+    record: ({
+      required FlutterObservabilityKind kind,
+      required String event,
+      String? payloadJson,
+    }) {
+      records.add(
+        _CapturedObservabilityRecord(
+          kind: kind,
+          event: event,
+          payload: jsonDecode(payloadJson ?? '{}') as Map<String, dynamic>,
+        ),
+      );
+      return const FlutterObservabilityRecordResult(
+        queued: true,
+        discarded: false,
+      );
+    },
+  );
+  service.markNodeInitialized();
+  return service;
+}
+
+class _ScheduledAlarm {
+  const _ScheduledAlarm({
+    required this.alarmId,
+    required this.slotNumber,
+    required this.delayMs,
+    required this.data,
+  });
+
+  final String alarmId;
+  final int slotNumber;
+  final int delayMs;
+  final Map<String, dynamic> data;
+}
+
+class _ForegroundResumeSchedule {
+  const _ForegroundResumeSchedule({
+    required this.rustWakeTimeMs,
+    required this.schedulerReason,
+    required this.globalSlot,
+    required this.slotTimeMs,
+  });
+
+  final int rustWakeTimeMs;
+  final String schedulerReason;
+  final int globalSlot;
+  final int slotTimeMs;
+}
+
+class _CapturedObservabilityRecord {
+  const _CapturedObservabilityRecord({
+    required this.kind,
+    required this.event,
+    required this.payload,
+  });
+
+  final FlutterObservabilityKind kind;
+  final String event;
+  final Map<String, dynamic> payload;
+}
+
+class _NoopMobileContextCollector implements MobileContextSnapshotCollector {
+  @override
+  Future<Map<String, dynamic>> collectPowerNetworkServiceContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async =>
+      {};
+
+  @override
+  Future<Map<String, dynamic>> collectRuntimeMobileContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async =>
+      {};
+
+  @override
+  Future<Map<String, dynamic>> collectStaticMobileContextSnapshot({
+    Map<String, dynamic>? eventData,
+  }) async =>
+      {};
+}


### PR DESCRIPTION

- Add Android alarm audit/recovery for block production slot alarms.
- Detect missing `slot_*` and `fg_resume` alarms after boot, package replace, exact alarm permission changes, and app restart after force-stop.
- Retry recovery while the node/VRF data is still starting up, then reschedule missing exact alarms.
- Add telemetry events for alarm audit start/skip/completion, missing/rescheduled alarms, force-stop restart, and foreground resume alarm state.
