### PR TITLE
fix: wake producers five minutes before slots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -219,9 +219,9 @@ VERSION_CHECK_INTERVAL_SECONDS=7200
 # Wake up time before slot in seconds (30-300)
 # How many seconds before a scheduled slot the app should wake up
 # Allows time for node startup, monitoring, and block production
-# Recommended: 60 seconds for reliable production
-# Default: 60
-BLOCK_PRODUCTION_WAKE_BEFORE_SLOT_SECONDS=60
+# Recommended: 300 seconds for reliable production
+# Default: 300
+BLOCK_PRODUCTION_WAKE_BEFORE_SLOT_SECONDS=300
 
 # Base epoch monitoring interval in seconds (60-1800)
 # How often to check for epoch transitions when VRF calculation is not complete

--- a/docs/BACKGROUND_PRODUCTION.md
+++ b/docs/BACKGROUND_PRODUCTION.md
@@ -87,9 +87,9 @@ flowchart TB
 
 The `AndroidForegroundTaskController` continuously polls VRF status and adaptively schedules:
 
-- **Next won slot > 1 minute away**: Schedules alarm, stops foreground monitoring (saves battery)
-- **Next won slot < 1 minute away**: Keeps foreground service running until slot time
-- **No won slots, VRF complete**: Schedules alarm for epoch boundary minus 1 minute
+- **Next won slot > 5 minutes away**: Schedules alarm, stops foreground monitoring (saves battery)
+- **Next won slot < 5 minutes away**: Keeps foreground service running until slot time
+- **No won slots, VRF complete**: Schedules alarm for epoch boundary minus 5 minutes
 - **VRF in progress**: Continues polling every 30 seconds
 
 This adaptive approach maximizes battery life while ensuring reliable wake-ups.
@@ -110,7 +110,7 @@ This adaptive approach maximizes battery life while ensuring reliable wake-ups.
    - Entry point for Android background block production
    - Polls VRF status every 30 seconds while node is running
    - Manages wakelock to prevent device sleep
-   - Schedules alarms when slots are > 1 minute away
+   - Schedules alarms when slots are > 5 minutes away
    - Stops foreground service when no imminent slots
 
 2. **AlarmScheduler** (`AlarmScheduler.kt`)
@@ -405,8 +405,8 @@ METRICS_COLLECTION_INTERVAL_SECONDS=30
 
 # Wake up time before slot (seconds)
 # Allows time for app startup and node sync
-# Default: 60 (1 minute before slot)
-BLOCK_PRODUCTION_WAKE_BEFORE_SLOT_SECONDS=60
+# Default: 300 (5 minutes before slot)
+BLOCK_PRODUCTION_WAKE_BEFORE_SLOT_SECONDS=300
 
 # Base epoch monitoring interval (seconds)
 # Adjusted automatically based on VRF status:

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -231,7 +231,7 @@ class AppConfig {
       defaultValue: 30);
   static const int blockProductionWakeBeforeSlotSeconds = int.fromEnvironment(
       'BLOCK_PRODUCTION_WAKE_BEFORE_SLOT_SECONDS',
-      defaultValue: 60);
+      defaultValue: 300);
   static const int epochMonitorBaseIntervalSeconds = int.fromEnvironment(
       'EPOCH_MONITOR_BASE_INTERVAL_SECONDS',
       defaultValue: 900);

--- a/lib/core/config/l10n/app_en.arb
+++ b/lib/core/config/l10n/app_en.arb
@@ -666,7 +666,7 @@
   "@bgProdSlotScheduling": {
     "description": "Slot scheduling step title"
   },
-  "bgProdSlotSchedulingDesc": "When you win slots, the app schedules alarms to wake your device ~1 minute before each slot",
+  "bgProdSlotSchedulingDesc": "When you win slots, the app schedules alarms to wake your device ~5 minutes before each slot",
   "@bgProdSlotSchedulingDesc": {
     "description": "Slot scheduling step description"
   },

