### PR TITLE
fix: retry transient GET failures in LeaderboardApiService

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -110,26 +110,26 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
-  battery_plus: b42253f6d2dde71712f8c36fef456d99121c5977
-  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
-  device_info_plus: 335f3ce08d2e174b9fdc3db3db0f4e3b1f66bd89
+  app_links: 585674be3c6661708e6cd794ab4f39fb9d8356f9
+  battery_plus: 34f72fa2afeeea83bbae306c72a25828d3ec727a
+  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
+  device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
-  objective_c: 89e720c30d716b036faf9c9684022048eee1eee2
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  rust_lib_crypto_mobile_app: 0097bc2ea6160d2db5cb396a7d4132173623e336
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
+  objective_c: 77e887b5ba1827970907e10e832eec1683f3431d
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  rust_lib_crypto_mobile_app: b14c41db44a5333f6b460d8e38f59b2bf5070e20
   Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
-  sentry_flutter: 7f88e12d1882ec6e648644a7c0ff5b1466f07f99
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
-  wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
-  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
+  sentry_flutter: b71c80b7a071cc42af82576046ff2db19fc12f57
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  wakelock_plus: 76957ab028e12bfa4e66813c99e46637f367fc7e
+  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
 
 PODFILE CHECKSUM: 2c7c539d651799d28b2a2256cf6f2d9c117ae948
 

--- a/lib/core/services/leaderboard_api_service.dart
+++ b/lib/core/services/leaderboard_api_service.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
@@ -19,13 +21,24 @@ class LeaderboardApiService {
     String? baseUrl,
     http.Client? httpClient,
     bool? writesEnabled,
+    int? maxGetRetries,
+    Duration? retryBaseDelay,
   })  : _baseUrl = baseUrl ?? AppConfig.leaderboardApiBaseUrl,
         _http = httpClient ?? createAppHttpClient(),
-        _writesEnabled = writesEnabled ?? !AppConfig.viewOnly;
+        _writesEnabled = writesEnabled ?? !AppConfig.viewOnly,
+        _maxGetRetries = maxGetRetries ?? 2,
+        _retryBaseDelay = retryBaseDelay ?? const Duration(milliseconds: 300);
 
   final String _baseUrl;
   final http.Client _http;
   final bool _writesEnabled;
