### PR TITLE
feat: share HTTP debug logs with the team

### DIFF
--- a/lib/core/config/l10n/app_en.arb
+++ b/lib/core/config/l10n/app_en.arb
@@ -2885,5 +2885,25 @@
   "httpLogsCopied": "Logs copied to clipboard",
   "@httpLogsCopied": {
     "description": "Snackbar shown after copying logs to the clipboard"
+  },
+  "httpLogsShare": "Share the logs with the team",
+  "@httpLogsShare": {
+    "description": "Button that starts sending captured logs to the backend"
+  },
+  "httpLogsSharing": "Sharing logs with the team every 30s…",
+  "@httpLogsSharing": {
+    "description": "Caption shown while logs are being shared periodically"
+  },
+  "httpLogsStopSharing": "Stop sharing",
+  "@httpLogsStopSharing": {
+    "description": "Button that stops the periodic log sharing session"
+  },
+  "httpLogsShareStopped": "The server stopped log sharing. You can share again anytime.",
+  "@httpLogsShareStopped": {
+    "description": "Snackbar shown when the backend asked the app to stop sharing logs"
+  },
+  "httpLogsShareNoParticipant": "No participant ID yet — finish onboarding to share logs",
+  "@httpLogsShareNoParticipant": {
+    "description": "Disabled-share hint shown when no participant ID is available"
   }
 }

--- a/lib/core/config/l10n/app_localizations.dart
+++ b/lib/core/config/l10n/app_localizations.dart
@@ -3789,6 +3789,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Logs copied to clipboard'**
   String get httpLogsCopied;
+
+  /// Button that starts sending captured logs to the backend
+  ///
+  /// In en, this message translates to:
+  /// **'Share the logs with the team'**
+  String get httpLogsShare;
+
+  /// Caption shown while logs are being shared periodically
+  ///
+  /// In en, this message translates to:
+  /// **'Sharing logs with the team every 30s…'**
+  String get httpLogsSharing;
+
+  /// Button that stops the periodic log sharing session
+  ///
+  /// In en, this message translates to:
+  /// **'Stop sharing'**
+  String get httpLogsStopSharing;
+
+  /// Snackbar shown when the backend asked the app to stop sharing logs
+  ///
+  /// In en, this message translates to:
+  /// **'The server stopped log sharing. You can share again anytime.'**
+  String get httpLogsShareStopped;
+
+  /// Disabled-share hint shown when no participant ID is available
+  ///
+  /// In en, this message translates to:
+  /// **'No participant ID yet — finish onboarding to share logs'**
+  String get httpLogsShareNoParticipant;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/core/config/l10n/app_localizations_en.dart
+++ b/lib/core/config/l10n/app_localizations_en.dart
@@ -2131,4 +2131,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get httpLogsCopied => 'Logs copied to clipboard';
+
+  @override
+  String get httpLogsShare => 'Share the logs with the team';
+
+  @override
+  String get httpLogsSharing => 'Sharing logs with the team every 30s…';
+
+  @override
+  String get httpLogsStopSharing => 'Stop sharing';
+
+  @override
+  String get httpLogsShareStopped =>
+      'The server stopped log sharing. You can share again anytime.';
+
+  @override
+  String get httpLogsShareNoParticipant =>
+      'No participant ID yet — finish onboarding to share logs';
 }

