### PR TITLE
fix: improve alarm telemetry audit

### DIFF
--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmLedger.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmLedger.kt
@@ -1,0 +1,217 @@
+package com.usernode_labs.usernode.alarm
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.json.JSONObject
+
+class AlarmLedger(context: Context) {
+    companion object {
+        private const val PREFS_NAME = "alarm_prefs"
+        private const val LEDGER_PREFIX = "alarm_ledger_"
+        private const val LEDGER_IDS_KEY = "alarm_ledger_ids"
+        private const val MAX_LEDGER_ENTRIES = 128
+    }
+
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun recordScheduled(
+        alarmId: String,
+        slotNumber: Int,
+        triggerAtMs: Long,
+        scheduledAtMs: Long,
+        scheduledElapsedRealtimeMs: Long,
+        triggerElapsedRealtimeMs: Long,
+        requestedDelayMs: Long,
+        effectiveDelayMs: Long,
+        data: Map<String, Any>
+    ) {
+        val json = JSONObject()
+        json.put("alarmId", alarmId)
+        json.put("slotNumber", slotNumber)
+        json.put("scheduledAtMs", scheduledAtMs)
+        json.put("triggerAtMs", triggerAtMs)
+        json.put("nativeTriggerAtMs", triggerAtMs)
+        json.put("scheduledElapsedRealtimeMs", scheduledElapsedRealtimeMs)
+        json.put("triggerElapsedRealtimeMs", triggerElapsedRealtimeMs)
+        json.put("requestedDelayMs", requestedDelayMs)
+        json.put("effectiveDelayMs", effectiveDelayMs)
+        json.put("alarmTimeMs", triggerAtMs)
+        json.put("scheduleStatus", "scheduled")
+        putData(json, data)
+        save(alarmId, json)
+    }
+
+    fun recordScheduleFailed(
+        alarmId: String,
+        slotNumber: Int,
+        triggerAtMs: Long,
+        scheduledAtMs: Long,
+        scheduledElapsedRealtimeMs: Long,
+        triggerElapsedRealtimeMs: Long,
+        requestedDelayMs: Long,
+        effectiveDelayMs: Long,
+        data: Map<String, Any>,
+        failureReason: String
+    ) {
+        val json = JSONObject()
+        json.put("alarmId", alarmId)
+        json.put("slotNumber", slotNumber)
+        json.put("scheduledAtMs", scheduledAtMs)
+        json.put("triggerAtMs", triggerAtMs)
+        json.put("nativeTriggerAtMs", triggerAtMs)
+        json.put("scheduledElapsedRealtimeMs", scheduledElapsedRealtimeMs)
+        json.put("triggerElapsedRealtimeMs", triggerElapsedRealtimeMs)
+        json.put("requestedDelayMs", requestedDelayMs)
+        json.put("effectiveDelayMs", effectiveDelayMs)
+        json.put("alarmTimeMs", triggerAtMs)
+        json.put("scheduleStatus", "failed")
+        json.put("scheduleFailureReason", failureReason)
+        putData(json, data)
+        save(alarmId, json)
+    }
+
+    fun recordReceiverEntered(
+        alarmId: String,
+        slotNumber: Int,
+        alarmTimeMs: Long,
+        nativeTriggerAtMs: Long?,
+        receiverEnteredAtMs: Long,
+        receiverElapsedRealtimeMs: Long,
+        receiverLatencyMs: Long,
+        nativeDeliveryLatencyMs: Long?,
+        elapsedDeliveryLatencyMs: Long?,
+        triggerElapsedRealtimeMs: Long?,
+        globalSlot: Long?,
+        purpose: String?,
+        schedulerReason: String?,
+        nodeRunning: Boolean
+    ) {
+        val json = read(alarmId)
+        json.put("alarmId", alarmId)
+        json.put("slotNumber", slotNumber)
+        if (alarmTimeMs > 0) {
+            json.put("alarmTimeMs", alarmTimeMs)
+            if (!json.has("triggerAtMs")) {
+                json.put("triggerAtMs", alarmTimeMs)
+            }
+        }
+        nativeTriggerAtMs?.takeIf { it > 0 }?.let {
+            json.put("nativeTriggerAtMs", it)
+            json.put("triggerAtMs", it)
+        }
+        triggerElapsedRealtimeMs?.takeIf { it > 0 }?.let {
+            json.put("triggerElapsedRealtimeMs", it)
+        }
+        json.put("receiverEnteredAtMs", receiverEnteredAtMs)
+        json.put("receiverSystemTimeMs", receiverEnteredAtMs)
+        json.put("receiverElapsedRealtimeMs", receiverElapsedRealtimeMs)
+        json.put("receiverLatencyMs", receiverLatencyMs)
+        nativeDeliveryLatencyMs?.let { json.put("nativeDeliveryLatencyMs", it) }
+        elapsedDeliveryLatencyMs?.let { json.put("elapsedDeliveryLatencyMs", it) }
+        json.put("nodeRunning", nodeRunning)
+        globalSlot?.let { json.put("globalSlot", it) }
+        purpose?.let { json.put("purpose", it) }
+        schedulerReason?.let { json.put("schedulerReason", it) }
+        save(alarmId, json)
+    }
+
+    fun recordFlutterEventSent(alarmId: String, sentAtMs: Long) {
+        val json = read(alarmId)
+        json.put("alarmId", alarmId)
+        json.put("flutterEventSentAtMs", sentAtMs)
+        save(alarmId, json)
+    }
+
+    fun recordCancelled(alarmId: String, reason: String, cancelledAtMs: Long) {
+        val json = read(alarmId)
+        json.put("alarmId", alarmId)
+        json.put("cancelledAtMs", cancelledAtMs)
+        json.put("cancelReason", reason)
+        save(alarmId, json)
+    }
+
+    fun getState(
+        alarmId: String,
+        pendingIntentExists: Boolean,
+        canScheduleExactAlarms: Boolean
+    ): Map<String, Any?> {
+        val map = jsonToMap(read(alarmId))
+        map["alarmId"] = alarmId
+        map["pendingIntentExists"] = pendingIntentExists
+        map["canScheduleExactAlarms"] = canScheduleExactAlarms
+        return map
+    }
+
+    private fun putData(json: JSONObject, data: Map<String, Any>) {
+        putIfSupported(json, "epoch", data["epoch"])
+        putIfSupported(json, "slotTimeMs", data["slotTimeMs"])
+        putIfSupported(json, "alarmTimeMs", data["alarmTimeMs"])
+        putIfSupported(json, "rustSlotTimeMs", data["rustSlotTimeMs"])
+        putIfSupported(json, "localSlotTimeMs", data["localSlotTimeMs"])
+        putIfSupported(json, "rustWakeTimeMs", data["rustWakeTimeMs"])
+        putIfSupported(json, "localWakeTimeMs", data["localWakeTimeMs"])
+        putIfSupported(json, "clockDriftMs", data["clockDriftMs"])
+        putIfSupported(json, "nodeTimeMsAtSchedule", data["nodeTimeMsAtSchedule"])
+        putIfSupported(json, "systemTimeMsAtSchedule", data["systemTimeMsAtSchedule"])
+        putIfSupported(json, "clockDriftSampleAgeMs", data["clockDriftSampleAgeMs"])
+        putIfSupported(json, "globalSlot", data["globalSlot"] ?: data["global_slot"])
+        putIfSupported(json, "purpose", data["purpose"])
+        putIfSupported(json, "schedulerReason", data["reason"])
+        putIfSupported(json, "nodeRunning", data["nodeRunning"])
+    }
+
+    private fun putIfSupported(json: JSONObject, key: String, value: Any?) {
+        when (value) {
+            is String -> json.put(key, value)
+            is Int -> json.put(key, value)
+            is Long -> json.put(key, value)
+            is Boolean -> json.put(key, value)
+            is Double -> json.put(key, value)
+            is Float -> json.put(key, value.toDouble())
+        }
+    }
+
+    private fun read(alarmId: String): JSONObject {
+        val raw = prefs.getString(ledgerKey(alarmId), null) ?: return JSONObject()
+        return try {
+            JSONObject(raw)
+        } catch (_: Exception) {
+            JSONObject()
+        }
+    }
+
+    private fun save(alarmId: String, json: JSONObject) {
+        val ids = ledgerIds().toMutableList()
+        ids.remove(alarmId)
+        ids.add(0, alarmId)
+
+        val editor = prefs.edit()
+            .putString(ledgerKey(alarmId), json.toString())
+            .putString(LEDGER_IDS_KEY, ids.take(MAX_LEDGER_ENTRIES).joinToString(","))
+
+        ids.drop(MAX_LEDGER_ENTRIES).forEach { editor.remove(ledgerKey(it)) }
+        editor.commit()
+    }
+
+    private fun ledgerIds(): List<String> {
+        val raw = prefs.getString(LEDGER_IDS_KEY, "") ?: ""
+        if (raw.isEmpty()) return emptyList()
+        return raw.split(",").filter { it.isNotEmpty() }
+    }
+
+    private fun jsonToMap(json: JSONObject): MutableMap<String, Any?> {
+        val map = mutableMapOf<String, Any?>()
+        val keys = json.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val value = json.opt(key)
+            if (value != JSONObject.NULL) {
+                map[key] = value
+            }
+        }
+        return map
+    }
+
+    private fun ledgerKey(alarmId: String): String = "$LEDGER_PREFIX$alarmId"
+}

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmMethodChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmMethodChannelHandler.kt
@@ -189,6 +189,15 @@ class AlarmMethodChannelHandler(context: Context) {
 
                 result.success(alarmScheduler.hasScheduledAlarm(alarmId))
             }
