### PR TITLE
fix: increase foreground resume alarm lead

### DIFF
--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -22,8 +22,8 @@ class AndroidForegroundTaskController {
       AndroidForegroundTaskController._();
 
   static const Duration _pollInterval = Duration(seconds: 30);
-  static const Duration _alarmLead = Duration(minutes: 1);
   static const Duration _alarmEventDedupWindow = Duration(seconds: 10);
+  static const foregroundResumeLead = Duration(minutes: 4);
   static const foregroundResumeAlarmId = 'fg_resume';
 
   Timer? _pollTimer;
@@ -253,16 +253,16 @@ class AndroidForegroundTaskController {
         );
         final diffMs = localSlotTimeMs - nowMs;
 
-        if (diffMs > _alarmLead.inMilliseconds) {
+        if (diffMs > foregroundResumeLead.inMilliseconds) {
           await _scheduleResume(
-            rustSlotTimeMs - _alarmLead.inMilliseconds,
+            rustSlotTimeMs - foregroundResumeLead.inMilliseconds,
             'next_won_slot:${nextWon.globalSlot}',
             targetGlobalSlot: nextWon.globalSlot,
             targetSlotTimeMs: localSlotTimeMs,
           );
         } else {
           _log.info(
-            'Next won slot ${nextWon.globalSlot} in <1m, keeping foreground running',
+            'Next won slot ${nextWon.globalSlot} is too close, keeping foreground running',
           );
         }
         return;
@@ -286,13 +286,13 @@ class AndroidForegroundTaskController {
         clockDriftMs: clockDriftMs,
       );
       final untilEndMs = localEpochEndTimeMs - nowMs;
-      if (untilEndMs > _alarmLead.inMilliseconds) {
+      if (untilEndMs > foregroundResumeLead.inMilliseconds) {
         await _scheduleResume(
-          epochEndRustTimeMs - _alarmLead.inMilliseconds,
+          epochEndRustTimeMs - foregroundResumeLead.inMilliseconds,
           'epoch_end_${info.currentEpoch}',
         );
       } else {
-        _log.info('Epoch end <1m, keeping foreground until end');
+        _log.info('Epoch end is too close, keeping foreground until end');
       }
     } catch (e, st) {
       _log.error('VRF poll failed', error: e, stackTrace: st);

--- a/lib/core/services/block_production_alarm_audit_service.dart
+++ b/lib/core/services/block_production_alarm_audit_service.dart
@@ -89,8 +89,8 @@ class BlockProductionAlarmAuditService {
         _observability =
             observability ?? ObservabilityReportingService.instance,
         _slotWakeLead = slotWakeLead ?? AppConfig.blockProductionWakeBeforeSlot,
-        _foregroundResumeLead =
-            foregroundResumeLead ?? const Duration(minutes: 1),
+        _foregroundResumeLead = foregroundResumeLead ??
+            AndroidForegroundTaskController.foregroundResumeLead,
         _recoveryRetryDelays = recoveryRetryDelays ??
             const [
               Duration(seconds: 5),

--- a/test/core/services/block_production_alarm_audit_service_test.dart
+++ b/test/core/services/block_production_alarm_audit_service_test.dart
@@ -159,6 +159,13 @@ void main() {
       expect(retryCallbacks, hasLength(1));
     });
 
+    test('foreground resume lead is four minutes in production', () {
+      expect(
+        AndroidForegroundTaskController.foregroundResumeLead,
+        const Duration(minutes: 4),
+      );
+    });
+
     test('foreground resume present emits present telemetry', () async {
       final harness = _AuditHarness(
         presentAlarms: {'slot_42', 'fg_resume'},


### PR DESCRIPTION
Increase the Android foreground resume alarm lead time from 1 minute to 4 minutes.

This gives the app more time to restart foreground monitoring before an upcoming block production slot, reducing the chance that Android startup delays make the app miss the slot window.