+
+  /// Number of additional attempts for idempotent GETs after the first one.
+  /// Writes (POST) are never retried to avoid duplicate side effects.
+  final int _maxGetRetries;
+
+  /// Base delay for exponential backoff between GET retries.
+  final Duration _retryBaseDelay;
 
   static const _jsonHeaders = {
     'Content-Type': 'application/json',
@@ -212,7 +225,8 @@ class LeaderboardApiService {
         : uri;
     _log.trace('GET $url');
 
-    final resp = await _send(() => _http.get(url, headers: _acceptJson));
+    final resp =
+        await _sendWithRetry(() => _http.get(url, headers: _acceptJson));
     return _parseEnvelope(resp, url);
   }
 
@@ -241,20 +255,72 @@ class LeaderboardApiService {
   }
 
   Future<http.Response> _send(
-    Future<http.Response> Function() fn,
-  ) async {
+    Future<http.Response> Function() fn, {
+    bool reportErrors = true,
+  }) async {
     try {
       return await fn().timeout(AppConfig.leaderboardApiTimeout);
     } catch (e, stackTrace) {
       _log.warn('Request failed: $e');
-      await SentryUtil.captureError(
-        e,
-        stackTrace,
-        tag: 'leaderboard_api',
-      );
+      // Only report to Sentry when the failure is terminal — transient errors
+      // that a retry recovers from would otherwise be noise.
+      if (reportErrors) {
+        await SentryUtil.captureError(
+          e,
+          stackTrace,
+          tag: 'leaderboard_api',
+        );
+      }
       rethrow;
     }
   }
+
+  /// Sends an idempotent request, retrying transient failures with exponential
+  /// backoff. Retries on connection errors/timeouts and on 429/5xx responses.
+  ///
+  /// Non-transient responses (e.g. 4xx other than 429, or any 2xx) are returned
+  /// to the caller for normal parsing. Sentry only sees a transport error once
+  /// the retries are exhausted; intermediate retryable HTTP statuses are not
+  /// captured here (the final one is captured by [_parseEnvelope]).
+  Future<http.Response> _sendWithRetry(
+    Future<http.Response> Function() fn,
+  ) async {
+    var attempt = 0;
+    while (true) {
+      final isLastAttempt = attempt >= _maxGetRetries;
+      try {
+        final resp = await _send(fn, reportErrors: isLastAttempt);
+        if (!isLastAttempt && _isRetryableStatus(resp.statusCode)) {
+          attempt++;
+          _log.debug('Retrying GET after HTTP ${resp.statusCode} '
+              '(attempt $attempt/$_maxGetRetries)');
+          await Future.delayed(_backoff(attempt));
+          continue;
+        }
+        return resp;
+      } catch (e) {
+        if (!isLastAttempt && _isRetryableError(e)) {
+          attempt++;
+          _log.debug('Retrying GET after error "$e" '
+              '(attempt $attempt/$_maxGetRetries)');
+          await Future.delayed(_backoff(attempt));
+          continue;
+        }
+        rethrow;
+      }
+    }
+  }
+
+  /// Exponential backoff for retry [attempt] (1-based): base, 2×base, 4×base…
+  Duration _backoff(int attempt) => _retryBaseDelay * (1 << (attempt - 1));
+
+  static bool _isRetryableStatus(int statusCode) =>
+      statusCode == 429 || statusCode >= 500;
+
+  static bool _isRetryableError(Object error) =>
+      error is TimeoutException ||
+      error is SocketException ||
+      error is http.ClientException;
 
   Future<dynamic> _parseEnvelope(http.Response resp, Uri url) async {
     if (resp.statusCode >= 200 && resp.statusCode < 300) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -173,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -737,18 +737,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: "direct dev"
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   material_symbols_icons:
     dependency: "direct main"
     description:
@@ -1197,10 +1197,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:

--- a/test/core/services/leaderboard_api_service_test.dart
+++ b/test/core/services/leaderboard_api_service_test.dart
@@ -588,4 +588,144 @@ void main() {
       );
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Retry (GET-only)
+  // -------------------------------------------------------------------------
+
+  group('retry', () {
+    Map<String, dynamic> breakdownEnvelope() => _envelope({
+          'scope': 'global',
+          'display_name': 'Alice',
+          'total_points': 1000,
+          'offchain_points': 200,
+        });
+
+    test('retries a GET after a transient 503 and then succeeds', () async {
+      var attempts = 0;
+      final client = MockClient((request) async {
+        attempts++;
+        if (attempts == 1) {
+          return http.Response(
+            jsonEncode({'error': 'Service unavailable'}),
+            503,
+            headers: {'content-type': 'application/json'},
+          );
+        }
+        return http.Response(
+          jsonEncode(breakdownEnvelope()),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final service = LeaderboardApiService(
+        baseUrl: _baseUrl,
+        httpClient: client,
+        retryBaseDelay: Duration.zero,
+      );
+
+      final result = await service.getBreakdown(participantId: 42);
+
+      expect(attempts, 2);
+      expect(result.totalPoints, 1000);
+    });
+
+    test('retries a GET after a transient connection error', () async {
+      var attempts = 0;
+      final client = MockClient((request) async {
+        attempts++;
+        if (attempts == 1) {
+          throw TimeoutException('Request timed out');
+        }
+        return http.Response(
+          jsonEncode(breakdownEnvelope()),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final service = LeaderboardApiService(
+        baseUrl: _baseUrl,
+        httpClient: client,
+        retryBaseDelay: Duration.zero,
+      );
+
+      final result = await service.getBreakdown(participantId: 42);
+
+      expect(attempts, 2);
+      expect(result.totalPoints, 1000);
+    });
+
+    test('gives up after exhausting retries on persistent 500', () async {
+      var attempts = 0;
+      final client = MockClient((request) async {
+        attempts++;
+        return http.Response('Internal server error', 500);
+      });
+      final service = LeaderboardApiService(
+        baseUrl: _baseUrl,
+        httpClient: client,
+        maxGetRetries: 2,
+        retryBaseDelay: Duration.zero,
+      );
+
+      await expectLater(
+        () => service.getBreakdown(participantId: 42),
+        throwsA(
+          isA<LeaderboardApiException>()
+              .having((e) => e.statusCode, 'statusCode', 500),
+        ),
+      );
+      expect(attempts, 3); // 1 initial + 2 retries
+    });
+
+    test('does NOT retry a POST (write) on a transient 503', () async {
+      var attempts = 0;
+      final client = MockClient((request) async {
+        attempts++;
+        return http.Response(
+          jsonEncode({'error': 'Service unavailable'}),
+          503,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final service = LeaderboardApiService(
+        baseUrl: _baseUrl,
+        httpClient: client,
+        writesEnabled: true,
+        retryBaseDelay: Duration.zero,
+      );
+
+      await expectLater(
+        () => service.register(
+          registrationCode: 'code',
+          identifier: 'id',
+        ),
+        throwsA(isA<LeaderboardApiException>()),
+      );
+      expect(attempts, 1);
+    });
+
+    test('does NOT retry a non-transient 4xx', () async {
+      var attempts = 0;
+      final client = MockClient((request) async {
+        attempts++;
+        return http.Response(
+          jsonEncode({'error': 'Participant not found'}),
+          404,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final service = LeaderboardApiService(
+        baseUrl: _baseUrl,
+        httpClient: client,
+        retryBaseDelay: Duration.zero,
+      );
+
+      await expectLater(
+        () => service.getBreakdown(participantId: 999),
+        throwsA(isA<LeaderboardApiException>()),
+      );
+      expect(attempts, 1);
+    });
+  });
 }


### PR DESCRIPTION
Rank and total points could render blank on the challenges screen when the initial ranking/breakdown GET hit a transient error, since nothing retried before the next 30s silent refresh.

Add GET-only retry with exponential backoff (default 2 retries) for idempotent reads. Retries on connection errors (timeout/socket/client) and on 429/5xx responses. POST writes are never retried to avoid duplicate side effects. Transient errors recovered by a retry are no longer reported to Sentry; only the terminal failure is.