+            "getAlarmDebugState" -> {
+                val alarmId = call.argument<String>("alarmId")
+                if (alarmId == null) {
+                    result.error("INVALID_ARGS", "Missing alarmId", null)
+                    return
+                }
+
+                result.success(alarmScheduler.getAlarmDebugState(alarmId))
+            }
             "startForegroundService" -> {
                 val title = call.argument<String>("title")
                 val message = call.argument<String>("message")

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.SystemClock
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import android.app.NotificationManager
@@ -46,6 +47,10 @@ class AlarmReceiver : BroadcastReceiver() {
         val alarmId = intent.getStringExtra("alarmId")
         val slotNumber = intent.getIntExtra("slotNumber", -1)
         val scheduledTimeMs = intent.getLongExtra("alarmTimeMs", -1L)
+        val nativeScheduledAtMs = optionalLongExtra(intent, "nativeScheduledAtMs")
+        val scheduledElapsedRealtimeMs = optionalLongExtra(intent, "scheduledElapsedRealtimeMs")
+        val nativeTriggerAtMs = optionalLongExtra(intent, "nativeTriggerAtMs")
+        val triggerElapsedRealtimeMs = optionalLongExtra(intent, "triggerElapsedRealtimeMs")
         val nodeRunning = intent.getBooleanExtra("nodeRunning", false)
         val globalSlot = optionalLongExtra(intent, "globalSlot")
             ?: optionalLongExtra(intent, "global_slot")
@@ -65,7 +70,27 @@ class AlarmReceiver : BroadcastReceiver() {
         }
 
         val currentTime = System.currentTimeMillis()
+        val receiverElapsedRealtimeMs = SystemClock.elapsedRealtime()
         val latencyMs = if (scheduledTimeMs > 0) currentTime - scheduledTimeMs else 0L
+        val nativeDeliveryLatencyMs = nativeTriggerAtMs?.let { currentTime - it }
+        val elapsedDeliveryLatencyMs =
+            triggerElapsedRealtimeMs?.let { receiverElapsedRealtimeMs - it }
+        AlarmLedger(context).recordReceiverEntered(
+            alarmId = alarmId,
+            slotNumber = slotNumber,
+            alarmTimeMs = scheduledTimeMs,
+            nativeTriggerAtMs = nativeTriggerAtMs,
+            receiverEnteredAtMs = currentTime,
+            receiverElapsedRealtimeMs = receiverElapsedRealtimeMs,
+            receiverLatencyMs = latencyMs,
+            nativeDeliveryLatencyMs = nativeDeliveryLatencyMs,
+            elapsedDeliveryLatencyMs = elapsedDeliveryLatencyMs,
+            triggerElapsedRealtimeMs = triggerElapsedRealtimeMs,
+            globalSlot = globalSlot,
+            purpose = purpose,
+            schedulerReason = reason,
+            nodeRunning = nodeRunning
+        )
         Log.i(TAG, "[AlarmReceiver] ✓ Slot alarm FIRED for slot $slotNumber (latency: ${latencyMs}ms)")
 
         // Take the native wakelock before handing control to Flutter so the
@@ -82,6 +107,13 @@ class AlarmReceiver : BroadcastReceiver() {
             "networkState" to "unknown",
             "nodeRunning" to nodeRunning
         )
+        nativeScheduledAtMs?.let { eventData["nativeScheduledAtMs"] = it }
+        scheduledElapsedRealtimeMs?.let { eventData["scheduledElapsedRealtimeMs"] = it }
+        nativeTriggerAtMs?.let { eventData["nativeTriggerAtMs"] = it }
+        triggerElapsedRealtimeMs?.let { eventData["triggerElapsedRealtimeMs"] = it }
+        eventData["receiverElapsedRealtimeMs"] = receiverElapsedRealtimeMs
+        nativeDeliveryLatencyMs?.let { eventData["nativeDeliveryLatencyMs"] = it }
+        elapsedDeliveryLatencyMs?.let { eventData["elapsedDeliveryLatencyMs"] = it }
         globalSlot?.let { eventData["globalSlot"] = it }
         reason?.let { eventData["reason"] = it }
         purpose?.let { eventData["purpose"] = it }
@@ -98,6 +130,7 @@ class AlarmReceiver : BroadcastReceiver() {
                 eventData
             )
         }
+        AlarmLedger(context).recordFlutterEventSent(alarmId, System.currentTimeMillis())
 
         // Start foreground service to keep app alive during monitoring
         Log.d(TAG, "[AlarmReceiver] Starting SlotMonitoringService")
@@ -107,6 +140,13 @@ class AlarmReceiver : BroadcastReceiver() {
             putExtra("slotNumber", slotNumber)
             putExtra("nodeRunning", nodeRunning)
             putExtra("alarmTimeMs", scheduledTimeMs)
+            nativeScheduledAtMs?.let { putExtra("nativeScheduledAtMs", it) }
+            scheduledElapsedRealtimeMs?.let { putExtra("scheduledElapsedRealtimeMs", it) }
+            nativeTriggerAtMs?.let { putExtra("nativeTriggerAtMs", it) }
+            triggerElapsedRealtimeMs?.let { putExtra("triggerElapsedRealtimeMs", it) }
+            putExtra("receiverElapsedRealtimeMs", receiverElapsedRealtimeMs)
+            nativeDeliveryLatencyMs?.let { putExtra("nativeDeliveryLatencyMs", it) }
+            elapsedDeliveryLatencyMs?.let { putExtra("elapsedDeliveryLatencyMs", it) }
             globalSlot?.let { putExtra("globalSlot", it) }
             reason?.let { putExtra("reason", it) }
             purpose?.let { putExtra("purpose", it) }

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmScheduler.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmScheduler.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.SystemClock
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.usernode_labs.usernode.R
@@ -24,6 +25,7 @@ class AlarmScheduler(
     }
 
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val ledger = AlarmLedger(context)
 
     fun scheduleExactAlarm(
         alarmId: String,
@@ -35,8 +37,10 @@ class AlarmScheduler(
             Log.d(TAG, "[AlarmScheduler] Attempting to schedule alarm - ID: $alarmId, Slot: $slotNumber, Delay: $delayMs")
 
             val currentTime = System.currentTimeMillis()
+            val scheduledElapsedRealtimeMs = SystemClock.elapsedRealtime()
             val effectiveDelayMs = delayMs.coerceAtLeast(0L)
             val triggerAtMs = currentTime + effectiveDelayMs
+            val triggerElapsedRealtimeMs = scheduledElapsedRealtimeMs + effectiveDelayMs
 
             // Check if we can schedule exact alarms
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -44,6 +48,18 @@ class AlarmScheduler(
                 Log.d(TAG, "[AlarmScheduler] Exact alarm permission status: $canSchedule (API ${Build.VERSION.SDK_INT})")
                 if (!canSchedule) {
                     Log.w(TAG, "[AlarmScheduler] Cannot schedule exact alarms - permission not granted")
+                    ledger.recordScheduleFailed(
+                        alarmId = alarmId,
+                        slotNumber = slotNumber,
+                        triggerAtMs = triggerAtMs,
+                        scheduledAtMs = currentTime,
+                        scheduledElapsedRealtimeMs = scheduledElapsedRealtimeMs,
+                        triggerElapsedRealtimeMs = triggerElapsedRealtimeMs,
+                        requestedDelayMs = delayMs,
+                        effectiveDelayMs = effectiveDelayMs,
+                        data = data,
+                        failureReason = "exact_alarm_permission_denied"
+                    )
                     return false
                 }
             } else {
@@ -68,6 +84,12 @@ class AlarmScheduler(
                         else -> Log.w(TAG, "[AlarmScheduler] Skipping extra for key=$key unsupported type=${value::class.java.simpleName}")
                     }
                 }
+                putExtra("nativeScheduledAtMs", currentTime)
+                putExtra("scheduledElapsedRealtimeMs", scheduledElapsedRealtimeMs)
+                putExtra("nativeTriggerAtMs", triggerAtMs)
+                putExtra("triggerElapsedRealtimeMs", triggerElapsedRealtimeMs)
+                putExtra("requestedDelayMs", delayMs)
+                putExtra("effectiveDelayMs", effectiveDelayMs)
             }
 
             val pendingIntent = PendingIntent.getBroadcast(
@@ -102,6 +124,17 @@ class AlarmScheduler(
 
             // Save alarm ID for tracking
             saveScheduledAlarm(alarmId, slotNumber)
+            ledger.recordScheduled(
+                alarmId = alarmId,
+                slotNumber = slotNumber,
+                triggerAtMs = triggerAtMs,
+                scheduledAtMs = currentTime,
+                scheduledElapsedRealtimeMs = scheduledElapsedRealtimeMs,
+                triggerElapsedRealtimeMs = triggerElapsedRealtimeMs,
+                requestedDelayMs = delayMs,
+                effectiveDelayMs = effectiveDelayMs,
+                data = data
+            )
             Log.d(TAG, "[AlarmScheduler] Alarm saved to SharedPreferences")
 
             showScheduledNotification(alarmId, slotNumber, triggerAtMs)
@@ -115,30 +148,7 @@ class AlarmScheduler(
     }
 
     fun cancelAlarm(alarmId: String): Boolean {
-        try {
-            val intent = Intent(context, AlarmReceiver::class.java).apply {
-                action = "com.usernode.app.SLOT_ALARM"
-            }
-
-            val pendingIntent = PendingIntent.getBroadcast(
-                context,
-                alarmId.hashCode(),
-                intent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-
-            alarmManager.cancel(pendingIntent)
-            pendingIntent.cancel()
-
-            // Remove from saved alarms
-            removeScheduledAlarm(alarmId)
-
-            Log.i(TAG, "Cancelled alarm: $alarmId")
-            return true
-        } catch (e: Exception) {
-            Log.e(TAG, "Error cancelling alarm", e)
-            return false
-        }
+        return cancelAlarm(alarmId, "cancel_alarm")
     }
 
     fun cancelAllAlarms(): Boolean {
@@ -146,7 +156,7 @@ class AlarmScheduler(
             val scheduledAlarms = getScheduledAlarms()
 
             for (alarmId in scheduledAlarms.keys) {
-                cancelAlarm(alarmId)
+                cancelAlarm(alarmId, "cancel_all_alarms")
             }
 
             clearScheduledAlarms()
@@ -178,6 +188,55 @@ class AlarmScheduler(
         } catch (e: Exception) {
             Log.e(TAG, "[AlarmScheduler] Error checking alarm existence for $alarmId", e)
             false
+        }
+    }
+
+    fun getAlarmDebugState(alarmId: String): Map<String, Any?> {
+        return ledger.getState(
+            alarmId = alarmId,
+            pendingIntentExists = hasScheduledAlarm(alarmId),
+            canScheduleExactAlarms = canScheduleExactAlarms()
+        )
+    }
+
+    private fun cancelAlarm(alarmId: String, reason: String): Boolean {
+        try {
+            val intent = Intent(context, AlarmReceiver::class.java).apply {
+                action = "com.usernode.app.SLOT_ALARM"
+            }
+
+            val pendingIntent = PendingIntent.getBroadcast(
+                context,
+                alarmId.hashCode(),
+                intent,
+                PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+            )
+
+            if (pendingIntent != null) {
+                alarmManager.cancel(pendingIntent)
+                pendingIntent.cancel()
+            }
+
+            removeScheduledAlarm(alarmId)
+            ledger.recordCancelled(
+                alarmId = alarmId,
+                reason = reason,
+                cancelledAtMs = System.currentTimeMillis()
+            )
+
+            Log.i(TAG, "Cancelled alarm: $alarmId")
+            return true
+        } catch (e: Exception) {
+            Log.e(TAG, "Error cancelling alarm", e)
+            return false
+        }
+    }
+
+    private fun canScheduleExactAlarms(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            alarmManager.canScheduleExactAlarms()
+        } else {
+            true
         }
     }
 

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
@@ -84,6 +84,13 @@ class SlotMonitoringService : Service() {
                 val alarmId = intent.getStringExtra("alarmId")
                 val nodeRunning = intent.getBooleanExtra("nodeRunning", false)
                 val alarmTimeMs = intent.getLongExtra("alarmTimeMs", -1L)
+                val nativeScheduledAtMs = optionalLongExtra(intent, "nativeScheduledAtMs")
+                val scheduledElapsedRealtimeMs = optionalLongExtra(intent, "scheduledElapsedRealtimeMs")
+                val nativeTriggerAtMs = optionalLongExtra(intent, "nativeTriggerAtMs")
+                val triggerElapsedRealtimeMs = optionalLongExtra(intent, "triggerElapsedRealtimeMs")
+                val receiverElapsedRealtimeMs = optionalLongExtra(intent, "receiverElapsedRealtimeMs")
+                val nativeDeliveryLatencyMs = optionalLongExtra(intent, "nativeDeliveryLatencyMs")
+                val elapsedDeliveryLatencyMs = optionalLongExtra(intent, "elapsedDeliveryLatencyMs")
                 val reason = intent.getStringExtra("reason")
                 val purpose = intent.getStringExtra("purpose")
                 Log.d(TAG, "[SlotMonitoringService] START_MONITORING - Slot: $slotNumber, AlarmId: $alarmId, nodeRunning=$nodeRunning")
@@ -107,6 +114,13 @@ class SlotMonitoringService : Service() {
                     "networkState" to "unknown",
                     "nodeRunning" to nodeRunning
                 )
+                nativeScheduledAtMs?.let { eventData["nativeScheduledAtMs"] = it }
+                scheduledElapsedRealtimeMs?.let { eventData["scheduledElapsedRealtimeMs"] = it }
+                nativeTriggerAtMs?.let { eventData["nativeTriggerAtMs"] = it }
+                triggerElapsedRealtimeMs?.let { eventData["triggerElapsedRealtimeMs"] = it }
+                receiverElapsedRealtimeMs?.let { eventData["receiverElapsedRealtimeMs"] = it }
+                nativeDeliveryLatencyMs?.let { eventData["nativeDeliveryLatencyMs"] = it }
+                elapsedDeliveryLatencyMs?.let { eventData["elapsedDeliveryLatencyMs"] = it }
                 globalSlot?.let { eventData["globalSlot"] = it }
                 reason?.let { eventData["reason"] = it }
                 purpose?.let { eventData["purpose"] = it }

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -258,6 +258,7 @@ class AndroidForegroundTaskController {
             rustSlotTimeMs - foregroundResumeLead.inMilliseconds,
             'next_won_slot:${nextWon.globalSlot}',
             targetGlobalSlot: nextWon.globalSlot,
+            targetRustSlotTimeMs: rustSlotTimeMs,
             targetSlotTimeMs: localSlotTimeMs,
           );
         } else {
@@ -375,12 +376,14 @@ class AndroidForegroundTaskController {
     int rustWakeTimeMs,
     String reason, {
     int? targetGlobalSlot,
+    int? targetRustSlotTimeMs,
     int? targetSlotTimeMs,
   }) async {
     await scheduleResumeAlarm(
       rustWakeTimeMs: rustWakeTimeMs,
       reason: reason,
       targetGlobalSlot: targetGlobalSlot,
+      targetRustSlotTimeMs: targetRustSlotTimeMs,
       targetSlotTimeMs: targetSlotTimeMs,
       stopMonitoringAfterSchedule: true,
     );
@@ -390,6 +393,7 @@ class AndroidForegroundTaskController {
     required int rustWakeTimeMs,
     required String reason,
     int? targetGlobalSlot,
+    int? targetRustSlotTimeMs,
     int? targetSlotTimeMs,
     bool stopMonitoringAfterSchedule = false,
   }) async {
@@ -419,6 +423,10 @@ class AndroidForegroundTaskController {
       clockDriftMs: clockDriftMs,
     );
     final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final sampleSystemTimeMs =
+        RustBackendService.instance.lastNodeClockSampleSystemTimeMs;
+    final clockDriftSampleAgeMs =
+        sampleSystemTimeMs == null ? null : nowMs - sampleSystemTimeMs;
     final delayMs = localWakeTimeMs - nowMs;
     final success = await PlatformAlarmService.instance.scheduleAlarm(
       alarmId: foregroundResumeAlarmId,
@@ -431,8 +439,16 @@ class AndroidForegroundTaskController {
         'localWakeTimeMs': localWakeTimeMs,
         'clockDriftMs': clockDriftMs,
         'purpose': 'foreground_resume',
+        'systemTimeMsAtSchedule': nowMs,
+        if (RustBackendService.instance.lastNodeTimeMs != null)
+          'nodeTimeMsAtSchedule': RustBackendService.instance.lastNodeTimeMs,
+        if (clockDriftSampleAgeMs != null)
+          'clockDriftSampleAgeMs': clockDriftSampleAgeMs,
         if (targetGlobalSlot != null) 'globalSlot': targetGlobalSlot,
+        if (targetRustSlotTimeMs != null)
+          'rustSlotTimeMs': targetRustSlotTimeMs,
         if (targetSlotTimeMs != null) 'slotTimeMs': targetSlotTimeMs,
+        if (targetSlotTimeMs != null) 'localSlotTimeMs': targetSlotTimeMs,
       },
     );
 

--- a/lib/core/services/block_production_alarm_audit_service.dart
+++ b/lib/core/services/block_production_alarm_audit_service.dart
@@ -38,6 +38,7 @@ class BlockProductionAlarmAuditService {
     Future<bool> Function()? refreshPermissions,
     Future<bool> Function()? hasExactAlarmPermission,
     Future<bool> Function(String alarmId)? hasScheduledAlarm,
+    Future<AlarmDebugState> Function(String alarmId)? getAlarmDebugState,
     AlarmAuditScheduleAlarm? scheduleAlarm,
     AlarmAuditScheduleForegroundResume? scheduleForegroundResume,
     Future<AlarmAuditEpochSnapshot?> Function()? loadEpochSnapshot,
@@ -47,6 +48,8 @@ class BlockProductionAlarmAuditService {
     Future<bool> Function()? wasForceStoppedOnStartup,
     int Function()? nowMs,
     int Function(int rustTimeMs, int clockDriftMs)? rustToLocalTimeMs,
+    int? Function()? lastNodeTimeMs,
+    int? Function()? lastNodeClockSampleSystemTimeMs,
     bool Function()? isAndroid,
     String Function()? appState,
     String Function()? platformVersion,
@@ -61,8 +64,13 @@ class BlockProductionAlarmAuditService {
             PlatformAlarmService.instance.refreshPermissions,
         _hasExactAlarmPermission = hasExactAlarmPermission ??
             PlatformAlarmService.instance.hasExactAlarmPermission,
-        _hasScheduledAlarm = hasScheduledAlarm ??
-            PlatformAlarmService.instance.hasScheduledAlarm,
+        _getAlarmDebugState = getAlarmDebugState ??
+            (hasScheduledAlarm == null
+                ? PlatformAlarmService.instance.getAlarmDebugState
+                : ((alarmId) async => AlarmDebugState(
+                      alarmId: alarmId,
+                      pendingIntentExists: await hasScheduledAlarm(alarmId),
+                    ))),
         _scheduleAlarm =
             scheduleAlarm ?? PlatformAlarmService.instance.scheduleAlarm,
         _scheduleForegroundResume =
@@ -82,6 +90,10 @@ class BlockProductionAlarmAuditService {
                   rustTimeMs,
                   clockDriftMs: clockDriftMs,
                 )),
+        _lastNodeTimeMs = lastNodeTimeMs ??
+            (() => RustBackendService.instance.lastNodeTimeMs),
+        _lastNodeClockSampleSystemTimeMs = lastNodeClockSampleSystemTimeMs ??
+            (() => RustBackendService.instance.lastNodeClockSampleSystemTimeMs),
         _isAndroid = isAndroid ?? (() => Platform.isAndroid),
         _appState = appState ?? _defaultAppState,
         _platformVersion =
@@ -107,6 +119,7 @@ class BlockProductionAlarmAuditService {
     Future<bool> Function()? refreshPermissions,
     Future<bool> Function()? hasExactAlarmPermission,
     Future<bool> Function(String alarmId)? hasScheduledAlarm,
+    Future<AlarmDebugState> Function(String alarmId)? getAlarmDebugState,
     AlarmAuditScheduleAlarm? scheduleAlarm,
     AlarmAuditScheduleForegroundResume? scheduleForegroundResume,
     Future<AlarmAuditEpochSnapshot?> Function()? loadEpochSnapshot,
@@ -116,6 +129,8 @@ class BlockProductionAlarmAuditService {
     Future<bool> Function()? wasForceStoppedOnStartup,
     int Function()? nowMs,
     int Function(int rustTimeMs, int clockDriftMs)? rustToLocalTimeMs,
+    int? Function()? lastNodeTimeMs,
+    int? Function()? lastNodeClockSampleSystemTimeMs,
     bool Function()? isAndroid,
     String Function()? appState,
     String Function()? platformVersion,
@@ -129,6 +144,7 @@ class BlockProductionAlarmAuditService {
           refreshPermissions: refreshPermissions,
           hasExactAlarmPermission: hasExactAlarmPermission,
           hasScheduledAlarm: hasScheduledAlarm,
+          getAlarmDebugState: getAlarmDebugState,
           scheduleAlarm: scheduleAlarm,
           scheduleForegroundResume: scheduleForegroundResume,
           loadEpochSnapshot: loadEpochSnapshot,
@@ -138,6 +154,8 @@ class BlockProductionAlarmAuditService {
           wasForceStoppedOnStartup: wasForceStoppedOnStartup,
           nowMs: nowMs,
           rustToLocalTimeMs: rustToLocalTimeMs,
+          lastNodeTimeMs: lastNodeTimeMs,
+          lastNodeClockSampleSystemTimeMs: lastNodeClockSampleSystemTimeMs,
           isAndroid: isAndroid,
           appState: appState,
           platformVersion: platformVersion,
@@ -154,7 +172,7 @@ class BlockProductionAlarmAuditService {
   final Future<bool> Function() _initializeAlarmService;
   final Future<bool> Function() _refreshPermissions;
   final Future<bool> Function() _hasExactAlarmPermission;
-  final Future<bool> Function(String alarmId) _hasScheduledAlarm;
+  final Future<AlarmDebugState> Function(String alarmId) _getAlarmDebugState;
   final AlarmAuditScheduleAlarm _scheduleAlarm;
   final AlarmAuditScheduleForegroundResume _scheduleForegroundResume;
   final Future<AlarmAuditEpochSnapshot?> Function() _loadEpochSnapshot;
@@ -164,6 +182,8 @@ class BlockProductionAlarmAuditService {
   final Future<bool> Function() _wasForceStoppedOnStartup;
   final int Function() _nowMs;
   final int Function(int rustTimeMs, int clockDriftMs) _rustToLocalTimeMs;
+  final int? Function() _lastNodeTimeMs;
+  final int? Function() _lastNodeClockSampleSystemTimeMs;
   final bool Function() _isAndroid;
   final String Function() _appState;
   final String Function() _platformVersion;
@@ -389,16 +409,24 @@ class BlockProductionAlarmAuditService {
         );
       }
 
+      final auditNowMs = _nowMs();
       final built = _buildExpectedAlarms(
-        reason: reason,
         epoch: epoch,
         clockDriftMs: clockDriftMs,
-        nowMs: _nowMs(),
+        nowMs: auditNowMs,
       );
-      final counts = _AlarmAuditCounts()..tooLateCount = built.tooLateCount;
+      final counts = _AlarmAuditCounts();
+
+      for (final alarm in built.pastSlotWakeAlarms) {
+        await _auditPastSlotWakeAlarm(
+          reason: reason,
+          alarm: alarm,
+          counts: counts,
+        );
+      }
 
       for (final alarm in built.futureSlotWakeAlarms) {
-        await _auditSlotWakeAlarm(
+        await _auditFutureSlotWakeAlarm(
           reason: reason,
           alarm: alarm,
           counts: counts,
@@ -426,7 +454,6 @@ class BlockProductionAlarmAuditService {
         missingCount: counts.missingCount,
         rescheduledCount: counts.rescheduledCount,
         failedCount: counts.failedCount,
-        tooLateCount: counts.tooLateCount,
         fgResumeStatus: fgResumeStatus,
       );
     } catch (e, st) {
@@ -441,13 +468,12 @@ class BlockProductionAlarmAuditService {
   }
 
   _ExpectedAlarmBuildResult _buildExpectedAlarms({
-    required String reason,
     required AlarmAuditEpochSnapshot epoch,
     required int clockDriftMs,
     required int nowMs,
   }) {
     final futureSlotWakeAlarms = <AlarmAuditExpectedAlarm>[];
-    var tooLateCount = 0;
+    final pastSlotWakeAlarms = <AlarmAuditExpectedAlarm>[];
     final wakeLeadMs = _slotWakeLead.inMilliseconds;
 
     final wonSlots = List<AlarmAuditWonSlot>.of(epoch.wonSlots)
@@ -467,37 +493,33 @@ class BlockProductionAlarmAuditService {
         rustSlotTimeMs: wonSlot.expectedTimeMs,
         slotTimeMs: slotTimeMs,
         alarmTimeMs: alarmTimeMs,
+        clockDriftMs: clockDriftMs,
+        nodeTimeMsAtAudit: _lastNodeTimeMs(),
+        systemTimeMsAtAudit: nowMs,
+        clockDriftSampleAgeMs: _clockDriftSampleAgeMs(nowMs),
       );
 
-      if (alarmTimeMs <= nowMs) {
-        tooLateCount++;
-        _reportTooLate(
-          reason: reason,
-          alarm: alarm,
-          nowMs: nowMs,
-        );
-        continue;
-      }
-
-      futureSlotWakeAlarms.add(alarm);
+      final target =
+          alarmTimeMs <= nowMs ? pastSlotWakeAlarms : futureSlotWakeAlarms;
+      target.add(alarm);
     }
 
     return _ExpectedAlarmBuildResult(
       futureSlotWakeAlarms: futureSlotWakeAlarms,
-      tooLateCount: tooLateCount,
+      pastSlotWakeAlarms: pastSlotWakeAlarms,
     );
   }
 
-  Future<void> _auditSlotWakeAlarm({
+  Future<void> _auditFutureSlotWakeAlarm({
     required String reason,
     required AlarmAuditExpectedAlarm alarm,
     required _AlarmAuditCounts counts,
     required int clockDriftMs,
   }) async {
-    final present = await _hasScheduledAlarm(alarm.alarmId);
-    if (present) {
+    final state = await _getAlarmDebugState(alarm.alarmId);
+    if (state.pendingIntentExists) {
       counts.presentCount++;
-      _reportPresent(reason: reason, alarm: alarm);
+      _reportPresent(reason: reason, alarm: alarm, state: state);
       return;
     }
 
@@ -505,8 +527,13 @@ class BlockProductionAlarmAuditService {
     final nowMs = _nowMs();
     final delayMs = alarm.alarmTimeMs - nowMs;
     if (delayMs <= 0) {
-      counts.tooLateCount++;
-      _reportTooLate(reason: reason, alarm: alarm, nowMs: nowMs);
+      await _auditPastSlotWakeAlarm(
+        reason: reason,
+        alarm: alarm,
+        counts: counts,
+        state: state,
+        nowMs: nowMs,
+      );
       return;
     }
 
@@ -519,6 +546,8 @@ class BlockProductionAlarmAuditService {
         'slotTime': DateTime.fromMillisecondsSinceEpoch(alarm.slotTimeMs)
             .toIso8601String(),
         'slotTimeMs': alarm.slotTimeMs,
+        'localSlotTimeMs': alarm.slotTimeMs,
+        'rustSlotTimeMs': alarm.rustSlotTimeMs,
         'alarmTimeMs': alarm.alarmTimeMs,
         'purpose': alarm.purpose,
         'reason': 'alarm_audit:$reason',
@@ -526,6 +555,7 @@ class BlockProductionAlarmAuditService {
         'rustWakeTimeMs': alarm.rustSlotTimeMs - _slotWakeLead.inMilliseconds,
         'localWakeTimeMs': alarm.alarmTimeMs,
         'clockDriftMs': clockDriftMs,
+        ..._scheduleClockTelemetryData(nowMs),
       },
     );
 
@@ -535,6 +565,7 @@ class BlockProductionAlarmAuditService {
         reason: reason,
         alarm: alarm,
         scheduleSuccess: true,
+        state: state,
       );
       return;
     }
@@ -544,6 +575,66 @@ class BlockProductionAlarmAuditService {
       reason: reason,
       alarm: alarm,
       failureReason: 'platform_schedule_failed',
+      state: state,
+    );
+  }
+
+  Future<void> _auditPastSlotWakeAlarm({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+    required _AlarmAuditCounts counts,
+    AlarmDebugState? state,
+    int? nowMs,
+  }) async {
+    final debugState = state ?? await _getAlarmDebugState(alarm.alarmId);
+    counts.pastSlotWakeCount++;
+
+    final receiverEnteredAtMs = debugState.receiverEnteredAtMs;
+    if (receiverEnteredAtMs != null) {
+      final slotDeltaMs = receiverEnteredAtMs - alarm.slotTimeMs;
+      final deliveryLatencyMs = receiverEnteredAtMs - alarm.alarmTimeMs;
+      if (receiverEnteredAtMs > alarm.slotTimeMs) {
+        counts.pastReceiverLateCount++;
+        _reportPastReceiverLate(
+          reason: reason,
+          alarm: alarm,
+          state: debugState,
+          nowMs: nowMs ?? _nowMs(),
+          deliveryLatencyMs: deliveryLatencyMs,
+          slotDeltaMs: slotDeltaMs,
+        );
+        return;
+      }
+
+      counts.pastReceiverOnTimeCount++;
+      _reportPastReceiverOnTime(
+        reason: reason,
+        alarm: alarm,
+        state: debugState,
+        nowMs: nowMs ?? _nowMs(),
+        deliveryLatencyMs: deliveryLatencyMs,
+        slotDeltaMs: slotDeltaMs,
+      );
+      return;
+    }
+
+    if (debugState.pendingIntentExists) {
+      counts.pastPendingNoReceiverCount++;
+      _reportPastPendingNoReceiver(
+        reason: reason,
+        alarm: alarm,
+        state: debugState,
+        nowMs: nowMs ?? _nowMs(),
+      );
+      return;
+    }
+
+    counts.pastMissingNoReceiverCount++;
+    _reportPastMissingNoReceiver(
+      reason: reason,
+      alarm: alarm,
+      state: debugState,
+      nowMs: nowMs ?? _nowMs(),
     );
   }
 
@@ -584,11 +675,15 @@ class BlockProductionAlarmAuditService {
       rustSlotTimeMs: nextWonSlot.rustSlotTimeMs,
       slotTimeMs: nextWonSlot.slotTimeMs,
       alarmTimeMs: nextWonSlot.slotTimeMs - fgLeadMs,
+      clockDriftMs: clockDriftMs,
+      nodeTimeMsAtAudit: _lastNodeTimeMs(),
+      systemTimeMsAtAudit: nowMs,
+      clockDriftSampleAgeMs: _clockDriftSampleAgeMs(nowMs),
     );
 
-    final present = await _hasScheduledAlarm(alarm.alarmId);
-    if (present) {
-      _reportPresent(reason: reason, alarm: alarm);
+    final state = await _getAlarmDebugState(alarm.alarmId);
+    if (state.pendingIntentExists) {
+      _reportPresent(reason: reason, alarm: alarm, state: state);
       _report(
         'foreground_resume_present',
         {
@@ -596,6 +691,7 @@ class BlockProductionAlarmAuditService {
           'global_slot': alarm.globalSlot,
           'alarm_time_ms': alarm.alarmTimeMs,
           'slot_time_ms': alarm.slotTimeMs,
+          ...state.telemetryDetails,
         },
       );
       return 'present';
@@ -617,6 +713,7 @@ class BlockProductionAlarmAuditService {
         reason: reason,
         alarm: scheduledAlarm,
         scheduleSuccess: true,
+        state: state,
       );
       _report(
         'foreground_resume_recreated',
@@ -625,6 +722,7 @@ class BlockProductionAlarmAuditService {
           'global_slot': scheduledAlarm.globalSlot,
           'alarm_time_ms': scheduledAlarm.alarmTimeMs,
           'slot_time_ms': scheduledAlarm.slotTimeMs,
+          ...state.telemetryDetails,
         },
       );
       return 'recreated';
@@ -634,6 +732,7 @@ class BlockProductionAlarmAuditService {
       reason: reason,
       alarm: scheduledAlarm,
       failureReason: result.failureReason ?? 'platform_schedule_failed',
+      state: state,
     );
     return 'reschedule_failed';
   }
@@ -660,6 +759,23 @@ class BlockProductionAlarmAuditService {
       ..sort((a, b) => a.slotTimeMs.compareTo(b.slotTimeMs));
 
     return futureSlots.isEmpty ? null : futureSlots.first;
+  }
+
+  Map<String, dynamic> _scheduleClockTelemetryData(int systemTimeMs) {
+    final nodeTimeMs = _lastNodeTimeMs();
+    final clockDriftSampleAgeMs = _clockDriftSampleAgeMs(systemTimeMs);
+    return {
+      'systemTimeMsAtSchedule': systemTimeMs,
+      if (nodeTimeMs != null) 'nodeTimeMsAtSchedule': nodeTimeMs,
+      if (clockDriftSampleAgeMs != null)
+        'clockDriftSampleAgeMs': clockDriftSampleAgeMs,
+    };
+  }
+
+  int? _clockDriftSampleAgeMs(int systemTimeMs) {
+    final sampleSystemTimeMs = _lastNodeClockSampleSystemTimeMs();
+    if (sampleSystemTimeMs == null) return null;
+    return systemTimeMs - sampleSystemTimeMs;
   }
 
   void _reportStarted({
@@ -713,7 +829,6 @@ class BlockProductionAlarmAuditService {
       missingCount: 0,
       rescheduledCount: 0,
       failedCount: 0,
-      tooLateCount: 0,
       fgResumeStatus: fgResumeStatus,
     );
   }
@@ -731,7 +846,11 @@ class BlockProductionAlarmAuditService {
       'missing_count': counts.missingCount,
       'rescheduled_count': counts.rescheduledCount,
       'failed_count': counts.failedCount,
-      'too_late_count': counts.tooLateCount,
+      'past_slot_wake_count': counts.pastSlotWakeCount,
+      'past_receiver_on_time_count': counts.pastReceiverOnTimeCount,
+      'past_receiver_late_count': counts.pastReceiverLateCount,
+      'past_pending_no_receiver_count': counts.pastPendingNoReceiverCount,
+      'past_missing_no_receiver_count': counts.pastMissingNoReceiverCount,
       'fg_resume_status': fgResumeStatus,
     });
     _report(
@@ -743,7 +862,11 @@ class BlockProductionAlarmAuditService {
         'missing_count': counts.missingCount,
         'rescheduled_count': counts.rescheduledCount,
         'failed_count': counts.failedCount,
-        'too_late_count': counts.tooLateCount,
+        'past_slot_wake_count': counts.pastSlotWakeCount,
+        'past_receiver_on_time_count': counts.pastReceiverOnTimeCount,
+        'past_receiver_late_count': counts.pastReceiverLateCount,
+        'past_pending_no_receiver_count': counts.pastPendingNoReceiverCount,
+        'past_missing_no_receiver_count': counts.pastMissingNoReceiverCount,
         'fg_resume_status': fgResumeStatus,
       },
     );
@@ -752,10 +875,12 @@ class BlockProductionAlarmAuditService {
   void _reportPresent({
     required String reason,
     required AlarmAuditExpectedAlarm alarm,
+    AlarmDebugState? state,
   }) {
     _report('alarm_audit_present', {
       'reason': reason,
       ...alarm.telemetryDetails,
+      if (state != null) ...state.telemetryDetails,
     });
   }
 
@@ -763,11 +888,13 @@ class BlockProductionAlarmAuditService {
     required String reason,
     required AlarmAuditExpectedAlarm alarm,
     required bool scheduleSuccess,
+    AlarmDebugState? state,
   }) {
     _report('alarm_audit_missing_rescheduled', {
       'reason': reason,
       ...alarm.telemetryDetails,
       'schedule_success': scheduleSuccess,
+      if (state != null) ...state.telemetryDetails,
     });
   }
 
@@ -775,24 +902,79 @@ class BlockProductionAlarmAuditService {
     required String reason,
     required AlarmAuditExpectedAlarm alarm,
     required String failureReason,
+    AlarmDebugState? state,
   }) {
     _report('alarm_audit_missing_reschedule_failed', {
       'reason': reason,
       ...alarm.telemetryDetails,
       'failure_reason': failureReason,
+      if (state != null) ...state.telemetryDetails,
     });
   }
 
-  void _reportTooLate({
+  void _reportPastReceiverOnTime({
     required String reason,
     required AlarmAuditExpectedAlarm alarm,
+    required AlarmDebugState state,
     required int nowMs,
+    required int deliveryLatencyMs,
+    required int slotDeltaMs,
   }) {
-    _report('alarm_audit_missing_too_late', {
+    _report('alarm_audit_past_receiver_on_time', {
       'reason': reason,
       ...alarm.telemetryDetails,
       'now_ms': nowMs,
-      'lateness_ms': nowMs - alarm.alarmTimeMs,
+      'delivery_latency_ms': deliveryLatencyMs,
+      'slot_delta_ms': slotDeltaMs,
+      ...state.telemetryDetails,
+    });
+  }
+
+  void _reportPastReceiverLate({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+    required AlarmDebugState state,
+    required int nowMs,
+    required int deliveryLatencyMs,
+    required int slotDeltaMs,
+  }) {
+    _report('alarm_audit_past_receiver_late', {
+      'reason': reason,
+      ...alarm.telemetryDetails,
+      'now_ms': nowMs,
+      'delivery_latency_ms': deliveryLatencyMs,
+      'slot_delta_ms': slotDeltaMs,
+      ...state.telemetryDetails,
+    });
+  }
+
+  void _reportPastPendingNoReceiver({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+    required AlarmDebugState state,
+    required int nowMs,
+  }) {
+    _report('alarm_audit_past_pending_no_receiver', {
+      'reason': reason,
+      ...alarm.telemetryDetails,
+      'now_ms': nowMs,
+      'past_alarm_age_ms': nowMs - alarm.alarmTimeMs,
+      ...state.telemetryDetails,
+    });
+  }
+
+  void _reportPastMissingNoReceiver({
+    required String reason,
+    required AlarmAuditExpectedAlarm alarm,
+    required AlarmDebugState state,
+    required int nowMs,
+  }) {
+    _report('alarm_audit_past_missing_no_receiver', {
+      'reason': reason,
+      ...alarm.telemetryDetails,
+      'now_ms': nowMs,
+      'past_alarm_age_ms': nowMs - alarm.alarmTimeMs,
+      ...state.telemetryDetails,
     });
   }
 
@@ -841,6 +1023,8 @@ class BlockProductionAlarmAuditService {
       rustWakeTimeMs: rustWakeTimeMs,
       reason: schedulerReason,
       targetGlobalSlot: globalSlot,
+      targetRustSlotTimeMs: rustWakeTimeMs +
+          AndroidForegroundTaskController.foregroundResumeLead.inMilliseconds,
       targetSlotTimeMs: slotTimeMs,
       stopMonitoringAfterSchedule: false,
     );
@@ -888,6 +1072,10 @@ class AlarmAuditExpectedAlarm {
     required this.rustSlotTimeMs,
     required this.slotTimeMs,
     required this.alarmTimeMs,
+    required this.clockDriftMs,
+    this.nodeTimeMsAtAudit,
+    this.systemTimeMsAtAudit,
+    this.clockDriftSampleAgeMs,
   });
 
   final String alarmId;
@@ -897,13 +1085,26 @@ class AlarmAuditExpectedAlarm {
   final int rustSlotTimeMs;
   final int slotTimeMs;
   final int alarmTimeMs;
+  final int clockDriftMs;
+  final int? nodeTimeMsAtAudit;
+  final int? systemTimeMsAtAudit;
+  final int? clockDriftSampleAgeMs;
 
   Map<String, dynamic> get telemetryDetails => {
         'alarm_id': alarmId,
         'purpose': purpose,
         'global_slot': globalSlot,
+        'epoch': epoch,
         'alarm_time_ms': alarmTimeMs,
         'slot_time_ms': slotTimeMs,
+        'rust_slot_time_ms': rustSlotTimeMs,
+        'local_slot_time_ms': slotTimeMs,
+        'clock_drift_ms': clockDriftMs,
+        if (nodeTimeMsAtAudit != null) 'audit_node_time_ms': nodeTimeMsAtAudit,
+        if (systemTimeMsAtAudit != null)
+          'audit_system_time_ms': systemTimeMsAtAudit,
+        if (clockDriftSampleAgeMs != null)
+          'audit_clock_drift_sample_age_ms': clockDriftSampleAgeMs,
       };
 
   AlarmAuditExpectedAlarm copyWith({
@@ -917,6 +1118,10 @@ class AlarmAuditExpectedAlarm {
       rustSlotTimeMs: rustSlotTimeMs,
       slotTimeMs: slotTimeMs,
       alarmTimeMs: alarmTimeMs ?? this.alarmTimeMs,
+      clockDriftMs: clockDriftMs,
+      nodeTimeMsAtAudit: nodeTimeMsAtAudit,
+      systemTimeMsAtAudit: systemTimeMsAtAudit,
+      clockDriftSampleAgeMs: clockDriftSampleAgeMs,
     );
   }
 }
@@ -929,7 +1134,6 @@ class AlarmAuditResult {
     required this.missingCount,
     required this.rescheduledCount,
     required this.failedCount,
-    required this.tooLateCount,
     required this.fgResumeStatus,
     this.skippedReason,
   });
@@ -941,18 +1145,17 @@ class AlarmAuditResult {
   final int missingCount;
   final int rescheduledCount;
   final int failedCount;
-  final int tooLateCount;
   final String fgResumeStatus;
 }
 
 class _ExpectedAlarmBuildResult {
   const _ExpectedAlarmBuildResult({
     required this.futureSlotWakeAlarms,
-    required this.tooLateCount,
+    required this.pastSlotWakeAlarms,
   });
 
   final List<AlarmAuditExpectedAlarm> futureSlotWakeAlarms;
-  final int tooLateCount;
+  final List<AlarmAuditExpectedAlarm> pastSlotWakeAlarms;
 }
 
 class _AlarmAuditCounts {
@@ -962,7 +1165,11 @@ class _AlarmAuditCounts {
   int missingCount = 0;
   int rescheduledCount = 0;
   int failedCount = 0;
-  int tooLateCount = 0;
+  int pastSlotWakeCount = 0;
+  int pastReceiverOnTimeCount = 0;
+  int pastReceiverLateCount = 0;
+  int pastPendingNoReceiverCount = 0;
+  int pastMissingNoReceiverCount = 0;
 }
 
 class _FutureWonSlot {

--- a/lib/core/services/epoch_slot_scheduler_service.dart
+++ b/lib/core/services/epoch_slot_scheduler_service.dart
@@ -367,6 +367,8 @@ class EpochSlotSchedulerService {
             slotTime: slotTime,
             alarmTime: alarmTime,
             epoch: epochData.epoch,
+            rustSlotTimeMs: rustSlotTimeMs,
+            clockDriftMs: clockDriftMs,
           );
 
           final success =
@@ -420,6 +422,11 @@ class EpochSlotSchedulerService {
 
       // Use platform alarm service for scheduling
       final alarmId = 'slot_${slot.slotNumber}';
+      final nowMs = DateTime.now().millisecondsSinceEpoch;
+      final sampleSystemTimeMs =
+          RustBackendService.instance.lastNodeClockSampleSystemTimeMs;
+      final clockDriftSampleAgeMs =
+          sampleSystemTimeMs == null ? null : nowMs - sampleSystemTimeMs;
       final success = await PlatformAlarmService.instance.scheduleAlarm(
         alarmId: alarmId,
         delayMs: delayMs,
@@ -428,8 +435,17 @@ class EpochSlotSchedulerService {
           'epoch': slot.epoch,
           'slotTime': slot.slotTime.toIso8601String(),
           'slotTimeMs': slot.slotTime.millisecondsSinceEpoch,
+          'localSlotTimeMs': slot.slotTime.millisecondsSinceEpoch,
           'alarmTimeMs': slot.alarmTime.millisecondsSinceEpoch,
           'purpose': 'slot_wake',
+          'systemTimeMsAtSchedule': nowMs,
+          if (slot.rustSlotTimeMs != null)
+            'rustSlotTimeMs': slot.rustSlotTimeMs,
+          if (slot.clockDriftMs != null) 'clockDriftMs': slot.clockDriftMs,
+          if (RustBackendService.instance.lastNodeTimeMs != null)
+            'nodeTimeMsAtSchedule': RustBackendService.instance.lastNodeTimeMs,
+          if (clockDriftSampleAgeMs != null)
+            'clockDriftSampleAgeMs': clockDriftSampleAgeMs,
         },
       );
 
@@ -712,12 +728,16 @@ class ScheduledSlot {
   final DateTime slotTime;
   final DateTime alarmTime;
   final int epoch;
+  final int? rustSlotTimeMs;
+  final int? clockDriftMs;
 
   ScheduledSlot({
     required this.slotNumber,
     required this.slotTime,
     required this.alarmTime,
     required this.epoch,
+    this.rustSlotTimeMs,
+    this.clockDriftMs,
   });
 
   Map<String, dynamic> toJson() => {
@@ -725,6 +745,8 @@ class ScheduledSlot {
         'slotTime': slotTime.toIso8601String(),
         'alarmTime': alarmTime.toIso8601String(),
         'epoch': epoch,
+        if (rustSlotTimeMs != null) 'rustSlotTimeMs': rustSlotTimeMs,
+        if (clockDriftMs != null) 'clockDriftMs': clockDriftMs,
       };
 
   factory ScheduledSlot.fromJson(Map<String, dynamic> json) => ScheduledSlot(
@@ -732,6 +754,8 @@ class ScheduledSlot {
         slotTime: DateTime.parse(json['slotTime'] as String),
         alarmTime: DateTime.parse(json['alarmTime'] as String),
         epoch: json['epoch'] as int,
+        rustSlotTimeMs: json['rustSlotTimeMs'] as int?,
+        clockDriftMs: json['clockDriftMs'] as int?,
       );
 }
 

--- a/lib/core/services/observability_reporting_service.dart
+++ b/lib/core/services/observability_reporting_service.dart
@@ -235,12 +235,17 @@ class ObservabilityReportingService {
     int? globalSlot,
     int? epoch,
     int? slotTimeMs,
+    int? rustSlotTimeMs,
+    int? localSlotTimeMs,
     int? leadMs,
     String? schedulerReason,
     bool? nodeRunning,
     int? rustWakeTimeMs,
     int? localWakeTimeMs,
     int? clockDriftMs,
+    int? nodeTimeMsAtSchedule,
+    int? systemTimeMsAtSchedule,
+    int? clockDriftSampleAgeMs,
     String? failureReason,
   }) {
     return recordEvent(
@@ -251,6 +256,8 @@ class ObservabilityReportingService {
         if (globalSlot != null) 'global_slot': globalSlot,
         if (epoch != null) 'epoch': epoch,
         if (slotTimeMs != null) 'slot_time_ms': slotTimeMs,
+        if (rustSlotTimeMs != null) 'rust_slot_time_ms': rustSlotTimeMs,
+        if (localSlotTimeMs != null) 'local_slot_time_ms': localSlotTimeMs,
         'scheduled_at_ms': scheduledAtMs,
         'alarm_time_ms': alarmTimeMs,
         'requested_delay_ms': requestedDelayMs,
@@ -263,6 +270,12 @@ class ObservabilityReportingService {
         if (rustWakeTimeMs != null) 'rust_wake_time_ms': rustWakeTimeMs,
         if (localWakeTimeMs != null) 'local_wake_time_ms': localWakeTimeMs,
         if (clockDriftMs != null) 'clock_drift_ms': clockDriftMs,
+        if (nodeTimeMsAtSchedule != null)
+          'node_time_ms_at_schedule': nodeTimeMsAtSchedule,
+        if (systemTimeMsAtSchedule != null)
+          'system_time_ms_at_schedule': systemTimeMsAtSchedule,
+        if (clockDriftSampleAgeMs != null)
+          'clock_drift_sample_age_ms': clockDriftSampleAgeMs,
         if (failureReason != null) 'failure_reason': failureReason,
       },
     );
@@ -277,6 +290,11 @@ class ObservabilityReportingService {
     int? globalSlot,
     int? alarmTimeMs,
     int? latencyMs,
+    int? nativeTriggerAtMs,
+    int? triggerElapsedRealtimeMs,
+    int? receiverElapsedRealtimeMs,
+    int? nativeDeliveryLatencyMs,
+    int? elapsedDeliveryLatencyMs,
     bool? nodeRunning,
     int? batteryLevel,
     String? networkState,
@@ -292,6 +310,16 @@ class ObservabilityReportingService {
         if (alarmTimeMs != null) 'alarm_time_ms': alarmTimeMs,
         'fired_at_ms': firedAtMs,
         if (latencyMs != null) 'latency_ms': latencyMs,
+        if (nativeTriggerAtMs != null)
+          'native_trigger_at_ms': nativeTriggerAtMs,
+        if (triggerElapsedRealtimeMs != null)
+          'trigger_elapsed_realtime_ms': triggerElapsedRealtimeMs,
+        if (receiverElapsedRealtimeMs != null)
+          'receiver_elapsed_realtime_ms': receiverElapsedRealtimeMs,
+        if (nativeDeliveryLatencyMs != null)
+          'native_delivery_latency_ms': nativeDeliveryLatencyMs,
+        if (elapsedDeliveryLatencyMs != null)
+          'elapsed_delivery_latency_ms': elapsedDeliveryLatencyMs,
         'platform': platform,
         if (nodeRunning != null) 'node_running': nodeRunning,
         if (batteryLevel != null) 'battery_level': batteryLevel,

--- a/lib/core/services/platform_alarm_service.dart
+++ b/lib/core/services/platform_alarm_service.dart
@@ -14,6 +14,234 @@ typedef BootRescheduleCallback = Future<void> Function();
 typedef NativeEventCallback = void Function(
     String eventType, Map<String, dynamic> eventData);
 
+class AlarmDebugState {
+  const AlarmDebugState({
+    required this.alarmId,
+    required this.pendingIntentExists,
+    this.canScheduleExactAlarms,
+    this.scheduledAtMs,
+    this.triggerAtMs,
+    this.slotNumber,
+    this.globalSlot,
+    this.epoch,
+    this.slotTimeMs,
+    this.rustSlotTimeMs,
+    this.localSlotTimeMs,
+    this.alarmTimeMs,
+    this.nativeTriggerAtMs,
+    this.scheduledElapsedRealtimeMs,
+    this.triggerElapsedRealtimeMs,
+    this.requestedDelayMs,
+    this.effectiveDelayMs,
+    this.rustWakeTimeMs,
+    this.localWakeTimeMs,
+    this.clockDriftMs,
+    this.nodeTimeMsAtSchedule,
+    this.systemTimeMsAtSchedule,
+    this.clockDriftSampleAgeMs,
+    this.purpose,
+    this.schedulerReason,
+    this.scheduleStatus,
+    this.scheduleFailureReason,
+    this.receiverEnteredAtMs,
+    this.receiverSystemTimeMs,
+    this.receiverElapsedRealtimeMs,
+    this.receiverLatencyMs,
+    this.nativeDeliveryLatencyMs,
+    this.elapsedDeliveryLatencyMs,
+    this.flutterEventSentAtMs,
+    this.cancelledAtMs,
+    this.cancelReason,
+    this.nodeRunning,
+    this.stateUnavailableReason,
+  });
+
+  factory AlarmDebugState.fromMap(Map<Object?, Object?> map) {
+    return AlarmDebugState(
+      alarmId: _alarmDebugString(map['alarmId']) ??
+          _alarmDebugString(map['alarm_id']) ??
+          'unknown',
+      pendingIntentExists: _alarmDebugBool(map['pendingIntentExists']) ??
+          _alarmDebugBool(map['pending_intent_exists']) ??
+          false,
+      canScheduleExactAlarms: _alarmDebugBool(map['canScheduleExactAlarms']) ??
+          _alarmDebugBool(map['can_schedule_exact_alarms']),
+      scheduledAtMs: _alarmDebugInt(map['scheduledAtMs']) ??
+          _alarmDebugInt(map['scheduled_at_ms']),
+      triggerAtMs: _alarmDebugInt(map['triggerAtMs']) ??
+          _alarmDebugInt(map['trigger_at_ms']),
+      slotNumber: _alarmDebugInt(map['slotNumber']) ??
+          _alarmDebugInt(map['slot_number']),
+      globalSlot: _alarmDebugInt(map['globalSlot']) ??
+          _alarmDebugInt(map['global_slot']),
+      epoch: _alarmDebugInt(map['epoch']),
+      slotTimeMs: _alarmDebugInt(map['slotTimeMs']) ??
+          _alarmDebugInt(map['slot_time_ms']),
+      rustSlotTimeMs: _alarmDebugInt(map['rustSlotTimeMs']) ??
+          _alarmDebugInt(map['rust_slot_time_ms']),
+      localSlotTimeMs: _alarmDebugInt(map['localSlotTimeMs']) ??
+          _alarmDebugInt(map['local_slot_time_ms']),
+      alarmTimeMs: _alarmDebugInt(map['alarmTimeMs']) ??
+          _alarmDebugInt(map['alarm_time_ms']),
+      nativeTriggerAtMs: _alarmDebugInt(map['nativeTriggerAtMs']) ??
+          _alarmDebugInt(map['native_trigger_at_ms']),
+      scheduledElapsedRealtimeMs:
+          _alarmDebugInt(map['scheduledElapsedRealtimeMs']) ??
+              _alarmDebugInt(map['scheduled_elapsed_realtime_ms']),
+      triggerElapsedRealtimeMs:
+          _alarmDebugInt(map['triggerElapsedRealtimeMs']) ??
+              _alarmDebugInt(map['trigger_elapsed_realtime_ms']),
+      requestedDelayMs: _alarmDebugInt(map['requestedDelayMs']) ??
+          _alarmDebugInt(map['requested_delay_ms']),
+      effectiveDelayMs: _alarmDebugInt(map['effectiveDelayMs']) ??
+          _alarmDebugInt(map['effective_delay_ms']),
+      rustWakeTimeMs: _alarmDebugInt(map['rustWakeTimeMs']) ??
+          _alarmDebugInt(map['rust_wake_time_ms']),
+      localWakeTimeMs: _alarmDebugInt(map['localWakeTimeMs']) ??
+          _alarmDebugInt(map['local_wake_time_ms']),
+      clockDriftMs: _alarmDebugInt(map['clockDriftMs']) ??
+          _alarmDebugInt(map['clock_drift_ms']),
+      nodeTimeMsAtSchedule: _alarmDebugInt(map['nodeTimeMsAtSchedule']) ??
+          _alarmDebugInt(map['node_time_ms_at_schedule']),
+      systemTimeMsAtSchedule: _alarmDebugInt(map['systemTimeMsAtSchedule']) ??
+          _alarmDebugInt(map['system_time_ms_at_schedule']),
+      clockDriftSampleAgeMs: _alarmDebugInt(map['clockDriftSampleAgeMs']) ??
+          _alarmDebugInt(map['clock_drift_sample_age_ms']),
+      purpose: _alarmDebugString(map['purpose']),
+      schedulerReason: _alarmDebugString(map['schedulerReason']) ??
+          _alarmDebugString(map['scheduler_reason']),
+      scheduleStatus: _alarmDebugString(map['scheduleStatus']) ??
+          _alarmDebugString(map['schedule_status']),
+      scheduleFailureReason: _alarmDebugString(map['scheduleFailureReason']) ??
+          _alarmDebugString(map['schedule_failure_reason']),
+      receiverEnteredAtMs: _alarmDebugInt(map['receiverEnteredAtMs']) ??
+          _alarmDebugInt(map['receiver_entered_at_ms']),
+      receiverSystemTimeMs: _alarmDebugInt(map['receiverSystemTimeMs']) ??
+          _alarmDebugInt(map['receiver_system_time_ms']),
+      receiverElapsedRealtimeMs:
+          _alarmDebugInt(map['receiverElapsedRealtimeMs']) ??
+              _alarmDebugInt(map['receiver_elapsed_realtime_ms']),
+      receiverLatencyMs: _alarmDebugInt(map['receiverLatencyMs']) ??
+          _alarmDebugInt(map['receiver_latency_ms']),
+      nativeDeliveryLatencyMs: _alarmDebugInt(map['nativeDeliveryLatencyMs']) ??
+          _alarmDebugInt(map['native_delivery_latency_ms']),
+      elapsedDeliveryLatencyMs:
+          _alarmDebugInt(map['elapsedDeliveryLatencyMs']) ??
+              _alarmDebugInt(map['elapsed_delivery_latency_ms']),
+      flutterEventSentAtMs: _alarmDebugInt(map['flutterEventSentAtMs']) ??
+          _alarmDebugInt(map['flutter_event_sent_at_ms']),
+      cancelledAtMs: _alarmDebugInt(map['cancelledAtMs']) ??
+          _alarmDebugInt(map['cancelled_at_ms']),
+      cancelReason: _alarmDebugString(map['cancelReason']) ??
+          _alarmDebugString(map['cancel_reason']),
+      nodeRunning: _alarmDebugBool(map['nodeRunning']) ??
+          _alarmDebugBool(map['node_running']),
+      stateUnavailableReason:
+          _alarmDebugString(map['stateUnavailableReason']) ??
+              _alarmDebugString(map['state_unavailable_reason']),
+    );
+  }
+
+  final String alarmId;
+  final bool pendingIntentExists;
+  final bool? canScheduleExactAlarms;
+  final int? scheduledAtMs;
+  final int? triggerAtMs;
+  final int? slotNumber;
+  final int? globalSlot;
+  final int? epoch;
+  final int? slotTimeMs;
+  final int? rustSlotTimeMs;
+  final int? localSlotTimeMs;
+  final int? alarmTimeMs;
+  final int? nativeTriggerAtMs;
+  final int? scheduledElapsedRealtimeMs;
+  final int? triggerElapsedRealtimeMs;
+  final int? requestedDelayMs;
+  final int? effectiveDelayMs;
+  final int? rustWakeTimeMs;
+  final int? localWakeTimeMs;
+  final int? clockDriftMs;
+  final int? nodeTimeMsAtSchedule;
+  final int? systemTimeMsAtSchedule;
+  final int? clockDriftSampleAgeMs;
+  final String? purpose;
+  final String? schedulerReason;
+  final String? scheduleStatus;
+  final String? scheduleFailureReason;
+  final int? receiverEnteredAtMs;
+  final int? receiverSystemTimeMs;
+  final int? receiverElapsedRealtimeMs;
+  final int? receiverLatencyMs;
+  final int? nativeDeliveryLatencyMs;
+  final int? elapsedDeliveryLatencyMs;
+  final int? flutterEventSentAtMs;
+  final int? cancelledAtMs;
+  final String? cancelReason;
+  final bool? nodeRunning;
+  final String? stateUnavailableReason;
+
+  Map<String, dynamic> get telemetryDetails => {
+        'native_pending_intent_exists': pendingIntentExists,
+        if (canScheduleExactAlarms != null)
+          'native_can_schedule_exact_alarms': canScheduleExactAlarms,
+        if (scheduledAtMs != null) 'ledger_scheduled_at_ms': scheduledAtMs,
+        if (triggerAtMs != null) 'ledger_trigger_at_ms': triggerAtMs,
+        if (slotNumber != null) 'ledger_slot_number': slotNumber,
+        if (globalSlot != null) 'ledger_global_slot': globalSlot,
+        if (epoch != null) 'ledger_epoch': epoch,
+        if (slotTimeMs != null) 'ledger_slot_time_ms': slotTimeMs,
+        if (rustSlotTimeMs != null) 'ledger_rust_slot_time_ms': rustSlotTimeMs,
+        if (localSlotTimeMs != null)
+          'ledger_local_slot_time_ms': localSlotTimeMs,
+        if (alarmTimeMs != null) 'ledger_alarm_time_ms': alarmTimeMs,
+        if (nativeTriggerAtMs != null)
+          'ledger_native_trigger_at_ms': nativeTriggerAtMs,
+        if (scheduledElapsedRealtimeMs != null)
+          'ledger_scheduled_elapsed_realtime_ms': scheduledElapsedRealtimeMs,
+        if (triggerElapsedRealtimeMs != null)
+          'ledger_trigger_elapsed_realtime_ms': triggerElapsedRealtimeMs,
+        if (requestedDelayMs != null)
+          'ledger_requested_delay_ms': requestedDelayMs,
+        if (effectiveDelayMs != null)
+          'ledger_effective_delay_ms': effectiveDelayMs,
+        if (rustWakeTimeMs != null) 'ledger_rust_wake_time_ms': rustWakeTimeMs,
+        if (localWakeTimeMs != null)
+          'ledger_local_wake_time_ms': localWakeTimeMs,
+        if (clockDriftMs != null) 'ledger_clock_drift_ms': clockDriftMs,
+        if (nodeTimeMsAtSchedule != null)
+          'ledger_node_time_ms_at_schedule': nodeTimeMsAtSchedule,
+        if (systemTimeMsAtSchedule != null)
+          'ledger_system_time_ms_at_schedule': systemTimeMsAtSchedule,
+        if (clockDriftSampleAgeMs != null)
+          'ledger_clock_drift_sample_age_ms': clockDriftSampleAgeMs,
+        if (purpose != null) 'ledger_purpose': purpose,
+        if (schedulerReason != null) 'ledger_scheduler_reason': schedulerReason,
+        if (scheduleStatus != null) 'ledger_schedule_status': scheduleStatus,
+        if (scheduleFailureReason != null)
+          'ledger_schedule_failure_reason': scheduleFailureReason,
+        if (receiverEnteredAtMs != null)
+          'ledger_receiver_entered_at_ms': receiverEnteredAtMs,
+        if (receiverSystemTimeMs != null)
+          'ledger_receiver_system_time_ms': receiverSystemTimeMs,
+        if (receiverElapsedRealtimeMs != null)
+          'ledger_receiver_elapsed_realtime_ms': receiverElapsedRealtimeMs,
+        if (receiverLatencyMs != null)
+          'ledger_receiver_latency_ms': receiverLatencyMs,
+        if (nativeDeliveryLatencyMs != null)
+          'ledger_native_delivery_latency_ms': nativeDeliveryLatencyMs,
+        if (elapsedDeliveryLatencyMs != null)
+          'ledger_elapsed_delivery_latency_ms': elapsedDeliveryLatencyMs,
+        if (flutterEventSentAtMs != null)
+          'ledger_flutter_event_sent_at_ms': flutterEventSentAtMs,
+        if (cancelledAtMs != null) 'ledger_cancelled_at_ms': cancelledAtMs,
+        if (cancelReason != null) 'ledger_cancel_reason': cancelReason,
+        if (nodeRunning != null) 'ledger_node_running': nodeRunning,
+        if (stateUnavailableReason != null)
+          'alarm_debug_state_unavailable_reason': stateUnavailableReason,
+      };
+}
+
 /// Abstract interface for platform-specific alarm/wake-up scheduling
 ///
 /// Android: Uses AlarmManager with exact alarms and Foreground Service
@@ -164,6 +392,15 @@ class PlatformAlarmService {
       alarmTimeMs: alarmTimeMs,
       firedAtMs: firedAtMs,
       latencyMs: latencyMs,
+      nativeTriggerAtMs: _intFromDynamic(eventData['nativeTriggerAtMs']),
+      triggerElapsedRealtimeMs:
+          _intFromDynamic(eventData['triggerElapsedRealtimeMs']),
+      receiverElapsedRealtimeMs:
+          _intFromDynamic(eventData['receiverElapsedRealtimeMs']),
+      nativeDeliveryLatencyMs:
+          _intFromDynamic(eventData['nativeDeliveryLatencyMs']),
+      elapsedDeliveryLatencyMs:
+          _intFromDynamic(eventData['elapsedDeliveryLatencyMs']),
       platform: Platform.operatingSystem,
       nodeRunning: _boolFromDynamic(eventData['nodeRunning']),
       batteryLevel: _intFromDynamic(eventData['batteryLevel']),
@@ -491,6 +728,53 @@ class PlatformAlarmService {
     }
   }
 
+  Future<AlarmDebugState> getAlarmDebugState(String alarmId) async {
+    if (!Platform.isAndroid) {
+      return AlarmDebugState(
+        alarmId: alarmId,
+        pendingIntentExists: false,
+        stateUnavailableReason: 'unsupported_platform',
+      );
+    }
+    if (!_initialized) {
+      _log.debug('Cannot get alarm debug state: service not initialized');
+      return AlarmDebugState(
+        alarmId: alarmId,
+        pendingIntentExists: false,
+        stateUnavailableReason: 'service_not_initialized',
+      );
+    }
+
+    try {
+      final raw = await _channel.invokeMethod<Object?>(
+        'getAlarmDebugState',
+        {'alarmId': alarmId},
+      );
+      if (raw is Map) {
+        return AlarmDebugState.fromMap(raw.cast<Object?, Object?>());
+      }
+      return AlarmDebugState(
+        alarmId: alarmId,
+        pendingIntentExists: await hasScheduledAlarm(alarmId),
+        stateUnavailableReason: 'invalid_native_state',
+      );
+    } on PlatformException catch (e) {
+      _log.warn('Error getting alarm debug state $alarmId: ${e.message}');
+      return AlarmDebugState(
+        alarmId: alarmId,
+        pendingIntentExists: await hasScheduledAlarm(alarmId),
+        stateUnavailableReason: 'platform_exception',
+      );
+    } catch (e) {
+      _log.warn('Error getting alarm debug state $alarmId: $e');
+      return AlarmDebugState(
+        alarmId: alarmId,
+        pendingIntentExists: await hasScheduledAlarm(alarmId),
+        stateUnavailableReason: 'exception',
+      );
+    }
+  }
+
   Future<bool> wasForceStoppedOnStartup() async {
     if (!Platform.isAndroid) return false;
     if (!_initialized) return false;
@@ -541,6 +825,8 @@ class PlatformAlarmService {
     final scheduledAtMs = DateTime.now().millisecondsSinceEpoch;
     final alarmTimeMs = _intFromDynamic(alarmData['alarmTimeMs']) ??
         scheduledAtMs + normalizedDelayMs;
+    alarmData.putIfAbsent('alarmTimeMs', () => alarmTimeMs);
+    alarmData.putIfAbsent('systemTimeMsAtSchedule', () => scheduledAtMs);
     final globalSlot = _globalSlotForAlarm(
       alarmId: alarmId,
       slotNumber: slotNumber,
@@ -562,6 +848,9 @@ class PlatformAlarmService {
         globalSlot: globalSlot,
         epoch: _intFromDynamic(alarmData['epoch']),
         slotTimeMs: slotTimeMs,
+        rustSlotTimeMs: _intFromDynamic(alarmData['rustSlotTimeMs']),
+        localSlotTimeMs:
+            _intFromDynamic(alarmData['localSlotTimeMs']) ?? slotTimeMs,
         scheduledAtMs: scheduledAtMs,
         alarmTimeMs: alarmTimeMs,
         requestedDelayMs: requestedDelayMs,
@@ -574,6 +863,12 @@ class PlatformAlarmService {
         rustWakeTimeMs: _intFromDynamic(alarmData['rustWakeTimeMs']),
         localWakeTimeMs: _intFromDynamic(alarmData['localWakeTimeMs']),
         clockDriftMs: _intFromDynamic(alarmData['clockDriftMs']),
+        nodeTimeMsAtSchedule:
+            _intFromDynamic(alarmData['nodeTimeMsAtSchedule']),
+        systemTimeMsAtSchedule:
+            _intFromDynamic(alarmData['systemTimeMsAtSchedule']),
+        clockDriftSampleAgeMs:
+            _intFromDynamic(alarmData['clockDriftSampleAgeMs']),
         failureReason: failureReason,
       );
     }
@@ -1127,6 +1422,27 @@ class PlatformAlarmService {
     _onBootReschedule = null;
     _onNativeEvent = null;
   }
+}
+
+int? _alarmDebugInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value);
+  return null;
+}
+
+bool? _alarmDebugBool(Object? value) {
+  if (value is bool) return value;
+  if (value is String) {
+    if (value == 'true') return true;
+    if (value == 'false') return false;
+  }
+  return null;
+}
+
+String? _alarmDebugString(Object? value) {
+  if (value is String && value.isNotEmpty) return value;
+  return null;
 }
 
 /// Result of an alarm scheduling operation

--- a/test/core/services/block_production_alarm_audit_service_test.dart
+++ b/test/core/services/block_production_alarm_audit_service_test.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
 import 'package:crypto_mobile_app/core/services/block_production_alarm_audit_service.dart';
 import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
+import 'package:crypto_mobile_app/core/services/platform_alarm_service.dart';
 import 'package:crypto_mobile_app/features/metrics/mobile_context_snapshot_collector.dart';
 import 'package:crypto_mobile_app/src/rust/observability.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -50,7 +51,8 @@ void main() {
       );
     });
 
-    test('does not reschedule past slot_wake alarms and emits too_late',
+    test(
+        'classifies past slot_wake alarm with no receiver and no pending intent',
         () async {
       final harness = _AuditHarness(
         epoch: const AlarmAuditEpochSnapshot(
@@ -64,11 +66,47 @@ void main() {
       final result = await harness.service.audit(reason: 'foreground_resume');
 
       expect(result.expectedSlotWakeCount, 0);
-      expect(result.tooLateCount, 1);
+      expect(result.missingCount, 0);
       expect(harness.scheduledAlarms, isEmpty);
-      final tooLate = harness.events('alarm_audit_missing_too_late').single;
-      expect(tooLate['alarm_id'], 'slot_42');
-      expect(tooLate['lateness_ms'], 500);
+      final missing =
+          harness.events('alarm_audit_past_missing_no_receiver').single;
+      expect(missing['alarm_id'], 'slot_42');
+      expect(missing['past_alarm_age_ms'], 500);
+      expect(missing['native_pending_intent_exists'], isFalse);
+      final completed = harness.events('alarm_audit_completed').single;
+      expect(completed['past_slot_wake_count'], 1);
+      expect(completed['past_missing_no_receiver_count'], 1);
+    });
+
+    test(
+        'classifies past slot_wake alarm delivered after slot as receiver late',
+        () async {
+      final harness = _AuditHarness(
+        debugStates: const {
+          'slot_42': AlarmDebugState(
+            alarmId: 'slot_42',
+            pendingIntentExists: false,
+            receiverEnteredAtMs: 9600,
+            receiverLatencyMs: 1100,
+          ),
+        },
+        epoch: const AlarmAuditEpochSnapshot(
+          epoch: 7,
+          wonSlots: [
+            AlarmAuditWonSlot(globalSlot: 42, expectedTimeMs: 9500),
+          ],
+        ),
+      );
+
+      final result = await harness.service.audit(reason: 'foreground_resume');
+
+      expect(result.expectedSlotWakeCount, 0);
+      expect(harness.scheduledAlarms, isEmpty);
+      final late = harness.events('alarm_audit_past_receiver_late').single;
+      expect(late['alarm_id'], 'slot_42');
+      expect(late['delivery_latency_ms'], 1100);
+      expect(late['slot_delta_ms'], 100);
+      expect(late['ledger_receiver_entered_at_ms'], 9600);
     });
 
     test('handles no won slots', () async {
@@ -235,16 +273,22 @@ class _AuditHarness {
     ),
     this.epochCompleter,
     Set<String>? presentAlarms,
+    Map<String, AlarmDebugState>? debugStates,
     this.nodeRunning = true,
     this.recoveryRetryDelays,
     this.scheduleRecoveryRetry,
-  }) : presentAlarms = presentAlarms ?? <String>{} {
+  })  : presentAlarms = presentAlarms ?? <String>{},
+        debugStates = debugStates ?? const <String, AlarmDebugState>{} {
     service = BlockProductionAlarmAuditService.test(
       initializeAlarmService: () async => true,
       refreshPermissions: () async => exactAlarmPermission,
       hasExactAlarmPermission: () async => exactAlarmPermission,
-      hasScheduledAlarm: (alarmId) async =>
-          this.presentAlarms.contains(alarmId),
+      getAlarmDebugState: (alarmId) async =>
+          this.debugStates[alarmId] ??
+          AlarmDebugState(
+            alarmId: alarmId,
+            pendingIntentExists: this.presentAlarms.contains(alarmId),
+          ),
       scheduleAlarm: ({
         required alarmId,
         required slotNumber,
@@ -299,6 +343,8 @@ class _AuditHarness {
       nowMs: () => nowMs,
       rustToLocalTimeMs: (rustTimeMs, clockDriftMs) =>
           rustTimeMs + clockDriftMs,
+      lastNodeTimeMs: () => nodeTimeMs,
+      lastNodeClockSampleSystemTimeMs: () => nodeClockSampleSystemTimeMs,
       isAndroid: () => true,
       appState: () => 'foreground',
       platformVersion: () => 'android-test',
@@ -317,11 +363,14 @@ class _AuditHarness {
   bool nodeRunning;
   final int clockDriftMs = 0;
   final int nowMs = 10000;
+  final int nodeTimeMs = 9950;
+  final int nodeClockSampleSystemTimeMs = 9950;
   final AlarmAuditEpochSnapshot? epoch;
   final Completer<AlarmAuditEpochSnapshot?>? epochCompleter;
   final List<Duration>? recoveryRetryDelays;
   final AlarmAuditRecoveryRetryScheduler? scheduleRecoveryRetry;
   final Set<String> presentAlarms;
+  final Map<String, AlarmDebugState> debugStates;
   final records = <_CapturedObservabilityRecord>[];
   final scheduledAlarms = <_ScheduledAlarm>[];
   final foregroundResumeSchedules = <_ForegroundResumeSchedule>[];

--- a/test/features/challenges/challenges_screen_test.dart
+++ b/test/features/challenges/challenges_screen_test.dart
@@ -285,10 +285,12 @@ void main() {
     });
 
     testWidgets('shows missed challenges when tab tapped', (tester) async {
-      await tester.pumpWidget(_buildTestApp(challengeData: _testChallenges));
+      await tester.pumpWidget(
+        _buildTestApp(challengeData: [_testChallenges[0], _testChallenges[2]]),
+      );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('Missed'));
+      await tester.tapAt(tester.getCenter(find.byType(Tab).at(2)));
       await tester.pumpAndSettle();
 
       expect(find.text('Quick Challenge'), findsOneWidget);


### PR DESCRIPTION
This PR fixes the main problem with the previous alarm telemetry: it could report that an alarm was “too late” or missing without proving what actually happened to the Android alarm.

The new telemetry makes missed block analysis much clearer by separating:

- alarm was never scheduled
- alarm was scheduled but no longer exists
- alarm still exists after its wake time
- Android receiver actually ran
- Android receiver ran late
- Flutter received the native alarm event
- clock conversion between Rust/node time and Android time was wrong or stale

## Main Changes

- Adds a native Android alarm ledger persisted in `SharedPreferences`.
- Adds `getAlarmDebugState` so Dart can inspect native alarm state during audits.
- Removes the misleading `alarm_audit_missing_too_late` path.
- Replaces it with evidence-based past-alarm states:
  - `alarm_audit_past_receiver_on_time`
  - `alarm_audit_past_receiver_late`
  - `alarm_audit_past_pending_no_receiver`
  - `alarm_audit_past_missing_no_receiver`
- Records whether the alarm was scheduled, failed to schedule, fired, notified Flutter, or was cancelled.
- Adds timing fields to distinguish app/Android alarm delay from clock-conversion issues.

## New Timing Evidence

The telemetry now includes both clock domains:

- Rust/protocol slot time
- converted Android local slot time
- node clock drift used for conversion
- age of the drift sample
- Android native trigger time
- Android receiver time
- elapsed-realtime delivery latency

This lets us tell whether a slot was missed because Android delivered late, the app did not receive the event, the alarm disappeared, or the Rust-to-local time conversion was stale/wrong.