### PR TITLE
fix: gate mobile context snapshots while sleeping

### DIFF
--- a/lib/core/bootstrap/app_bootstrap.dart
+++ b/lib/core/bootstrap/app_bootstrap.dart
@@ -128,6 +128,9 @@ class AppBootstrap {
     ObservabilityReportingService.instance.configureMobileContextCollector(
       MetricsCollectorService.instance,
     );
+    ObservabilityReportingService.instance.configureNodeRuntimeActiveGetter(
+      () => RustBackendService.instance.isRuntimeActive,
+    );
 
     if (registerLifecycleObserver) {
       await AppSleepService.instance.initializeForInteractiveApp();

--- a/lib/core/services/observability_reporting_service.dart
+++ b/lib/core/services/observability_reporting_service.dart
@@ -21,18 +21,23 @@ typedef _MobileContextCollectorCall = Future<Map<String, dynamic>> Function({
   Map<String, dynamic>? eventData,
 });
 
+typedef NodeRuntimeActiveGetter = bool Function();
+
 class ObservabilityReportingService {
   ObservabilityReportingService._()
       : _record = observabilityRecord,
-        _canRecordOverride = null;
+        _canRecordOverride = null,
+        _isNodeRuntimeActive = null;
 
   ObservabilityReportingService.test({
     required MobileContextSnapshotCollector collector,
     required ObservabilityRecordClient record,
     bool Function()? canRecord,
+    NodeRuntimeActiveGetter? isNodeRuntimeActive,
   })  : _collector = collector,
         _record = record,
-        _canRecordOverride = canRecord;
+        _canRecordOverride = canRecord,
+        _isNodeRuntimeActive = isNodeRuntimeActive;
 
   static final ObservabilityReportingService instance =
       ObservabilityReportingService._();
@@ -46,6 +51,7 @@ class ObservabilityReportingService {
 
   final ObservabilityRecordClient _record;
   final bool Function()? _canRecordOverride;
+  NodeRuntimeActiveGetter? _isNodeRuntimeActive;
   final Battery _battery = Battery();
   final Connectivity _connectivity = Connectivity();
   MobileContextSnapshotCollector? _collector;
@@ -77,6 +83,10 @@ class ObservabilityReportingService {
   void configureMobileContextCollector(
       MobileContextSnapshotCollector collector) {
     _collector = collector;
+  }
+
+  void configureNodeRuntimeActiveGetter(NodeRuntimeActiveGetter getter) {
+    _isNodeRuntimeActive = getter;
   }
 
   Future<void> reportNodeInitialized({
@@ -188,6 +198,16 @@ class ObservabilityReportingService {
     _connectivitySubscription = null;
     _mobileContextReportingStarted = false;
     _powerNetworkServiceSnapshotInFlight = false;
+  }
+
+  Future<void> pauseMobileContextSnapshotReportingForNodePause() async {
+    await stopMobileContextSnapshotReporting();
+  }
+
+  Future<void> resumeMobileContextSnapshotReportingAfterNodeResume() async {
+    await startMobileContextSnapshotReporting(
+      initialReason: 'node_wake',
+    );
   }
 
   FlutterObservabilityRecordResult recordEvent({
@@ -423,7 +443,22 @@ class ObservabilityReportingService {
       (!AppConfig.viewOnly &&
           AppConfig.observabilityHubBaseUrl.trim().isNotEmpty);
 
-  bool get _canReportMobileContextSnapshots => _canRecordObservability;
+  bool get _canReportMobileContextSnapshots =>
+      _canRecordObservability && _isNodeRuntimeActiveForMobileContext;
+
+  bool get _isNodeRuntimeActiveForMobileContext {
+    final isActive = _isNodeRuntimeActive;
+    if (isActive == null) {
+      return true;
+    }
+
+    try {
+      return isActive();
+    } catch (e) {
+      _log.debug('Failed to read node runtime active state: $e');
+      return false;
+    }
+  }
 
   void _handleBatteryStateChanged(BatteryState state) {
     final now = DateTime.now();

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -84,6 +84,7 @@ class RustBackendService {
   NodeControl? _control;
   NodeRpcClient? _rpc;
   bool get isRunning => _nodeRunning;
+  bool get isRuntimeActive => _nodeRunning && !_nodePaused;
   String? get instanceId => _instanceId;
   int? get nodeClockDriftMs => _nodeClockDriftMs;
   int? get lastNodeTimeMs => _lastNodeTimeMs;
@@ -485,14 +486,24 @@ class RustBackendService {
 
   Future<void> resumeNode() async {
     _log.info('Resuming node');
+    final wasPaused = _nodePaused;
     _nodePaused = false;
     _control?.resume();
+    if (wasPaused && _nodeRunning) {
+      await ObservabilityReportingService.instance
+          .resumeMobileContextSnapshotReportingAfterNodeResume();
+    }
   }
 
   Future<void> pauseNode() async {
     _log.info('Pausing node');
+    final wasRuntimeActive = isRuntimeActive;
     _nodePaused = true;
     _control?.pause();
+    if (wasRuntimeActive) {
+      await ObservabilityReportingService.instance
+          .pauseMobileContextSnapshotReportingForNodePause();
+    }
   }
 
   Future<void> stopNode() async {

--- a/test/core/services/observability_reporting_service_test.dart
+++ b/test/core/services/observability_reporting_service_test.dart
@@ -195,6 +195,68 @@ void main() {
       expect(powerPayload.containsKey('device'), isFalse);
     });
 
+    test('mobile context snapshots are suppressed while node runtime sleeps',
+        () async {
+      final records = <_CapturedObservabilityRecord>[];
+      final service = _service(
+        records,
+        isNodeRuntimeActive: () => false,
+      );
+
+      await service.reportRuntimeMobileContextSnapshot(
+        reason: 'foreground',
+        eventData: {'lifecycle_state': 'resumed'},
+      );
+      await service.reportPowerNetworkServiceContextSnapshot(
+        reason: 'periodic',
+        force: true,
+      );
+
+      expect(records, isEmpty);
+
+      service.recordEvent(
+        event: 'app_sleep_control',
+        details: {'state': 'sleeping'},
+      );
+
+      expect(records, hasLength(1));
+      expect(records.single.event, 'app_sleep_control');
+      expect(records.single.payload, {'state': 'sleeping'});
+    });
+
+    test('node resume restarts mobile context with immediate fresh snapshots',
+        () async {
+      final records = <_CapturedObservabilityRecord>[];
+      var nodeRuntimeActive = false;
+      final service = _service(
+        records,
+        isNodeRuntimeActive: () => nodeRuntimeActive,
+      );
+
+      await service.startMobileContextSnapshotReporting(
+        initialReason: 'startup',
+      );
+      expect(records, isEmpty);
+
+      nodeRuntimeActive = true;
+      await service.resumeMobileContextSnapshotReportingAfterNodeResume();
+
+      expect(records, hasLength(2));
+      expect(records.map((record) => record.event).toList(), [
+        'app_mobile_context_snapshot',
+        'app_mobile_context_snapshot',
+      ]);
+      expect(records[0].payload['event_data'], {
+        'snapshot_reason': 'node_wake',
+      });
+      expect(records[0].payload.containsKey('runtime'), isTrue);
+      expect(records[1].payload['event_data'], {
+        'snapshot_reason': 'node_wake',
+      });
+      expect(records[1].payload.containsKey('battery'), isTrue);
+      expect(records[1].payload.containsKey('network'), isTrue);
+    });
+
     test('semantic record methods own observability kind selection', () {
       final records = <_CapturedObservabilityRecord>[];
       final service = _service(records);
@@ -470,10 +532,12 @@ ObservabilityReportingService _service(
   List<_CapturedObservabilityRecord> records, {
   bool nodeInitialized = true,
   ObservabilityRecordClient? record,
+  NodeRuntimeActiveGetter? isNodeRuntimeActive,
 }) {
   final service = ObservabilityReportingService.test(
     collector: _FakeMobileContextCollector(),
     canRecord: () => true,
+    isNodeRuntimeActive: isNodeRuntimeActive,
     record: record ??
         ({
           required FlutterObservabilityKind kind,


### PR DESCRIPTION
While the app is running but the background node is sleeping, it is still ending observability data, we don't want to do that. May be useful in some corner cases but is too spammy and invasive, so it is better to just not do it.