--- a/lib/core/providers/log_share_provider.dart
+++ b/lib/core/providers/log_share_provider.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import 'package:crypto_mobile_app/core/services/http_debug_log_store.dart';
+import 'package:crypto_mobile_app/core/services/log_share_service.dart';
+
+enum LogShareStatus { idle, sharing }
+
+/// State of the "share logs with the team" feature.
+///
+/// [stoppedByServer] is set for the single transition where the backend asked
+/// us to stop (`{"continue": false}` or 404). The UI listens for it to surface
+/// a message, then the user is free to start again (the button stays enabled).
+class LogShareState {
+  const LogShareState({
+    this.status = LogShareStatus.idle,
+    this.stoppedByServer = false,
+  });
+
+  final LogShareStatus status;
+  final bool stoppedByServer;
+
+  bool get isSharing => status == LogShareStatus.sharing;
+}
+
+/// Drives periodic, incremental sharing of the HTTP debug log buffer.
+///
+/// On [start] the whole currently-buffered set is sent immediately, then only
+/// newly-captured entries are flushed every [flushInterval]. Sending is
+/// fire-and-forget: failures keep the cursor put so nothing is lost, and the
+/// loop never throws into the UI.
+class LogShareController extends StateNotifier<LogShareState> {
+  LogShareController({
+    required this.ref,
+    LogShareService? service,
+    HttpDebugLogStore? store,
+  })  : _service = service ?? LogShareService(),
+        _store = store ?? HttpDebugLogStore.instance,
+        super(const LogShareState());
+
+  final Ref ref;
+  final LogShareService _service;
+  final HttpDebugLogStore _store;
+
+  static const flushInterval = Duration(seconds: 30);
+
+  Timer? _timer;
+  bool _flushing = false;
+
+  /// Cursor into [HttpDebugLogStore.totalAdded]: entries before it were sent.
+  int _cursor = 0;
+  int? _participantId;
+  String _appVersion = 'unknown';
+  late final String _platform = _resolvePlatform();
+
+  /// Begin a sharing session for [participantId]. No-op if already sharing.
+  Future<void> start(int participantId) async {
+    if (state.isSharing) return;
+    _participantId = participantId;
+    _cursor = 0; // send everything currently buffered on the first flush
+    _appVersion = await _resolveAppVersion();
+    state = const LogShareState(status: LogShareStatus.sharing);
+
+    await _flush();
+    // The first flush may have been told to stop; only arm the timer if not.
+    if (mounted && state.isSharing) {
+      _timer = Timer.periodic(flushInterval, (_) => _flush());
+    }
+  }
+
+  /// User-initiated stop. Returns to idle without the [stoppedByServer] flag.
+  void stop() {
+    _stopTimer();
+    state = const LogShareState();
+  }
+
+  Future<void> _flush() async {
+    if (_flushing) return; // a slow POST is still in flight; skip this tick
+    final participantId = _participantId;
+    if (participantId == null) return;
+
+    final batch = _store.entriesAdded(_cursor);
+    if (batch.isEmpty) return;
+    final nextCursor = _store.totalAdded;
+
+    _flushing = true;
+    try {
+      final outcome = await _service.postLogs(
+        participantId: participantId,
+        body: _buildBody(batch),
+      );
+      if (!mounted) return;
+      switch (outcome) {
+        case LogShareOutcome.keepGoing:
+          _cursor = nextCursor;
+        case LogShareOutcome.stop:
+          _cursor = nextCursor;
+          _stopTimer();
+          state = const LogShareState(stoppedByServer: true);
+        case LogShareOutcome.failed:
+          break; // keep cursor; the same batch retries on the next flush
+      }
+    } finally {
+      _flushing = false;
+    }
+  }
+
+  Map<String, dynamic> _buildBody(List<HttpLogEntry> batch) => {
+        'logged_at': DateTime.now().toUtc().toIso8601String(),
+        'level': 'info',
+        'message': 'http debug logs',
+        'app_version': _appVersion,
+        'platform': _platform,
+        'context': const <String, dynamic>{},
+        'events': batch.map((e) => e.toJsonEvent()).toList(growable: false),
+      };
+
+  Future<String> _resolveAppVersion() async {
+    try {
+      final info = await PackageInfo.fromPlatform();
+      return '${info.version}+${info.buildNumber}';
+    } catch (_) {
+      return 'unknown';
+    }
+  }
+
+  String _resolvePlatform() {
+    if (Platform.isIOS) return 'ios';
+    if (Platform.isAndroid) return 'android';
+    return Platform.operatingSystem;
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  @override
+  void dispose() {
+    _stopTimer();
+    _service.dispose();
+    super.dispose();
+  }
+}
+
+final logShareControllerProvider =
+    StateNotifierProvider<LogShareController, LogShareState>(
+  (ref) => LogShareController(ref: ref),
+);

--- a/lib/core/services/http_debug_log_store.dart
+++ b/lib/core/services/http_debug_log_store.dart
@@ -90,6 +90,21 @@ class HttpLogEntry {
     return chars * 2;
   }
 
+  /// JSON form for the `events` array when sharing logs with the backend.
+  /// Mirrors the redacted/truncated fields exactly — no raw data leaks here.
+  Map<String, dynamic> toJsonEvent() => {
+        'timestamp': timestamp.toUtc().toIso8601String(),
+        'method': method,
+        'url': url,
+        if (statusCode != null) 'status_code': statusCode,
+        if (durationMs != null) 'duration_ms': durationMs,
+        if (requestHeaders.isNotEmpty) 'request_headers': requestHeaders,
+        if (requestBody != null) 'request_body': requestBody,
+        if (responseHeaders.isNotEmpty) 'response_headers': responseHeaders,
+        if (responseBody != null) 'response_body': responseBody,
+        if (error != null) 'error': error,
+      };
+
   /// Multi-line, human-readable form used for copy/share.
   String toLogText() {
     final b = StringBuffer()
@@ -139,13 +154,34 @@ class HttpDebugLogStore extends ChangeNotifier {
   final List<HttpLogEntry> _entries = [];
   int _totalBytes = 0;
 
+  /// Monotonic count of every entry ever [add]ed, unaffected by eviction.
+  /// Used as a stable cursor for incremental log sharing: callers remember a
+  /// value of [totalAdded] and later ask for [entriesAdded] since it.
+  int _totalAdded = 0;
+
   /// Newest-first snapshot for display.
   List<HttpLogEntry> get entries => _entries.reversed.toList(growable: false);
 
   int get totalBytes => _totalBytes;
 
+  /// See [_totalAdded].
+  int get totalAdded => _totalAdded;
+
+  /// Entries added since [cursor] (a prior [totalAdded] value), oldest-first.
+  ///
+  /// Entries evicted from the buffer since [cursor] are silently skipped — the
+  /// caller gets whatever is still retained, never duplicates. Returns an empty
+  /// list when nothing new (or everything new) has been evicted.
+  List<HttpLogEntry> entriesAdded(int cursor) {
+    final firstRetained = _totalAdded - _entries.length;
+    final from = (cursor - firstRetained).clamp(0, _entries.length);
+    if (from >= _entries.length) return const [];
+    return _entries.sublist(from);
+  }
+
   void add(HttpLogEntry entry) {
     _entries.add(entry);
+    _totalAdded++;
     _totalBytes += entry.approxBytes;
     // Evict oldest until within budget, but always keep the just-added entry.
     while (_totalBytes > maxBytes && _entries.length > 1) {

--- a/lib/core/services/log_share_service.dart
+++ b/lib/core/services/log_share_service.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:crypto_mobile_app/core/config/app_config.dart';
+import 'package:crypto_mobile_app/core/utils/logger.dart';
+
+final _log = LoggingService.instance.withTag('usernode/LogShareService');
+
+/// Result of a single batch POST to the team-logs endpoint.
+enum LogShareOutcome {
+  /// Stored — advance the cursor and keep sending (`{"continue": true}`).
+  keepGoing,
+
+  /// Stop sending for this session: either `{"continue": false}` (stored or
+  /// not, the server asked us to stop) or 404 (bad participant id). Not retried.
+  stop,
+
+  /// Transient failure (network error or 5xx after retries). The cursor is kept
+  /// so the same batch is re-sent on the next flush.
+  failed,
+}
+
+/// Fire-and-forget client for `POST /api/v2/mobile/logs/{participant}`.
+///
+/// Public, unauthenticated endpoint that always returns 200 with
+/// `{"continue": bool}`. Per the spec: retry only network/5xx (exp backoff,
+/// ~3 tries); never retry a 200 or 404. This client never throws — every path
+/// resolves to a [LogShareOutcome] so logging can never crash the caller.
+class LogShareService {
+  /// Defaults to a plain [http.Client] — deliberately NOT the app's logging
+  /// client, so these share POSTs aren't captured into the debug buffer (which
+  /// would feed them back into the next flush, an endless self-referential loop).
+  LogShareService({String? baseUrl, http.Client? httpClient})
+      : _baseUrl = baseUrl ?? AppConfig.leaderboardApiBaseUrl,
+        _http = httpClient ?? http.Client();
+
+  final String _baseUrl;
+  final http.Client _http;
+
+  static const _maxAttempts = 3;
+  static const _baseBackoff = Duration(seconds: 1);
+  static const _headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  };
+
+  /// POST [body] for [participantId]. See [LogShareOutcome] for semantics.
+  Future<LogShareOutcome> postLogs({
+    required int participantId,
+    required Map<String, dynamic> body,
+  }) async {
+    final url = Uri.parse('$_baseUrl/logs/$participantId');
+    final payload = jsonEncode(body);
+    var backoff = _baseBackoff;
+
+    for (var attempt = 1; attempt <= _maxAttempts; attempt++) {
+      try {
+        final resp = await _http
+            .post(url, headers: _headers, body: payload)
+            .timeout(AppConfig.leaderboardApiTimeout);
+
+        if (resp.statusCode == 404) {
+          _log.warn('Bad participant id ($participantId); stopping log share');
+          return LogShareOutcome.stop;
+        }
+        if (resp.statusCode >= 500) {
+          if (attempt < _maxAttempts) {
+            await Future<void>.delayed(backoff);
+            backoff *= 2;
+            continue;
+          }
+          _log.warn('Server error ${resp.statusCode} after $attempt attempts');
+          return LogShareOutcome.failed;
+        }
+        if (resp.statusCode == 200) {
+          return _shouldContinue(resp.body)
+              ? LogShareOutcome.keepGoing
+              : LogShareOutcome.stop;
+        }
+        // Any other 4xx: spec says don't retry. Treat as a transient failure
+        // (cursor kept) so a misconfiguration doesn't silently drop logs.
+        _log.warn('Unexpected status ${resp.statusCode}');
+        return LogShareOutcome.failed;
+      } catch (e) {
+        if (attempt < _maxAttempts) {
+          await Future<void>.delayed(backoff);
+          backoff *= 2;
+          continue;
+        }
+        _log.warn('Log share request failed after $attempt attempts: $e');
+        return LogShareOutcome.failed;
+      }
+    }
+    return LogShareOutcome.failed;
+  }
+
+  /// Defaults to stop on any unparseable/unexpected body — safer than looping.
+  bool _shouldContinue(String responseBody) {
+    try {
+      final decoded = jsonDecode(responseBody);
+      return decoded is Map && decoded['continue'] == true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  void dispose() => _http.close();
+}

--- a/lib/features/settings/screens/http_debug_logs_screen.dart
+++ b/lib/features/settings/screens/http_debug_logs_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
+import 'package:crypto_mobile_app/core/providers/leaderboard_participant_provider.dart';
+import 'package:crypto_mobile_app/core/providers/log_share_provider.dart';
 import 'package:crypto_mobile_app/core/providers/providers.dart';
 import 'package:crypto_mobile_app/core/services/http_debug_log_store.dart';
 import 'package:crypto_mobile_app/design_system/design_system.dart';
@@ -20,6 +22,15 @@ class HttpDebugLogsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final store = ref.watch(httpDebugLogStoreProvider);
     final l10n = AppLocalizations.of(context);
+
+    // Surface a one-off message when the backend asks us to stop sharing.
+    ref.listen(logShareControllerProvider, (prev, next) {
+      if (next.stoppedByServer && prev?.stoppedByServer != true) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.httpLogsShareStopped)),
+        );
+      }
+    });
 
     return Scaffold(
       appBar: AppBar(
@@ -60,6 +71,72 @@ class HttpDebugLogsScreen extends ConsumerWidget {
             );
           },
         ),
+      ),
+      bottomNavigationBar: const _ShareLogsBar(),
+    );
+  }
+}
+
+/// Bottom action bar that toggles periodic log sharing with the team.
+///
+/// Disabled until a participant ID exists. While active it shows a caption and
+/// a stop button; the backend can also end the session (see [LogShareState]),
+/// after which this returns to the idle "share" affordance.
+class _ShareLogsBar extends ConsumerWidget {
+  const _ShareLogsBar();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final spacing = theme.extension<AppSpacing>()!;
+    final l10n = AppLocalizations.of(context);
+
+    final shareState = ref.watch(logShareControllerProvider);
+    final participantId = ref.watch(participantIdProvider).valueOrNull;
+    final controller = ref.read(logShareControllerProvider.notifier);
+
+    final Widget child;
+    if (shareState.isSharing) {
+      child = Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            l10n.httpLogsSharing,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          SizedBox(height: spacing.space8),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              icon: const Icon(Symbols.stop_circle_sharp),
+              label: Text(l10n.httpLogsStopSharing),
+              onPressed: controller.stop,
+            ),
+          ),
+        ],
+      );
+    } else {
+      final canShare = participantId != null;
+      child = Tooltip(
+        message: canShare ? '' : l10n.httpLogsShareNoParticipant,
+        child: SizedBox(
+          width: double.infinity,
+          child: FilledButton.icon(
+            icon: const Icon(Symbols.upload_sharp),
+            label: Text(l10n.httpLogsShare),
+            onPressed: canShare ? () => controller.start(participantId) : null,
+          ),
+        ),
+      );
+    }
+
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.all(spacing.space16),
+        child: child,
       ),
     );
   }


### PR DESCRIPTION
Add a "Share the logs with the team" button on the HTTP Logs screen that POSTs captured logs to /api/v2/mobile/logs/{participant} every 30s while on.

- LogShareService: fire-and-forget POST, obeys {"continue"} (stop on false or 404), retries only network/5xx with exp backoff (3 tries), never throws. Uses a plain http.Client so share POSTs aren't recaptured into the buffer.
- LogShareController: flushes the buffer immediately on start, then only new entries every 30s via a cursor over HttpDebugLogStore.totalAdded; server stop returns to idle so the user can share again anytime.
- HttpDebugLogStore: monotonic totalAdded cursor, entriesAdded(), toJsonEvent().