--- a/lib/core/config/l10n/app_localizations.dart
+++ b/lib/core/config/l10n/app_localizations.dart
@@ -877,7 +877,7 @@ abstract class AppLocalizations {
   /// Slot scheduling step description
   ///
   /// In en, this message translates to:
-  /// **'When you win slots, the app schedules alarms to wake your device ~1 minute before each slot'**
+  /// **'When you win slots, the app schedules alarms to wake your device ~5 minutes before each slot'**
   String get bgProdSlotSchedulingDesc;
 
   /// Block production step title

--- a/lib/core/config/l10n/app_localizations_en.dart
+++ b/lib/core/config/l10n/app_localizations_en.dart
@@ -467,7 +467,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get bgProdSlotSchedulingDesc =>
-      'When you win slots, the app schedules alarms to wake your device ~1 minute before each slot';
+      'When you win slots, the app schedules alarms to wake your device ~5 minutes before each slot';
 
   @override
   String get bgProdBlockProduction => 'Block Production';

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -31,7 +31,7 @@ class AndroidForegroundTaskController {
   bool _initialized = false;
   bool _wakelockHeld = false;
   AccountPublicKey? _cachedOurPubKey;
-  ({int height, int globalSlot, DateTime since})? _postProductionHoldState;
+  ({int height, int globalSlot, DateTime until})? _postProductionHoldState;
   String? _alarmRecoveryInFlightKey;
   String? _lastHandledAlarmKey;
   DateTime? _lastHandledAlarmAt;
@@ -337,18 +337,22 @@ class AndroidForegroundTaskController {
             reportedBlockIntervalMs == null || reportedBlockIntervalMs <= 0
                 ? 5000
                 : reportedBlockIntervalMs;
-        final holdSlots =
-            (postProductionHold.inMilliseconds + blockIntervalMs - 1) ~/
-                blockIntervalMs;
-        if (currentGlobalSlot != null &&
-            currentGlobalSlot - ownBlock.globalSlot > holdSlots) {
+        final slotsSinceOwnBlock = currentGlobalSlot == null
+            ? null
+            : currentGlobalSlot - ownBlock.globalSlot;
+        final elapsedSinceOwnBlock =
+            slotsSinceOwnBlock != null && slotsSinceOwnBlock >= 0
+                ? Duration(milliseconds: slotsSinceOwnBlock * blockIntervalMs)
+                : Duration.zero;
+        final remainingHold = postProductionHold - elapsedSinceOwnBlock;
+        if (remainingHold <= Duration.zero) {
           return false;
         }
 
         _postProductionHoldState = (
           height: ownBlock.height,
           globalSlot: ownBlock.globalSlot,
-          since: DateTime.now(),
+          until: DateTime.now().add(remainingHold),
         );
         _log.info(
           'Holding wakelock after own produced block',
@@ -356,6 +360,7 @@ class AndroidForegroundTaskController {
             'height': ownBlock.height,
             'global_slot': ownBlock.globalSlot,
             'max_hold_ms': postProductionHold.inMilliseconds,
+            'remaining_hold_ms': remainingHold.inMilliseconds,
           },
         );
       }
@@ -364,8 +369,7 @@ class AndroidForegroundTaskController {
         return false;
       }
 
-      final waitingSince = _postProductionHoldState!.since;
-      if (DateTime.now().difference(waitingSince) > postProductionHold) {
+      if (!DateTime.now().isBefore(_postProductionHoldState!.until)) {
         _log.info(
           'Post-production hold elapsed after height ${_postProductionHoldState!.height}; releasing',
         );

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -23,14 +23,15 @@ class AndroidForegroundTaskController {
 
   static const Duration _pollInterval = Duration(seconds: 30);
   static const Duration _alarmEventDedupWindow = Duration(seconds: 10);
-  static const foregroundResumeLead = Duration(minutes: 4);
+  static const postProductionHold = Duration(minutes: 2);
+  static const foregroundResumeLead = Duration(minutes: 5);
   static const foregroundResumeAlarmId = 'fg_resume';
 
   Timer? _pollTimer;
   bool _initialized = false;
   bool _wakelockHeld = false;
   AccountPublicKey? _cachedOurPubKey;
-  ({int height, DateTime since})? _awaitingOtherProducerState;
+  ({int height, int globalSlot, DateTime since})? _postProductionHoldState;
   String? _alarmRecoveryInFlightKey;
   String? _lastHandledAlarmKey;
   DateTime? _lastHandledAlarmAt;
@@ -205,7 +206,7 @@ class AndroidForegroundTaskController {
     _initialized = false;
     _wakelockHeld = false;
     _cachedOurPubKey = null;
-    _awaitingOtherProducerState = null;
+    _postProductionHoldState = null;
     _alarmRecoveryInFlightKey = null;
     _lastHandledAlarmKey = null;
     _lastHandledAlarmAt = null;
@@ -300,7 +301,7 @@ class AndroidForegroundTaskController {
     }
   }
 
-  Future<bool> _shouldHoldForOtherProducerBlock(
+  Future<bool> _shouldHoldAfterOwnProducedBlock(
       {bool doubleCheck = true}) async {
     try {
       if (_cachedOurPubKey == null) {
@@ -309,11 +310,11 @@ class AndroidForegroundTaskController {
         _cachedOurPubKey = bpStatus?.blockProducer?.pubKey;
       }
       if (_cachedOurPubKey == null) {
-        _awaitingOtherProducerState = null;
+        _postProductionHoldState = null;
         return false;
       }
 
-      if (_awaitingOtherProducerState == null) {
+      if (_postProductionHoldState == null) {
         final ownBlocks = await RustBackendService.instance.listBlockchain(
           limit: 1,
           fromTip: true,
@@ -323,24 +324,52 @@ class AndroidForegroundTaskController {
             ? ownBlocks!.items.first
             : null;
         if (ownBlock == null) {
-          _awaitingOtherProducerState = null;
+          _postProductionHoldState = null;
           return false;
         }
-        _awaitingOtherProducerState =
-            (height: ownBlock.height, since: DateTime.now());
+
+        final status = await RustBackendService.instance.getStatus(
+          includeVrfDetails: false,
+        );
+        final currentGlobalSlot = status?.node.curGlobalSlot;
+        final reportedBlockIntervalMs = status?.node.blockInterval;
+        final blockIntervalMs =
+            reportedBlockIntervalMs == null || reportedBlockIntervalMs <= 0
+                ? 5000
+                : reportedBlockIntervalMs;
+        final holdSlots =
+            (postProductionHold.inMilliseconds + blockIntervalMs - 1) ~/
+                blockIntervalMs;
+        if (currentGlobalSlot != null &&
+            currentGlobalSlot - ownBlock.globalSlot > holdSlots) {
+          return false;
+        }
+
+        _postProductionHoldState = (
+          height: ownBlock.height,
+          globalSlot: ownBlock.globalSlot,
+          since: DateTime.now(),
+        );
+        _log.info(
+          'Holding wakelock after own produced block',
+          context: {
+            'height': ownBlock.height,
+            'global_slot': ownBlock.globalSlot,
+            'max_hold_ms': postProductionHold.inMilliseconds,
+          },
+        );
       }
 
-      if (_awaitingOtherProducerState == null) {
+      if (_postProductionHoldState == null) {
         return false;
       }
 
-      final waitingSince = _awaitingOtherProducerState!.since;
-      if (DateTime.now().difference(waitingSince) >
-          const Duration(seconds: 30)) {
+      final waitingSince = _postProductionHoldState!.since;
+      if (DateTime.now().difference(waitingSince) > postProductionHold) {
         _log.info(
-          'Waited 30 seconds for another producer block after height ${_awaitingOtherProducerState!.height}; releasing',
+          'Post-production hold elapsed after height ${_postProductionHoldState!.height}; releasing',
         );
-        _awaitingOtherProducerState = null;
+        _postProductionHoldState = null;
         return false;
       }
 
@@ -351,14 +380,14 @@ class AndroidForegroundTaskController {
       final items = recentBlocks?.items ?? const [];
       final ourPubKeyStr = _cachedOurPubKey.toString();
       final hasOtherAfter = items.any((block) =>
-          block.height > _awaitingOtherProducerState!.height &&
+          block.height > _postProductionHoldState!.height &&
           block.producerPubkey.toString() != ourPubKeyStr);
 
       if (hasOtherAfter) {
         if (doubleCheck) {
-          return await _shouldHoldForOtherProducerBlock(doubleCheck: false);
+          return await _shouldHoldAfterOwnProducedBlock(doubleCheck: false);
         }
-        _awaitingOtherProducerState = null;
+        _postProductionHoldState = null;
         return false;
       }
 
@@ -368,7 +397,7 @@ class AndroidForegroundTaskController {
         'Failed to check post-production block status: $e',
       );
       _log.debug('$st');
-      return _awaitingOtherProducerState != null;
+      return _postProductionHoldState != null;
     }
   }
 
@@ -397,14 +426,14 @@ class AndroidForegroundTaskController {
     int? targetSlotTimeMs,
     bool stopMonitoringAfterSchedule = false,
   }) async {
-    if (await _shouldHoldForOtherProducerBlock()) {
-      final height = _awaitingOtherProducerState?.height;
+    if (await _shouldHoldAfterOwnProducedBlock()) {
+      final height = _postProductionHoldState?.height;
       _log.info(
-        'Keeping wakelock: waiting for another producer block after height ${height ?? 'unknown'}',
+        'Keeping wakelock for post-production propagation after height ${height ?? 'unknown'}',
       );
       return const ForegroundResumeAlarmScheduleResult(
         success: false,
-        failureReason: 'holding_for_other_producer_block',
+        failureReason: 'holding_after_own_produced_block',
       );
     }
 
@@ -551,11 +580,13 @@ class AndroidForegroundTaskController {
     }
 
     final alarmId = data['alarmId'] as String? ?? '';
-    if (alarmId == foregroundResumeAlarmId) {
+    if (alarmId == foregroundResumeAlarmId || alarmId.startsWith('slot_')) {
       final alarmKey = _alarmEventKey(data);
       unawaited(
         handleAlarmFire(
-          reason: 'alarm_resume',
+          reason: alarmId == foregroundResumeAlarmId
+              ? 'alarm_resume'
+              : 'alarm_slot_wake',
           alarmKey: alarmKey,
           allowWhileSleeping: allowWhileSleeping,
         ),

--- a/lib/core/services/epoch_slot_scheduler_service.dart
+++ b/lib/core/services/epoch_slot_scheduler_service.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:crypto_mobile_app/core/providers/node_provider.dart';
 import '../../features/node/node_service.dart';
 import '../data/slot_production_repository.dart';
+import 'android_foreground_task_controller.dart';
 import 'platform_alarm_service.dart';
 
 final _log = LoggingService.instance.withTag('usernode/EpochSlotScheduler');
@@ -517,7 +518,8 @@ class EpochSlotSchedulerService {
     return _scheduledSlots.any((slot) {
       final beforeSlot =
           slot.slotTime.subtract(AppConfig.blockProductionWakeBeforeSlot);
-      final afterSlot = slot.slotTime.add(const Duration(minutes: 5));
+      final afterSlot =
+          slot.slotTime.add(AndroidForegroundTaskController.postProductionHold);
       return now.isAfter(beforeSlot) && now.isBefore(afterSlot);
     });
   }

--- a/lib/core/services/epoch_slot_scheduler_service.dart
+++ b/lib/core/services/epoch_slot_scheduler_service.dart
@@ -513,9 +513,10 @@ class EpochSlotSchedulerService {
   bool isSlotMonitoringActive() {
     final now = DateTime.now();
 
-    // Check if any slot is within monitoring window (2 min before to 5 min after)
+    // Check if any slot is within monitoring window.
     return _scheduledSlots.any((slot) {
-      final beforeSlot = slot.slotTime.subtract(const Duration(minutes: 2));
+      final beforeSlot =
+          slot.slotTime.subtract(AppConfig.blockProductionWakeBeforeSlot);
       final afterSlot = slot.slotTime.add(const Duration(minutes: 5));
       return now.isAfter(beforeSlot) && now.isBefore(afterSlot);
     });

--- a/lib/core/services/slot_monitor_service.dart
+++ b/lib/core/services/slot_monitor_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/features/metrics/services/slot_outcome_recorder.dart';
@@ -376,7 +377,7 @@ class SlotMonitorService {
   /// Automatically start monitoring when slot time approaches
   ///
   /// This should be called when an alarm fires or when entering
-  /// a slot monitoring window (2 minutes before slot time).
+  /// a slot monitoring window.
   Future<void> autoStartMonitoring() async {
     if (!_initialized) {
       _log.warn('Cannot auto-start monitoring: service not initialized');
@@ -391,10 +392,8 @@ class SlotMonitorService {
     }
 
     final now = DateTime.now();
-    // 12 slots before and 24 slots after (using cached blockInterval)
-    final monitoringStartTime = nextSlot.slotTime.subtract(
-      Duration(milliseconds: _blockInterval * 12),
-    );
+    final monitoringStartTime =
+        nextSlot.slotTime.subtract(AppConfig.blockProductionWakeBeforeSlot);
     final monitoringEndTime = nextSlot.slotTime.add(
       Duration(milliseconds: _blockInterval * 24),
     );

--- a/lib/design_system/.specs/BurstPulseIllustration.genesis.md
+++ b/lib/design_system/.specs/BurstPulseIllustration.genesis.md
@@ -1,0 +1,15 @@
+# BurstPulseIllustration Genesis
+
+## Inspiration
+
+Backfilled from `lib/design_system/src/burst_pulse_illustration.dart`, tests,
+and Widgetbook coverage during DS harness standardization.
+
+## Design Decisions
+
+- Kept as a custom animated illustration because M3 has no equivalent for burst
+  pulse visual language.
+- Animation state remains internal and visual-only; business state stays outside
+  the widget.
+- Uses tokenized colors, sizing, and animation timing so it can be reused
+  without feature coupling.

--- a/lib/design_system/design_system.dart
+++ b/lib/design_system/design_system.dart
@@ -18,6 +18,7 @@ export 'tokens/app_typography.dart';
 // Widgets
 export 'src/block_production_status_card.dart';
 export 'src/bottom_nav.dart';
+export 'src/burst_pulse_illustration.dart';
 export 'src/empty_state.dart';
 export 'src/full_page_error_state.dart';
 export 'src/full_page_loading_state.dart';

--- a/lib/design_system/src/burst_pulse_illustration.dart
+++ b/lib/design_system/src/burst_pulse_illustration.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+
+import 'paint_helpers.dart';
+
+/// Outcome of a single burst transaction, used to style the ring.
+enum BurstRingOutcome { succeeded, failed }
+
+/// Expanding concentric rings animation for the burst transactions screen.
+///
+/// Each entry in [rings] emits a ring from the center that expands and fades
+/// over 2.5 seconds. Succeeded rings are solid; failed rings are dashed.
+///
+/// Presentation-only: the screen builds [rings] from provider state.
+class BurstPulseIllustration extends StatefulWidget {
+  const BurstPulseIllustration({
+    super.key,
+    required this.rings,
+    this.active = true,
+  });
+
+  /// Ordered list of ring outcomes, grows as transactions complete.
+  final List<BurstRingOutcome> rings;
+
+  /// Set to false when the burst finishes. Stops the animation once all rings
+  /// have expired.
+  final bool active;
+
+  @override
+  State<BurstPulseIllustration> createState() => _BurstPulseIllustrationState();
+}
+
+class _BurstPulseIllustrationState extends State<BurstPulseIllustration>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  final Stopwatch _stopwatch = Stopwatch();
+  final List<_RingState> _ringStates = [];
+  int _prevRingCount = 0;
+  int _totalEmitted = 0;
+
+  static const _ringLifetime = 2.5; // seconds
+  static const _shadeSteps = 5;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 1),
+    );
+    _prevRingCount = widget.rings.length;
+    _appendNewRings(widget.rings.length);
+    if (widget.rings.isNotEmpty) {
+      _startAnimating();
+    }
+  }
+
+  @override
+  void didUpdateWidget(BurstPulseIllustration old) {
+    super.didUpdateWidget(old);
+
+    final newCount = widget.rings.length - _prevRingCount;
+    if (newCount > 0) {
+      if (!_stopwatch.isRunning) _startAnimating();
+      _appendNewRings(newCount);
+      _prevRingCount = widget.rings.length;
+    }
+
+    if (!widget.active) {
+      _maybeStopIfExpired();
+    }
+  }
+
+  void _appendNewRings(int count) {
+    final now = _stopwatch.elapsedMilliseconds / 1000.0;
+    final startIndex = widget.rings.length - count;
+    for (var i = startIndex; i < widget.rings.length; i++) {
+      final shade = (_totalEmitted % _shadeSteps) / (_shadeSteps - 1);
+      _ringStates.add(_RingState(
+        birthTime: now,
+        outcome: widget.rings[i],
+        shade: shade,
+      ));
+      _totalEmitted++;
+    }
+  }
+
+  void _startAnimating() {
+    _stopwatch.start();
+    if (!_controller.isAnimating) {
+      _controller.repeat();
+    }
+  }
+
+  void _maybeStopIfExpired() {
+    if (_ringStates.isEmpty) {
+      _stopAnimating();
+      return;
+    }
+    final now = _stopwatch.elapsedMilliseconds / 1000.0;
+    final allExpired =
+        _ringStates.every((ring) => (now - ring.birthTime) > _ringLifetime);
+    if (allExpired) {
+      _stopAnimating();
+    }
+  }
+
+  void _stopAnimating() {
+    _stopwatch.stop();
+    if (_controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _stopwatch.stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final now = _stopwatch.elapsedMilliseconds / 1000.0;
+
+        _ringStates.removeWhere(
+          (ring) => (now - ring.birthTime) > _ringLifetime,
+        );
+
+        if (!widget.active && _ringStates.isEmpty) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _stopAnimating();
+          });
+        }
+
+        return CustomPaint(
+          size: Size.infinite,
+          painter: _BurstPulsePainter(
+            rings: List.unmodifiable(_ringStates),
+            now: now,
+            ringLifetime: _ringLifetime,
+            lineColor: colorScheme.onSurface,
+            dimColor: colorScheme.outlineVariant,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RingState {
+  const _RingState({
+    required this.birthTime,
+    required this.outcome,
+    required this.shade,
+  });
+
+  final double birthTime;
+  final BurstRingOutcome outcome;
+
+  /// 0.0-1.0 value used to lerp between lineColor and dimColor.
+  final double shade;
+}
+
+class _BurstPulsePainter extends CustomPainter {
+  const _BurstPulsePainter({
+    required this.rings,
+    required this.now,
+    required this.ringLifetime,
+    required this.lineColor,
+    required this.dimColor,
+  });
+
+  final List<_RingState> rings;
+  final double now;
+  final double ringLifetime;
+  final Color lineColor;
+  final Color dimColor;
+
+  double _scale(Size size) => size.shortestSide / 100;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final scale = _scale(size);
+    final center = Offset(size.width / 2, size.height / 2);
+
+    canvas.drawCircle(
+      center,
+      2 * scale,
+      Paint()..color = lineColor,
+    );
+
+    for (final ring in rings) {
+      final age = now - ring.birthTime;
+      if (age < 0 || age > ringLifetime) continue;
+
+      final t = age / ringLifetime;
+      final radius = 48 * Curves.easeOut.transform(t) * scale;
+      final opacity = 0.8 * (1.0 - Curves.easeIn.transform(t));
+      if (opacity <= 0 || radius <= 0) continue;
+
+      final baseColor = Color.lerp(lineColor, dimColor, ring.shade)!;
+
+      if (ring.outcome == BurstRingOutcome.succeeded) {
+        canvas.drawCircle(
+          center,
+          radius,
+          Paint()
+            ..color = baseColor.withValues(alpha: opacity)
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = 1,
+        );
+      } else {
+        final failColor = Color.lerp(dimColor, lineColor, ring.shade * 0.3)!;
+        final path = Path()
+          ..addOval(Rect.fromCircle(center: center, radius: radius));
+        drawDashedPath(
+          canvas,
+          path,
+          Paint()
+            ..color = failColor.withValues(alpha: opacity)
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = 1,
+          dash: 4 * scale,
+          gap: 4 * scale,
+        );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_BurstPulsePainter old) => true;
+}

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -13,7 +13,6 @@ import 'package:crypto_mobile_app/features/challenges/screens/challenges_screen.
 import 'package:crypto_mobile_app/core/config/l10n/app_localizations.dart';
 import 'package:crypto_mobile_app/features/home/home_tab_provider.dart';
 import 'package:crypto_mobile_app/core/providers/providers.dart';
-import 'package:crypto_mobile_app/core/config/legacy_colors.dart';
 import 'package:crypto_mobile_app/features/zkpassport/data/models/zkpassport_models.dart';
 import 'package:crypto_mobile_app/features/zkpassport/providers/zkpassport_flow_provider.dart';
 import 'package:crypto_mobile_app/features/zk_identity/providers/zk_identity_providers.dart';
@@ -80,7 +79,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     final l10n = AppLocalizations.of(context);
     final currentNetwork = ref.watch(currentNetworkProvider);
     final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
     final index = ref.watch(currentHomeTabProvider);
     final isInternal = currentNetwork == 'internal';
 
@@ -108,7 +106,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
         semantic,
         index,
         isInternal,
-        isDark,
       ),
     );
   }
@@ -118,7 +115,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     AppSemanticColors semantic,
     int index,
     bool isInternal,
-    bool isDark,
   ) {
     final items = [
       BottomNavItem(
@@ -170,10 +166,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     if (isInternal) {
       bottomNav = DecoratedBox(
         decoration: BoxDecoration(
-          color: LegacyColors.getInternalNetworkBackgroundColor(isDark),
+          color: semantic.warning.colorSurface,
           border: Border(
             top: BorderSide(
-              color: LegacyColors.getInternalNetworkBorderColor(isDark),
+              color: semantic.warning.colorContainer,
             ),
           ),
         ),

--- a/test/core/services/block_production_alarm_audit_service_test.dart
+++ b/test/core/services/block_production_alarm_audit_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:crypto_mobile_app/core/config/app_config.dart';
 import 'package:crypto_mobile_app/core/services/android_foreground_task_controller.dart';
 import 'package:crypto_mobile_app/core/services/block_production_alarm_audit_service.dart';
 import 'package:crypto_mobile_app/core/services/observability_reporting_service.dart';
@@ -197,10 +198,24 @@ void main() {
       expect(retryCallbacks, hasLength(1));
     });
 
-    test('foreground resume lead is four minutes in production', () {
+    test('foreground resume lead is five minutes in production', () {
       expect(
         AndroidForegroundTaskController.foregroundResumeLead,
-        const Duration(minutes: 4),
+        const Duration(minutes: 5),
+      );
+    });
+
+    test('slot wake lead is five minutes in production', () {
+      expect(
+        AppConfig.blockProductionWakeBeforeSlot,
+        const Duration(minutes: 5),
+      );
+    });
+
+    test('post-production hold is two minutes in production', () {
+      expect(
+        AndroidForegroundTaskController.postProductionHold,
+        const Duration(minutes: 2),
       );
     });
 

--- a/test/design_system/parallax_surface_layout_test.dart
+++ b/test/design_system/parallax_surface_layout_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:crypto_mobile_app/design_system/design_system.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
This PR gives mobile block producers more time to wake up before a won slot.
It changes both wake paths to start 5 minutes before slot time:
- slot wake alarms
- foreground resume alarms
- 
It also keeps the app awake briefly after producing our own block, so the node has time to finish broadcasting before sleep logic can pause it again.

**Why**
Some Android devices deliver background alarms late. Waking only 1 minute before the slot left too little margin. Moving to 5 minutes gives delayed alarms more room to still arrive before block production time.