### PR TITLE
Fix Android alarm delivery and slot notification handling

### DIFF
--- a/android/app/src/main/kotlin/com/example/mobile_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mobile_app/MainActivity.kt
@@ -121,8 +121,11 @@ class MainActivity: FlutterActivity() {
     private fun handleAlarmIntent(intent: Intent?) {
         intent?.let {
             if (it.action == "com.usernode.app.SLOT_ALARM") {
-                val slotNumber = it.getIntExtra("slotNumber", -1)
-                if (slotNumber != -1) {
+                val globalSlot = it.getIntExtra(
+                    "globalSlot",
+                    it.getIntExtra("slotNumber", -1)
+                )
+                if (globalSlot != -1) {
                     // Alarm fired - Flutter will handle via AlarmReceiver callback
                 }
             }

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmLedger.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmLedger.kt
@@ -17,7 +17,7 @@ class AlarmLedger(context: Context) {
 
     fun recordScheduled(
         alarmId: String,
-        slotNumber: Int,
+        globalSlot: Int,
         triggerAtMs: Long,
         scheduledAtMs: Long,
         scheduledElapsedRealtimeMs: Long,
@@ -28,7 +28,7 @@ class AlarmLedger(context: Context) {
     ) {
         val json = JSONObject()
         json.put("alarmId", alarmId)
-        json.put("slotNumber", slotNumber)
+        json.put("globalSlot", globalSlot)
         json.put("scheduledAtMs", scheduledAtMs)
         json.put("triggerAtMs", triggerAtMs)
         json.put("nativeTriggerAtMs", triggerAtMs)
@@ -44,7 +44,7 @@ class AlarmLedger(context: Context) {
 
     fun recordScheduleFailed(
         alarmId: String,
-        slotNumber: Int,
+        globalSlot: Int,
         triggerAtMs: Long,
         scheduledAtMs: Long,
         scheduledElapsedRealtimeMs: Long,
@@ -56,7 +56,7 @@ class AlarmLedger(context: Context) {
     ) {
         val json = JSONObject()
         json.put("alarmId", alarmId)
-        json.put("slotNumber", slotNumber)
+        json.put("globalSlot", globalSlot)
         json.put("scheduledAtMs", scheduledAtMs)
         json.put("triggerAtMs", triggerAtMs)
         json.put("nativeTriggerAtMs", triggerAtMs)
@@ -73,7 +73,7 @@ class AlarmLedger(context: Context) {
 
     fun recordReceiverEntered(
         alarmId: String,
-        slotNumber: Int,
+        globalSlot: Int,
         alarmTimeMs: Long,
         nativeTriggerAtMs: Long?,
         receiverEnteredAtMs: Long,
@@ -82,14 +82,13 @@ class AlarmLedger(context: Context) {
         nativeDeliveryLatencyMs: Long?,
         elapsedDeliveryLatencyMs: Long?,
         triggerElapsedRealtimeMs: Long?,
-        globalSlot: Long?,
         purpose: String?,
         schedulerReason: String?,
         nodeRunning: Boolean
     ) {
         val json = read(alarmId)
         json.put("alarmId", alarmId)
-        json.put("slotNumber", slotNumber)
+        json.put("globalSlot", globalSlot)
         if (alarmTimeMs > 0) {
             json.put("alarmTimeMs", alarmTimeMs)
             if (!json.has("triggerAtMs")) {
@@ -110,7 +109,6 @@ class AlarmLedger(context: Context) {
         nativeDeliveryLatencyMs?.let { json.put("nativeDeliveryLatencyMs", it) }
         elapsedDeliveryLatencyMs?.let { json.put("elapsedDeliveryLatencyMs", it) }
         json.put("nodeRunning", nodeRunning)
-        globalSlot?.let { json.put("globalSlot", it) }
         purpose?.let { json.put("purpose", it) }
         schedulerReason?.let { json.put("schedulerReason", it) }
         save(alarmId, json)

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmMethodChannelHandler.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmMethodChannelHandler.kt
@@ -150,18 +150,19 @@ class AlarmMethodChannelHandler(context: Context) {
             "scheduleExactAlarm" -> {
                 val alarmId = call.argument<String>("alarmId")
                 val delayMs = call.argument<Number>("delayMs")?.toLong()
-                val slotNumber = call.argument<Int>("slotNumber")
+                val globalSlot = call.argument<Number>("globalSlot")?.toInt()
+                    ?: call.argument<Number>("slotNumber")?.toInt()
                 val data = call.argument<Map<String, Any>>("data")
 
-                if (alarmId == null || slotNumber == null || delayMs == null) {
-                    result.error("INVALID_ARGS", "Missing required delayMs argument", null)
+                if (alarmId == null || globalSlot == null || delayMs == null) {
+                    result.error("INVALID_ARGS", "Missing required alarmId/globalSlot/delayMs arguments", null)
                     return
                 }
 
                 val success = alarmScheduler.scheduleExactAlarm(
                     alarmId = alarmId,
                     delayMs = delayMs,
-                    slotNumber = slotNumber,
+                    globalSlot = globalSlot,
                     data = data ?: emptyMap()
                 )
                 result.success(success)
@@ -201,9 +202,10 @@ class AlarmMethodChannelHandler(context: Context) {
             "startForegroundService" -> {
                 val title = call.argument<String>("title")
                 val message = call.argument<String>("message")
-                val slotNumber = call.argument<Int>("slotNumber")
+                val globalSlot = call.argument<Number>("globalSlot")?.toInt()
+                    ?: call.argument<Number>("slotNumber")?.toInt()
 
-                if (title == null || message == null || slotNumber == null) {
+                if (title == null || message == null || globalSlot == null) {
                     result.error("INVALID_ARGS", "Missing required arguments", null)
                     return
                 }
@@ -211,7 +213,7 @@ class AlarmMethodChannelHandler(context: Context) {
                 val success = foregroundServiceManager.startForegroundService(
                     title = title,
                     message = message,
-                    slotNumber = slotNumber
+                    globalSlot = globalSlot
                 )
                 result.success(success)
             }

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmReceiver.kt
@@ -45,27 +45,24 @@ class AlarmReceiver : BroadcastReceiver() {
 
     private fun handleSlotAlarm(context: Context, intent: Intent) {
         val alarmId = intent.getStringExtra("alarmId")
-        val slotNumber = intent.getIntExtra("slotNumber", -1)
+        val globalSlot = readGlobalSlotExtra(intent)
         val scheduledTimeMs = intent.getLongExtra("alarmTimeMs", -1L)
         val nativeScheduledAtMs = optionalLongExtra(intent, "nativeScheduledAtMs")
         val scheduledElapsedRealtimeMs = optionalLongExtra(intent, "scheduledElapsedRealtimeMs")
         val nativeTriggerAtMs = optionalLongExtra(intent, "nativeTriggerAtMs")
         val triggerElapsedRealtimeMs = optionalLongExtra(intent, "triggerElapsedRealtimeMs")
         val nodeRunning = intent.getBooleanExtra("nodeRunning", false)
-        val globalSlot = optionalLongExtra(intent, "globalSlot")
-            ?: optionalLongExtra(intent, "global_slot")
-            ?: slotNumber.takeIf { it > 0 }?.toLong()
         val reason = intent.getStringExtra("reason")
         val purpose = intent.getStringExtra("purpose")
 
-        Log.d(TAG, "[AlarmReceiver] Slot alarm details - ID: $alarmId, Slot: $slotNumber, Scheduled: $scheduledTimeMs")
+        Log.d(TAG, "[AlarmReceiver] Slot alarm details - ID: $alarmId, GlobalSlot: $globalSlot, Scheduled: $scheduledTimeMs")
 
         if (alarmId == null) {
             Log.e(TAG, "[AlarmReceiver] Missing alarmId in intent")
             return
         }
-        if (slotNumber == -1) {
-            Log.e(TAG, "[AlarmReceiver] Missing or invalid slotNumber in intent")
+        if (globalSlot == null) {
+            Log.e(TAG, "[AlarmReceiver] Missing or invalid globalSlot in intent")
             return
         }
 
@@ -77,7 +74,7 @@ class AlarmReceiver : BroadcastReceiver() {
             triggerElapsedRealtimeMs?.let { receiverElapsedRealtimeMs - it }
         AlarmLedger(context).recordReceiverEntered(
             alarmId = alarmId,
-            slotNumber = slotNumber,
+            globalSlot = globalSlot,
             alarmTimeMs = scheduledTimeMs,
             nativeTriggerAtMs = nativeTriggerAtMs,
             receiverEnteredAtMs = currentTime,
@@ -86,12 +83,11 @@ class AlarmReceiver : BroadcastReceiver() {
             nativeDeliveryLatencyMs = nativeDeliveryLatencyMs,
             elapsedDeliveryLatencyMs = elapsedDeliveryLatencyMs,
             triggerElapsedRealtimeMs = triggerElapsedRealtimeMs,
-            globalSlot = globalSlot,
             purpose = purpose,
             schedulerReason = reason,
             nodeRunning = nodeRunning
         )
-        Log.i(TAG, "[AlarmReceiver] ✓ Slot alarm FIRED for slot $slotNumber (latency: ${latencyMs}ms)")
+        Log.i(TAG, "[AlarmReceiver] ✓ Slot alarm FIRED for global slot $globalSlot (latency: ${latencyMs}ms)")
 
         // Take the native wakelock before handing control to Flutter so the
         // inactivity sleep path cannot win a race against alarm recovery.
@@ -99,7 +95,7 @@ class AlarmReceiver : BroadcastReceiver() {
 
         val eventData = mutableMapOf<String, Any?>(
             "alarmId" to alarmId,
-            "slotNumber" to slotNumber,
+            "globalSlot" to globalSlot,
             "alarmTimeMs" to scheduledTimeMs,
             "firedAtMs" to currentTime,
             "latencyMs" to latencyMs,
@@ -114,7 +110,6 @@ class AlarmReceiver : BroadcastReceiver() {
         eventData["receiverElapsedRealtimeMs"] = receiverElapsedRealtimeMs
         nativeDeliveryLatencyMs?.let { eventData["nativeDeliveryLatencyMs"] = it }
         elapsedDeliveryLatencyMs?.let { eventData["elapsedDeliveryLatencyMs"] = it }
-        globalSlot?.let { eventData["globalSlot"] = it }
         reason?.let { eventData["reason"] = it }
         purpose?.let { eventData["purpose"] = it }
 
@@ -137,7 +132,7 @@ class AlarmReceiver : BroadcastReceiver() {
         val serviceIntent = Intent(context, SlotMonitoringService::class.java).apply {
             action = SlotMonitoringService.ACTION_START_MONITORING
             putExtra("alarmId", alarmId)
-            putExtra("slotNumber", slotNumber)
+            putExtra("globalSlot", globalSlot)
             putExtra("nodeRunning", nodeRunning)
             putExtra("alarmTimeMs", scheduledTimeMs)
             nativeScheduledAtMs?.let { putExtra("nativeScheduledAtMs", it) }
@@ -147,7 +142,6 @@ class AlarmReceiver : BroadcastReceiver() {
             putExtra("receiverElapsedRealtimeMs", receiverElapsedRealtimeMs)
             nativeDeliveryLatencyMs?.let { putExtra("nativeDeliveryLatencyMs", it) }
             elapsedDeliveryLatencyMs?.let { putExtra("elapsedDeliveryLatencyMs", it) }
-            globalSlot?.let { putExtra("globalSlot", it) }
             reason?.let { putExtra("reason", it) }
             purpose?.let { putExtra("purpose", it) }
         }
@@ -171,7 +165,7 @@ class AlarmReceiver : BroadcastReceiver() {
         startMonitoringService(
             context = context,
             alarmId = "boot_completed",
-            slotNumber = 0,
+            globalSlot = 0,
             nodeRunning = false
         )
     }
@@ -182,7 +176,7 @@ class AlarmReceiver : BroadcastReceiver() {
         startMonitoringService(
             context = context,
             alarmId = "package_replaced",
-            slotNumber = 0,
+            globalSlot = 0,
             nodeRunning = false
         )
     }
@@ -238,13 +232,13 @@ class AlarmReceiver : BroadcastReceiver() {
     private fun startMonitoringService(
         context: Context,
         alarmId: String,
-        slotNumber: Int,
+        globalSlot: Int,
         nodeRunning: Boolean
     ) {
         val serviceIntent = Intent(context, SlotMonitoringService::class.java).apply {
             action = SlotMonitoringService.ACTION_START_MONITORING
             putExtra("alarmId", alarmId)
-            putExtra("slotNumber", slotNumber)
+            putExtra("globalSlot", globalSlot)
             putExtra("nodeRunning", nodeRunning)
         }
 
@@ -254,12 +248,12 @@ class AlarmReceiver : BroadcastReceiver() {
             context.startService(serviceIntent)
         }
 
-        Log.i(TAG, "SlotMonitoringService started (alarmId=$alarmId, slot=$slotNumber)")
+        Log.i(TAG, "SlotMonitoringService started (alarmId=$alarmId, globalSlot=$globalSlot)")
     }
 
     private fun showFallbackNotification(
         context: Context,
-        slotNumber: Int,
+        globalSlot: Int,
         scheduledTimeMs: Long
     ) {
         val channelId = "slot_alarm_fallback"
@@ -275,7 +269,7 @@ class AlarmReceiver : BroadcastReceiver() {
 
         val launchIntent = Intent(context, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra("slotNumber", slotNumber)
+            putExtra("globalSlot", globalSlot)
             putExtra("fromAlarm", true)
         }
         val piFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
@@ -283,9 +277,9 @@ class AlarmReceiver : BroadcastReceiver() {
 
         val scheduledTimeText = AlarmTimeFormatter.formatScheduledTime(scheduledTimeMs)
         val message = if (scheduledTimeText != null) {
-            "Resumed for slot $slotNumber (scheduled $scheduledTimeText)"
+            "Resumed for slot $globalSlot (scheduled $scheduledTimeText)"
         } else {
-            "Resumed for slot $slotNumber"
+            "Resumed for slot $globalSlot"
         }
 
         val notification = NotificationCompat.Builder(context, channelId)
@@ -297,7 +291,26 @@ class AlarmReceiver : BroadcastReceiver() {
             .setContentIntent(pendingIntent)
             .build()
 
-        nm.notify(slotNumber, notification)
+        nm.notify(globalSlot, notification)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun readGlobalSlotExtra(intent: Intent): Int? {
+        return numberExtra(intent, "globalSlot")
+            ?: numberExtra(intent, "global_slot")
+            ?: numberExtra(intent, "slotNumber")
+    }
+
+    @Suppress("DEPRECATION")
+    private fun numberExtra(intent: Intent, key: String): Int? {
+        val value = intent.extras?.get(key) ?: return null
+        return when (value) {
+            is Int -> value
+            is Long -> value.toInt()
+            is Number -> value.toInt()
+            is String -> value.toIntOrNull()
+            else -> null
+        }?.takeIf { it >= 0 }
     }
 
     @Suppress("DEPRECATION")

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmScheduler.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmScheduler.kt
@@ -22,6 +22,7 @@ class AlarmScheduler(
         private const val SCHEDULED_ALARMS_KEY = "scheduled_alarms"
         private const val SCHEDULED_CHANNEL_ID = "slot_alarm_scheduled"
         private const val SCHEDULED_CHANNEL_NAME = "Scheduled Slot Alarms"
+        private const val SCHEDULED_NOTIFICATION_ID = 1002
     }
 
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -137,7 +138,7 @@ class AlarmScheduler(
             )
             Log.d(TAG, "[AlarmScheduler] Alarm saved to SharedPreferences")
 
-            showScheduledNotification(alarmId, globalSlot, triggerAtMs)
+            showScheduledNotification(globalSlot, triggerAtMs)
 
             Log.i(TAG, "[AlarmScheduler] ✓ Successfully scheduled exact alarm for global slot $globalSlot at $triggerAtMs (in ${effectiveDelayMs/1000}s)")
             return true
@@ -276,7 +277,6 @@ class AlarmScheduler(
     }
 
     private fun showScheduledNotification(
-        alarmId: String,
         globalSlot: Int,
         alarmTimeMs: Long
     ) {
@@ -306,7 +306,7 @@ class AlarmScheduler(
                 .setAutoCancel(true)
                 .build()
 
-            nm.notify(alarmId.hashCode(), notification)
+            nm.notify(SCHEDULED_NOTIFICATION_ID, notification)
         } catch (e: Exception) {
             Log.w(TAG, "[AlarmScheduler] Failed to show scheduled notification", e)
         }

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmScheduler.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/AlarmScheduler.kt
@@ -30,11 +30,11 @@ class AlarmScheduler(
     fun scheduleExactAlarm(
         alarmId: String,
         delayMs: Long,
-        slotNumber: Int,
+        globalSlot: Int,
         data: Map<String, Any>
     ): Boolean {
         try {
-            Log.d(TAG, "[AlarmScheduler] Attempting to schedule alarm - ID: $alarmId, Slot: $slotNumber, Delay: $delayMs")
+            Log.d(TAG, "[AlarmScheduler] Attempting to schedule alarm - ID: $alarmId, GlobalSlot: $globalSlot, Delay: $delayMs")
 
             val currentTime = System.currentTimeMillis()
             val scheduledElapsedRealtimeMs = SystemClock.elapsedRealtime()
@@ -50,7 +50,7 @@ class AlarmScheduler(
                     Log.w(TAG, "[AlarmScheduler] Cannot schedule exact alarms - permission not granted")
                     ledger.recordScheduleFailed(
                         alarmId = alarmId,
-                        slotNumber = slotNumber,
+                        globalSlot = globalSlot,
                         triggerAtMs = triggerAtMs,
                         scheduledAtMs = currentTime,
                         scheduledElapsedRealtimeMs = scheduledElapsedRealtimeMs,
@@ -71,7 +71,7 @@ class AlarmScheduler(
             val intent = Intent(context, AlarmReceiver::class.java).apply {
                 action = "com.usernode.app.SLOT_ALARM"
                 putExtra("alarmId", alarmId)
-                putExtra("slotNumber", slotNumber)
+                putExtra("globalSlot", globalSlot)
                 putExtra("alarmTimeMs", triggerAtMs)
                 // Fan out provided data map into intent extras for downstream consumers
                 for ((key, value) in data) {
@@ -123,10 +123,10 @@ class AlarmScheduler(
             }
 
             // Save alarm ID for tracking
-            saveScheduledAlarm(alarmId, slotNumber)
+            saveScheduledAlarm(alarmId, globalSlot)
             ledger.recordScheduled(
                 alarmId = alarmId,
-                slotNumber = slotNumber,
+                globalSlot = globalSlot,
                 triggerAtMs = triggerAtMs,
                 scheduledAtMs = currentTime,
                 scheduledElapsedRealtimeMs = scheduledElapsedRealtimeMs,
@@ -137,12 +137,12 @@ class AlarmScheduler(
             )
             Log.d(TAG, "[AlarmScheduler] Alarm saved to SharedPreferences")
 
-            showScheduledNotification(alarmId, slotNumber, triggerAtMs)
+            showScheduledNotification(alarmId, globalSlot, triggerAtMs)
 
-            Log.i(TAG, "[AlarmScheduler] ✓ Successfully scheduled exact alarm for slot $slotNumber at $triggerAtMs (in ${effectiveDelayMs/1000}s)")
+            Log.i(TAG, "[AlarmScheduler] ✓ Successfully scheduled exact alarm for global slot $globalSlot at $triggerAtMs (in ${effectiveDelayMs/1000}s)")
             return true
         } catch (e: Exception) {
-            Log.e(TAG, "[AlarmScheduler] ✗ Error scheduling exact alarm for slot $slotNumber", e)
+            Log.e(TAG, "[AlarmScheduler] ✗ Error scheduling exact alarm for global slot $globalSlot", e)
             return false
         }
     }
@@ -240,9 +240,9 @@ class AlarmScheduler(
         }
     }
 
-    private fun saveScheduledAlarm(alarmId: String, slotNumber: Int) {
+    private fun saveScheduledAlarm(alarmId: String, globalSlot: Int) {
         val alarms = getScheduledAlarms().toMutableMap()
-        alarms[alarmId] = slotNumber
+        alarms[alarmId] = globalSlot
         prefs.edit()
             .putString(SCHEDULED_ALARMS_KEY, alarms.entries.joinToString(",") { "${it.key}:${it.value}" })
             .apply()
@@ -277,7 +277,7 @@ class AlarmScheduler(
 
     private fun showScheduledNotification(
         alarmId: String,
-        slotNumber: Int,
+        globalSlot: Int,
         alarmTimeMs: Long
     ) {
         try {
@@ -292,12 +292,11 @@ class AlarmScheduler(
             }
 
             val scheduledText = AlarmTimeFormatter.formatScheduledTime(alarmTimeMs)
-            // val message = if (scheduledText != null) {
-            //     "Scheduled slot $slotNumber at $scheduledText"
-            // } else {
-            //     "Scheduled slot $slotNumber"
-            // }
-            val message = "wakeup at $scheduledText"
+            val message = if (scheduledText != null) {
+                "Slot $globalSlot wakeup at $scheduledText"
+            } else {
+                "Slot $globalSlot wakeup scheduled"
+            }
 
             val notification = NotificationCompat.Builder(context, SCHEDULED_CHANNEL_ID)
                 .setSmallIcon(R.drawable.launch_background)

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/ForegroundServiceManager.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/ForegroundServiceManager.kt
@@ -10,11 +10,11 @@ class ForegroundServiceManager(private val context: Context) {
         private const val TAG = "usernode/ForegroundServiceMgr"
     }
 
-    fun startForegroundService(title: String, message: String, slotNumber: Int): Boolean {
+    fun startForegroundService(title: String, message: String, globalSlot: Int): Boolean {
         return try {
             val intent = Intent(context, SlotMonitoringService::class.java).apply {
                 action = SlotMonitoringService.ACTION_START_MONITORING
-                putExtra("slotNumber", slotNumber)
+                putExtra("globalSlot", globalSlot)
                 putExtra("title", title)
                 putExtra("message", message)
             }
@@ -25,7 +25,7 @@ class ForegroundServiceManager(private val context: Context) {
                 context.startService(intent)
             }
 
-            Log.i(TAG, "Started foreground service for slot $slotNumber")
+            Log.i(TAG, "Started foreground service for global slot $globalSlot")
             true
         } catch (e: Exception) {
             Log.e(TAG, "Error starting foreground service", e)

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
@@ -51,30 +51,6 @@ class SlotMonitoringService : Service() {
             Log.w(TAG, "[SlotMonitoringService] Received null intent in onStartCommand")
 
             startMonitoring(0, false)
-            val firedAtMs = System.currentTimeMillis()
-
-            val eventData = mapOf(
-                "alarmId" to "slot_monitoring_null_intent",
-                "slotNumber" to 0,
-                "firedAtMs" to firedAtMs,
-                "batteryLevel" to 0,
-                "networkState" to "unknown",
-                "nodeRunning" to false
-            )
-
-            // Enforce a single-engine policy:
-            // - If the UI engine/channel exists, deliver the event through it (no headless engine).
-            // - Otherwise, spin up the headless engine to deliver the alarm event.
-            val handler = AlarmMethodChannelHandler.getInstance()
-            if (handler != null && handler.isActivityAttached()) {
-                handler.sendEventToFlutter("android_alarm_fired", eventData)
-            } else {
-                BackgroundAlarmEngine.sendAlarmEvent(
-                    applicationContext,
-                    "android_alarm_fired",
-                    eventData
-                )
-            }
             return START_STICKY
         }
 
@@ -84,60 +60,11 @@ class SlotMonitoringService : Service() {
                 val alarmId = intent.getStringExtra("alarmId")
                 val nodeRunning = intent.getBooleanExtra("nodeRunning", false)
                 val alarmTimeMs = intent.getLongExtra("alarmTimeMs", -1L)
-                val nativeScheduledAtMs = optionalLongExtra(intent, "nativeScheduledAtMs")
-                val scheduledElapsedRealtimeMs = optionalLongExtra(intent, "scheduledElapsedRealtimeMs")
-                val nativeTriggerAtMs = optionalLongExtra(intent, "nativeTriggerAtMs")
-                val triggerElapsedRealtimeMs = optionalLongExtra(intent, "triggerElapsedRealtimeMs")
-                val receiverElapsedRealtimeMs = optionalLongExtra(intent, "receiverElapsedRealtimeMs")
-                val nativeDeliveryLatencyMs = optionalLongExtra(intent, "nativeDeliveryLatencyMs")
-                val elapsedDeliveryLatencyMs = optionalLongExtra(intent, "elapsedDeliveryLatencyMs")
-                val reason = intent.getStringExtra("reason")
-                val purpose = intent.getStringExtra("purpose")
                 Log.d(TAG, "[SlotMonitoringService] START_MONITORING - Slot: $slotNumber, AlarmId: $alarmId, nodeRunning=$nodeRunning")
 
                 // Allow alarmId-only wake (e.g., fg_resume) by using 0 as placeholder
                 val safeSlot = if (slotNumber != -1) slotNumber else 0
-                val globalSlot = optionalLongExtra(intent, "globalSlot")
-                    ?: optionalLongExtra(intent, "global_slot")
-                    ?: safeSlot.takeIf { it > 0 }?.toLong()
                 startMonitoring(safeSlot, nodeRunning, alarmTimeMs)
-                val firedAtMs = System.currentTimeMillis()
-                val latencyMs = if (alarmTimeMs > 0) firedAtMs - alarmTimeMs else 0L
-
-                val eventData = mutableMapOf<String, Any?>(
-                    "alarmId" to (alarmId ?: "unknown"),
-                    "slotNumber" to safeSlot,
-                    "alarmTimeMs" to alarmTimeMs,
-                    "firedAtMs" to firedAtMs,
-                    "latencyMs" to latencyMs,
-                    "batteryLevel" to 0,
-                    "networkState" to "unknown",
-                    "nodeRunning" to nodeRunning
-                )
-                nativeScheduledAtMs?.let { eventData["nativeScheduledAtMs"] = it }
-                scheduledElapsedRealtimeMs?.let { eventData["scheduledElapsedRealtimeMs"] = it }
-                nativeTriggerAtMs?.let { eventData["nativeTriggerAtMs"] = it }
-                triggerElapsedRealtimeMs?.let { eventData["triggerElapsedRealtimeMs"] = it }
-                receiverElapsedRealtimeMs?.let { eventData["receiverElapsedRealtimeMs"] = it }
-                nativeDeliveryLatencyMs?.let { eventData["nativeDeliveryLatencyMs"] = it }
-                elapsedDeliveryLatencyMs?.let { eventData["elapsedDeliveryLatencyMs"] = it }
-                globalSlot?.let { eventData["globalSlot"] = it }
-                reason?.let { eventData["reason"] = it }
-                purpose?.let { eventData["purpose"] = it }
-
-                // Enforce a single-engine policy:
-                // - If the UI engine/channel exists, deliver the event through it (no headless engine).
-                // - Otherwise, spin up the headless engine to deliver the alarm event.
-                val handler = AlarmMethodChannelHandler.getInstance()
-                if (handler != null && handler.isActivityAttached()) {
-                    handler.sendEventToFlutter("android_alarm_fired", eventData)
-                } else {
-                    BackgroundAlarmEngine.sendAlarmEvent(
-                        applicationContext,
-                        "android_alarm_fired",
-                        eventData
-                    )
-                }
             }
             ACTION_STOP_MONITORING -> {
                 Log.d(TAG, "[SlotMonitoringService] STOP_MONITORING action received")
@@ -275,19 +202,6 @@ class SlotMonitoringService : Service() {
             isPersistentMode = false
             isPersistentModeActive = false
         }
-    }
-
-    @Suppress("DEPRECATION")
-    private fun optionalLongExtra(intent: Intent, key: String): Long? {
-        if (!intent.hasExtra(key)) return null
-        val value = intent.extras?.get(key) ?: return null
-        return when (value) {
-            is Int -> value.toLong()
-            is Long -> value
-            is Number -> value.toLong()
-            is String -> value.toLongOrNull()
-            else -> null
-        }?.takeIf { it > 0 }
     }
 
     private fun stopPersistentMode() {

--- a/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
+++ b/android/app/src/main/kotlin/com/usernode_labs/usernode/alarm/SlotMonitoringService.kt
@@ -31,7 +31,7 @@ class SlotMonitoringService : Service() {
             private set
     }
 
-    private var currentSlotNumber: Int? = null
+    private var currentGlobalSlot: Int? = null
     private var isPersistentMode = false
 
     override fun onCreate() {
@@ -56,15 +56,14 @@ class SlotMonitoringService : Service() {
 
         when (intent.action) {
             ACTION_START_MONITORING -> {
-                val slotNumber = intent.getIntExtra("slotNumber", -1)
+                val globalSlot = readGlobalSlotExtra(intent) ?: 0
                 val alarmId = intent.getStringExtra("alarmId")
                 val nodeRunning = intent.getBooleanExtra("nodeRunning", false)
                 val alarmTimeMs = intent.getLongExtra("alarmTimeMs", -1L)
-                Log.d(TAG, "[SlotMonitoringService] START_MONITORING - Slot: $slotNumber, AlarmId: $alarmId, nodeRunning=$nodeRunning")
+                Log.d(TAG, "[SlotMonitoringService] START_MONITORING - GlobalSlot: $globalSlot, AlarmId: $alarmId, nodeRunning=$nodeRunning")
 
                 // Allow alarmId-only wake (e.g., fg_resume) by using 0 as placeholder
-                val safeSlot = if (slotNumber != -1) slotNumber else 0
-                startMonitoring(safeSlot, nodeRunning, alarmTimeMs)
+                startMonitoring(globalSlot, nodeRunning, alarmTimeMs)
             }
             ACTION_STOP_MONITORING -> {
                 Log.d(TAG, "[SlotMonitoringService] STOP_MONITORING action received")
@@ -87,13 +86,13 @@ class SlotMonitoringService : Service() {
         return START_STICKY
     }
 
-    private fun startMonitoring(slotNumber: Int, nodeRunning: Boolean, alarmTimeMs: Long = -1L) {
-        currentSlotNumber = slotNumber
-        Log.i(TAG, "[SlotMonitoringService] ✓ Starting foreground monitoring for slot $slotNumber")
+    private fun startMonitoring(globalSlot: Int, nodeRunning: Boolean, alarmTimeMs: Long = -1L) {
+        currentGlobalSlot = globalSlot
+        Log.i(TAG, "[SlotMonitoringService] ✓ Starting foreground monitoring for global slot $globalSlot")
 
         val scheduledTime = AlarmTimeFormatter.formatScheduledTime(alarmTimeMs)
         val baseMessage = if (nodeRunning) {
-            "Monitoring slot $slotNumber for block production"
+            "Monitoring slot $globalSlot for block production"
         } else {
             "Warming up node to monitor slots"
         }
@@ -115,7 +114,7 @@ class SlotMonitoringService : Service() {
 
             // Send event to Flutter
             Log.d(TAG, "[SlotMonitoringService] Sending android_foreground_service_started event to Flutter")
-            val eventData = mapOf("slotNumber" to slotNumber)
+            val eventData = mapOf("globalSlot" to globalSlot)
             val handler = AlarmMethodChannelHandler.getInstance()
             if (handler != null && handler.isActivityAttached()) {
                 handler.sendEventToFlutter("android_foreground_service_started", eventData)
@@ -133,8 +132,8 @@ class SlotMonitoringService : Service() {
     }
 
     private fun stopMonitoring() {
-        val slotBeingStopped = currentSlotNumber
-        Log.i(TAG, "[SlotMonitoringService] Stopping foreground monitoring for slot $slotBeingStopped")
+        val globalSlotBeingStopped = currentGlobalSlot
+        Log.i(TAG, "[SlotMonitoringService] Stopping foreground monitoring for global slot $globalSlotBeingStopped")
 
         try {
             stopForeground(STOP_FOREGROUND_REMOVE)
@@ -143,7 +142,7 @@ class SlotMonitoringService : Service() {
 
             // Send event to Flutter
             Log.d(TAG, "[SlotMonitoringService] Sending android_foreground_service_stopped event to Flutter")
-            val eventData = mapOf("slotNumber" to slotBeingStopped)
+            val eventData = mapOf("globalSlot" to globalSlotBeingStopped)
             val handler = AlarmMethodChannelHandler.getInstance()
             if (handler != null && handler.isActivityAttached()) {
                 handler.sendEventToFlutter("android_foreground_service_stopped", eventData)
@@ -158,7 +157,7 @@ class SlotMonitoringService : Service() {
             Log.e(TAG, "[SlotMonitoringService] Error stopping foreground", e)
         }
 
-        currentSlotNumber = null
+        currentGlobalSlot = null
 
         try {
             stopSelf()
@@ -166,6 +165,25 @@ class SlotMonitoringService : Service() {
         } catch (e: Exception) {
             Log.e(TAG, "[SlotMonitoringService] Error calling stopSelf()", e)
         }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun readGlobalSlotExtra(intent: Intent): Int? {
+        return numberExtra(intent, "globalSlot")
+            ?: numberExtra(intent, "global_slot")
+            ?: numberExtra(intent, "slotNumber")
+    }
+
+    @Suppress("DEPRECATION")
+    private fun numberExtra(intent: Intent, key: String): Int? {
+        val value = intent.extras?.get(key) ?: return null
+        return when (value) {
+            is Int -> value
+            is Long -> value.toInt()
+            is Number -> value.toInt()
+            is String -> value.toIntOrNull()
+            else -> null
+        }?.takeIf { it >= 0 }
     }
 
     private fun startPersistentMode() {
@@ -248,7 +266,7 @@ class SlotMonitoringService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
-        Log.i(TAG, "[SlotMonitoringService] ✗ Service onDestroy() - Slot: $currentSlotNumber, Time: ${System.currentTimeMillis()}")
+        Log.i(TAG, "[SlotMonitoringService] Service onDestroy() - GlobalSlot: $currentGlobalSlot, Time: ${System.currentTimeMillis()}")
         Log.d(TAG, "[SlotMonitoringService] Service destroyed, monitoring ended")
         isForegroundServiceActive = false
     }

--- a/lib/core/bootstrap/app_bootstrap.dart
+++ b/lib/core/bootstrap/app_bootstrap.dart
@@ -323,6 +323,7 @@ class AppBootstrap {
       if (!nodeWasRunning) {
         log.info('Backend not running, initializing...');
         await RustBackendService.instance.init();
+        await PlatformAlarmService.instance.markReadyForNativeEvents();
         log.info('FRB initialized, starting node...');
         final started = await RustBackendService.instance.startNode();
         log.info(
@@ -338,6 +339,7 @@ class AppBootstrap {
         }
       } else {
         log.info('Backend already running, skipping start');
+        await PlatformAlarmService.instance.markReadyForNativeEvents();
         await ObservabilityReportingService.instance.reportNodeInitialized(
           resetStaticContext: false,
         );

--- a/lib/core/config/l10n/app_en.arb
+++ b/lib/core/config/l10n/app_en.arb
@@ -2834,6 +2834,26 @@
   "@httpLogsShareNoParticipant": {
     "description": "Disabled-share hint shown when no participant ID is available"
   },
+  "httpLogsFilterHint": "Filter by URL",
+  "@httpLogsFilterHint": {
+    "description": "Placeholder text for the field that filters HTTP logs by URL substring"
+  },
+  "httpLogsNoMatches": "No requests match the filter.",
+  "@httpLogsNoMatches": {
+    "description": "Empty state shown when no captured requests match the active URL filter"
+  },
+  "httpLogsFilterCount": "{count} of {total}",
+  "@httpLogsFilterCount": {
+    "description": "Caption showing how many captured requests match the active URL filter",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "participantRecoveryTitle": "Onboarding has evolved",
   "@participantRecoveryTitle": {
     "description": "Title of the dialog prompting the user to re-register to restore their participant ID"

--- a/lib/core/config/l10n/app_localizations.dart
+++ b/lib/core/config/l10n/app_localizations.dart
@@ -3742,6 +3742,24 @@ abstract class AppLocalizations {
   /// **'No participant ID yet — finish onboarding to share logs'**
   String get httpLogsShareNoParticipant;
 
+  /// Placeholder text for the field that filters HTTP logs by URL substring
+  ///
+  /// In en, this message translates to:
+  /// **'Filter by URL'**
+  String get httpLogsFilterHint;
+
+  /// Empty state shown when no captured requests match the active URL filter
+  ///
+  /// In en, this message translates to:
+  /// **'No requests match the filter.'**
+  String get httpLogsNoMatches;
+
+  /// Caption showing how many captured requests match the active URL filter
+  ///
+  /// In en, this message translates to:
+  /// **'{count} of {total}'**
+  String httpLogsFilterCount(int count, int total);
+
   /// Title of the dialog prompting the user to re-register to restore their participant ID
   ///
   /// In en, this message translates to:

--- a/lib/core/config/l10n/app_localizations_en.dart
+++ b/lib/core/config/l10n/app_localizations_en.dart
@@ -2100,6 +2100,17 @@ class AppLocalizationsEn extends AppLocalizations {
       'No participant ID yet — finish onboarding to share logs';
 
   @override
+  String get httpLogsFilterHint => 'Filter by URL';
+
+  @override
+  String get httpLogsNoMatches => 'No requests match the filter.';
+
+  @override
+  String httpLogsFilterCount(int count, int total) {
+    return '$count of $total';
+  }
+
+  @override
   String get participantRecoveryTitle => 'Onboarding has evolved';
 
   @override

--- a/lib/core/providers/log_share_provider.dart
+++ b/lib/core/providers/log_share_provider.dart
@@ -86,11 +86,26 @@ class LogShareController extends StateNotifier<LogShareState> {
     if (batch.isEmpty) return;
     final nextCursor = _store.totalAdded;
 
+    // Honour the viewer's active URL filter so sharing sends exactly what the
+    // user sees. Non-matching entries in this range are skipped permanently —
+    // the cursor still advances past them so the single-cursor model stays
+    // valid (broadening the filter later won't back-fill older entries).
+    final query = ref.read(httpLogFilterProvider).trim().toLowerCase();
+    final toSend = query.isEmpty
+        ? batch
+        : batch
+            .where((e) => e.url.toLowerCase().contains(query))
+            .toList(growable: false);
+    if (toSend.isEmpty) {
+      _cursor = nextCursor;
+      return;
+    }
+
     _flushing = true;
     try {
       final outcome = await _service.postLogs(
         participantId: participantId,
-        body: _buildBody(batch),
+        body: _buildBody(toSend),
       );
       if (!mounted) return;
       switch (outcome) {
@@ -150,3 +165,10 @@ final logShareControllerProvider =
     StateNotifierProvider<LogShareController, LogShareState>(
   (ref) => LogShareController(ref: ref),
 );
+
+/// Case-insensitive URL substring that filters the HTTP debug log viewer.
+///
+/// Empty means "no filter". Held here (rather than as screen-local state) so
+/// the on-screen list, the copy action, and [LogShareController] sharing all
+/// honour the same filter.
+final httpLogFilterProvider = StateProvider<String>((ref) => '');

--- a/lib/core/services/android_foreground_task_controller.dart
+++ b/lib/core/services/android_foreground_task_controller.dart
@@ -114,7 +114,7 @@ class AndroidForegroundTaskController {
       final result = await PlatformAlarmService.instance.startForegroundService(
         title: 'Usernode',
         message: 'Evaluating VRF slots',
-        slotNumber: 0,
+        globalSlot: 0,
       );
       _log.info('Foreground service start result: $result');
     }
@@ -464,7 +464,7 @@ class AndroidForegroundTaskController {
     final success = await PlatformAlarmService.instance.scheduleAlarm(
       alarmId: foregroundResumeAlarmId,
       delayMs: delayMs,
-      slotNumber: 0,
+      globalSlot: targetGlobalSlot ?? 0,
       data: {
         'reason': reason,
         'nodeRunning': RustBackendService.instance.isRunning,
@@ -605,9 +605,11 @@ class AndroidForegroundTaskController {
       return '$alarmId:$alarmTimeMs';
     }
 
-    final slotNumber = _intFromDynamic(data['slotNumber']);
-    if (slotNumber != null) {
-      return '$alarmId:slot:$slotNumber';
+    final globalSlot = _intFromDynamic(data['globalSlot']) ??
+        _intFromDynamic(data['global_slot']) ??
+        _intFromDynamic(data['slotNumber']);
+    if (globalSlot != null) {
+      return '$alarmId:slot:$globalSlot';
     }
 
     return alarmId;

--- a/lib/core/services/block_production_alarm_audit_service.dart
+++ b/lib/core/services/block_production_alarm_audit_service.dart
@@ -14,7 +14,7 @@ final _log = LoggingService.instance.withTag('usernode/AlarmAudit');
 
 typedef AlarmAuditScheduleAlarm = Future<bool> Function({
   required String alarmId,
-  required int slotNumber,
+  required int globalSlot,
   required int delayMs,
   Map<String, dynamic>? data,
 });
@@ -539,7 +539,7 @@ class BlockProductionAlarmAuditService {
 
     final success = await _scheduleAlarm(
       alarmId: alarm.alarmId,
-      slotNumber: alarm.globalSlot,
+      globalSlot: alarm.globalSlot,
       delayMs: delayMs,
       data: {
         'epoch': alarm.epoch,

--- a/lib/core/services/epoch_slot_scheduler_service.dart
+++ b/lib/core/services/epoch_slot_scheduler_service.dart
@@ -431,7 +431,7 @@ class EpochSlotSchedulerService {
       final success = await PlatformAlarmService.instance.scheduleAlarm(
         alarmId: alarmId,
         delayMs: delayMs,
-        slotNumber: slot.slotNumber,
+        globalSlot: slot.slotNumber,
         data: {
           'epoch': slot.epoch,
           'slotTime': slot.slotTime.toIso8601String(),

--- a/lib/core/services/explorer_service.dart
+++ b/lib/core/services/explorer_service.dart
@@ -401,8 +401,11 @@ class ExplorerTransactionsResponse {
   }
 
   Map<String, dynamic> toJson() {
+    // Mirror the live API shape (`items`) so a cached blob round-trips back
+    // through [fromJson]. Writing a different key here silently yields an
+    // empty list on read, wiping cached Recent Activity.
     return {
-      'transactions': transactions.map((tx) => tx.toJson()).toList(),
+      'items': transactions.map((tx) => tx.toJson()).toList(),
       'data_source': dataSource.toString(),
       'fetched_at': fetchedAt.millisecondsSinceEpoch,
     };
@@ -459,16 +462,19 @@ class ExplorerTransaction {
   }
 
   Map<String, dynamic> toJson() {
+    // Use the same field names [fromJson] reads from the live API so a cached
+    // entry deserializes back into an identical ExplorerTransaction. (`amount`
+    // round-trips as a number; `token_symbol` is not in the API and is
+    // re-defaulted to TKN on read, so it is intentionally not persisted.)
     return {
-      'id': id,
+      'tx_id': id,
       'tx_type': txType,
       'direction': direction,
       'amount': amount,
-      'token_symbol': tokenSymbol,
-      'timestamp': timestamp.millisecondsSinceEpoch,
+      'timestamp_ms': timestamp.millisecondsSinceEpoch,
       'status': status,
-      'from_address': fromAddress,
-      'to_address': toAddress,
+      'source': fromAddress,
+      'destination': toAddress,
       'block_height': blockHeight,
       'block_hash': blockHash,
     };

--- a/lib/core/services/platform_alarm_service.dart
+++ b/lib/core/services/platform_alarm_service.dart
@@ -432,9 +432,7 @@ class PlatformAlarmService {
   void setNativeEventCallback(NativeEventCallback callback) {
     _onNativeEvent = callback;
     _log.debug('Native event callback registered');
-    if (Platform.isAndroid) {
-      unawaited(_markFlutterReadyForAlarmEvents());
-    }
+    // AppBootstrap marks native events ready only after RustLib.init() completes.
   }
 
   /// Handle alarm rescheduling after device reboot
@@ -458,7 +456,9 @@ class PlatformAlarmService {
     }
   }
 
-  Future<void> _markFlutterReadyForAlarmEvents() async {
+  Future<void> markReadyForNativeEvents() async {
+    if (!Platform.isAndroid) return;
+
     try {
       await _channel.invokeMethod<bool>('markFlutterReadyForAlarmEvents');
       _log.debug('Marked Flutter alarm channel ready on native side');

--- a/lib/core/services/platform_alarm_service.dart
+++ b/lib/core/services/platform_alarm_service.dart
@@ -359,15 +359,15 @@ class PlatformAlarmService {
     }
 
     final alarmId = _stringFromDynamic(eventData['alarmId']);
-    final slotNumber = _intFromDynamic(eventData['slotNumber']);
+    final legacySlotNumber = _intFromDynamic(eventData['slotNumber']);
     final globalSlot = _globalSlotForAlarm(
       alarmId: alarmId,
-      slotNumber: slotNumber,
+      globalSlot: legacySlotNumber,
       data: eventData,
     );
     final alarmTimeMs = _intFromDynamic(eventData['alarmTimeMs']);
     final eventKey = '$eventType:${alarmId ?? ''}:${alarmTimeMs ?? ''}:'
-        '${globalSlot ?? slotNumber ?? ''}';
+        '${globalSlot ?? legacySlotNumber ?? ''}';
     final now = DateTime.now();
     final lastAt = _lastAlarmFiredEventAt;
     if (_lastAlarmFiredEventKey == eventKey &&
@@ -815,7 +815,7 @@ class PlatformAlarmService {
   /// iOS: Schedules BGProcessingTask + local notification
   Future<bool> scheduleAlarm({
     required String alarmId,
-    required int slotNumber,
+    required int globalSlot,
     required int delayMs,
     Map<String, dynamic>? data,
   }) async {
@@ -827,13 +827,13 @@ class PlatformAlarmService {
         scheduledAtMs + normalizedDelayMs;
     alarmData.putIfAbsent('alarmTimeMs', () => alarmTimeMs);
     alarmData.putIfAbsent('systemTimeMsAtSchedule', () => scheduledAtMs);
-    final globalSlot = _globalSlotForAlarm(
+    final resolvedGlobalSlot = _globalSlotForAlarm(
       alarmId: alarmId,
-      slotNumber: slotNumber,
+      globalSlot: globalSlot,
       data: alarmData,
     );
-    if (globalSlot != null) {
-      alarmData['globalSlot'] = globalSlot;
+    if (resolvedGlobalSlot != null) {
+      alarmData['globalSlot'] = resolvedGlobalSlot;
     }
 
     void recordScheduleResult({
@@ -845,7 +845,7 @@ class PlatformAlarmService {
       _observability.reportBlockProductionAlarmScheduled(
         alarmId: alarmId,
         purpose: _alarmPurpose(alarmId, alarmData),
-        globalSlot: globalSlot,
+        globalSlot: resolvedGlobalSlot,
         epoch: _intFromDynamic(alarmData['epoch']),
         slotTimeMs: slotTimeMs,
         rustSlotTimeMs: _intFromDynamic(alarmData['rustSlotTimeMs']),
@@ -894,7 +894,7 @@ class PlatformAlarmService {
     try {
       final params = {
         'alarmId': alarmId,
-        'slotNumber': slotNumber,
+        'globalSlot': resolvedGlobalSlot ?? globalSlot,
         'delayMs': normalizedDelayMs,
         'data': alarmData,
       };
@@ -937,7 +937,7 @@ class PlatformAlarmService {
 
   int? _globalSlotForAlarm({
     required String? alarmId,
-    required int? slotNumber,
+    required int? globalSlot,
     required Map<String, dynamic> data,
   }) {
     for (final key in const [
@@ -952,8 +952,8 @@ class PlatformAlarmService {
       }
     }
 
-    if (slotNumber != null && slotNumber > 0) {
-      return slotNumber;
+    if (globalSlot != null && globalSlot > 0) {
+      return globalSlot;
     }
 
     final alarmSlot = _slotFromAlarmId(alarmId);
@@ -1019,7 +1019,7 @@ class PlatformAlarmService {
 
       if (success) {
         _log.info(
-            'Android exact alarm scheduled for slot ${params['slotNumber']}');
+            'Android exact alarm scheduled for global slot ${params['globalSlot']}');
       } else {
         _log.warn('Failed to schedule Android exact alarm');
       }
@@ -1039,7 +1039,8 @@ class PlatformAlarmService {
               false;
 
       if (success) {
-        _log.info('iOS BGTask scheduled for slot ${params['slotNumber']}');
+        _log.info(
+            'iOS BGTask scheduled for global slot ${params['globalSlot']}');
       } else {
         _log.warn('Failed to schedule iOS BGTask');
       }
@@ -1107,7 +1108,7 @@ class PlatformAlarmService {
   Future<bool> startForegroundService({
     required String title,
     required String message,
-    required int slotNumber,
+    required int globalSlot,
   }) async {
     if (!Platform.isAndroid) {
       _log.debug('Foreground service is Android-only');
@@ -1118,7 +1119,7 @@ class PlatformAlarmService {
       final params = {
         'title': title,
         'message': message,
-        'slotNumber': slotNumber,
+        'globalSlot': globalSlot,
       };
 
       final success =
@@ -1126,7 +1127,7 @@ class PlatformAlarmService {
               false;
 
       if (success) {
-        _log.info('Foreground service started for slot $slotNumber');
+        _log.info('Foreground service started for global slot $globalSlot');
         _recordPowerNetworkServiceContextChanged('foreground_service_changed');
       } else {
         _log.warn('Failed to start foreground service');

--- a/lib/features/settings/screens/http_debug_logs_screen.dart
+++ b/lib/features/settings/screens/http_debug_logs_screen.dart
@@ -15,13 +15,47 @@ import 'package:crypto_mobile_app/design_system/design_system.dart';
 /// Reads the in-memory [HttpDebugLogStore] and rebuilds live as requests
 /// arrive (the store is a [ChangeNotifier]). Entries are already redacted and
 /// truncated. The app bar offers copy-all-to-clipboard and clear.
-class HttpDebugLogsScreen extends ConsumerWidget {
+class HttpDebugLogsScreen extends ConsumerStatefulWidget {
   const HttpDebugLogsScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HttpDebugLogsScreen> createState() =>
+      _HttpDebugLogsScreenState();
+}
+
+class _HttpDebugLogsScreenState extends ConsumerState<HttpDebugLogsScreen> {
+  final _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    // Reflect any filter already in effect — it persists across screen opens
+    // and also drives copy/share.
+    _searchController.text = ref.read(httpLogFilterProvider);
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  /// Case-insensitive substring match on the request URL.
+  List<HttpLogEntry> _applyFilter(List<HttpLogEntry> entries, String query) {
+    final q = query.trim().toLowerCase();
+    if (q.isEmpty) return entries;
+    return entries
+        .where((e) => e.url.toLowerCase().contains(q))
+        .toList(growable: false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final store = ref.watch(httpDebugLogStoreProvider);
+    final query = ref.watch(httpLogFilterProvider);
     final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final spacing = theme.extension<AppSpacing>()!;
 
     // Surface a one-off message when the backend asks us to stop sharing.
     ref.listen(logShareControllerProvider, (prev, next) {
@@ -32,6 +66,8 @@ class HttpDebugLogsScreen extends ConsumerWidget {
       }
     });
 
+    final hasQuery = query.trim().isNotEmpty;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.httpLogsTitle),
@@ -40,8 +76,10 @@ class HttpDebugLogsScreen extends ConsumerWidget {
             icon: const Icon(Symbols.content_copy_sharp),
             tooltip: l10n.httpLogsCopy,
             onPressed: () async {
-              final text = store.toExportText();
-              if (text.isEmpty) return;
+              // Copy the currently-visible (filtered) entries.
+              final visible = _applyFilter(store.entries, query);
+              if (visible.isEmpty) return;
+              final text = visible.map((e) => e.toLogText()).join('\n');
               await Clipboard.setData(ClipboardData(text: text));
               if (!context.mounted) return;
               ScaffoldMessenger.of(context).showSnackBar(
@@ -55,19 +93,79 @@ class HttpDebugLogsScreen extends ConsumerWidget {
             onPressed: store.clear,
           ),
         ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(64),
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              spacing.space16,
+              0,
+              spacing.space16,
+              spacing.space8,
+            ),
+            child: TextField(
+              controller: _searchController,
+              onChanged: (value) =>
+                  ref.read(httpLogFilterProvider.notifier).state = value,
+              textInputAction: TextInputAction.search,
+              autocorrect: false,
+              decoration: InputDecoration(
+                isDense: true,
+                hintText: l10n.httpLogsFilterHint,
+                prefixIcon: const Icon(Symbols.search_sharp),
+                suffixIcon: hasQuery
+                    ? IconButton(
+                        icon: const Icon(Symbols.close_sharp),
+                        tooltip: l10n.httpLogsClear,
+                        onPressed: () {
+                          _searchController.clear();
+                          ref.read(httpLogFilterProvider.notifier).state = '';
+                        },
+                      )
+                    : null,
+                border: const OutlineInputBorder(),
+              ),
+            ),
+          ),
+        ),
       ),
       body: SafeArea(
         child: ListenableBuilder(
           listenable: store,
           builder: (context, _) {
-            final entries = store.entries;
+            final all = store.entries;
+            final entries = _applyFilter(all, query);
             if (entries.isEmpty) {
-              return _EmptyState(message: l10n.httpLogsEmpty);
+              return _EmptyState(
+                message: hasQuery ? l10n.httpLogsNoMatches : l10n.httpLogsEmpty,
+              );
             }
-            return ListView.separated(
-              itemCount: entries.length,
-              separatorBuilder: (_, __) => const Divider(height: 1),
-              itemBuilder: (context, i) => _HttpLogTile(entry: entries[i]),
+            return Column(
+              children: [
+                if (hasQuery)
+                  Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: spacing.space16,
+                      vertical: spacing.space8,
+                    ),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        l10n.httpLogsFilterCount(entries.length, all.length),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ),
+                Expanded(
+                  child: ListView.separated(
+                    itemCount: entries.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, i) =>
+                        _HttpLogTile(entry: entries[i]),
+                  ),
+                ),
+              ],
             );
           },
         ),

--- a/test/core/services/block_production_alarm_audit_service_test.dart
+++ b/test/core/services/block_production_alarm_audit_service_test.dart
@@ -45,7 +45,7 @@ void main() {
       expect(result.missingCount, 1);
       expect(result.rescheduledCount, 1);
       expect(harness.scheduledAlarms.single.alarmId, 'slot_42');
-      expect(harness.scheduledAlarms.single.slotNumber, 42);
+      expect(harness.scheduledAlarms.single.globalSlot, 42);
       expect(
         harness.events('alarm_audit_missing_rescheduled').single['purpose'],
         'slot_wake',
@@ -306,14 +306,14 @@ class _AuditHarness {
           ),
       scheduleAlarm: ({
         required alarmId,
-        required slotNumber,
+        required globalSlot,
         required delayMs,
         data,
       }) async {
         scheduledAlarms.add(
           _ScheduledAlarm(
             alarmId: alarmId,
-            slotNumber: slotNumber,
+            globalSlot: globalSlot,
             delayMs: delayMs,
             data: data ?? const {},
           ),
@@ -431,13 +431,13 @@ ObservabilityReportingService _observability(
 class _ScheduledAlarm {
   const _ScheduledAlarm({
     required this.alarmId,
-    required this.slotNumber,
+    required this.globalSlot,
     required this.delayMs,
     required this.data,
   });
 
   final String alarmId;
-  final int slotNumber;
+  final int globalSlot;
   final int delayMs;
   final Map<String, dynamic> data;
 }

--- a/test/core/services/observability_reporting_service_test.dart
+++ b/test/core/services/observability_reporting_service_test.dart
@@ -443,7 +443,6 @@ void main() {
 
       alarmService.handleNativeEventForTest('android_alarm_fired', {
         'alarmId': 'fg_resume',
-        'slotNumber': 0,
         'globalSlot': 42,
         'alarmTimeMs': 1700000005000,
         'firedAtMs': 1700000005123,
@@ -464,7 +463,6 @@ void main() {
 
       alarmService.handleNativeEventForTest('android_alarm_fired', {
         'alarmId': 'fg_resume',
-        'slotNumber': 0,
         'alarmTimeMs': 1700000005000,
         'firedAtMs': 1700000005123,
         'reason': 'next_won_slot:43',
@@ -480,7 +478,6 @@ void main() {
       final alarmService = PlatformAlarmService.test(observability: service);
       final eventData = {
         'alarmId': 'fg_resume',
-        'slotNumber': 0,
         'globalSlot': 42,
         'alarmTimeMs': 1700000005000,
         'firedAtMs': 1700000005123,


### PR DESCRIPTION
 ### Gate native alarm event delivery until FRB/Rust init is complete
 • Old behavior:

  - Dart registered the native alarm callback.
  - PlatformAlarmService.setNativeEventCallback() immediately told Android: “Flutter is ready for alarm events.”
  - But FRB/Rust might not be initialized yet.
  - If Android delivered a pending alarm event in that window, Dart handled it and could call into Rust too early, causing the error: flutter_rust_bridge has not been initialized.

  New behavior:

  - Dart still registers the callback early.
  - But it does not tell Android “Flutter is ready” yet.
  - AppBootstrap now calls markReadyForNativeEvents() only after RustBackendService.instance.init() has completed, or after it confirms the backend is already running.
  - Android can buffer alarm events until that ready signal, then flush them once Rust/FRB is usable.
  
 ### Other changes 
 
 - Remove duplicate `android_alarm_fired` emission from `SlotMonitoringService`
  - Rename native alarm scheduling/display path from `slotNumber` to `globalSlot` - it was always displaying slot 0 for scheduling and monitoring notification, now it correctly shows the slot.
  - Keep legacy `slotNumber` reads for already-scheduled Android intents
  - Use one shared scheduled-alarm notification ID so scheduled slot notifications replace each other. - otherwise they were piling up and once notification count hit 50, no new notification would be shown from usernode.
  
  ### EDIT
  
  - fixed empty recent activity in-spite of explorer returning it.
  - **MINOR:** added url filtering to http debug logs screen.