### PR TITLE
feat(wallet): wait for sync instead of failing

### DIFF
--- a/lib/core/config/l10n/app_en.arb
+++ b/lib/core/config/l10n/app_en.arb
@@ -2136,6 +2136,14 @@
   "@walletSending": {
     "description": "Send button text while transaction is processing"
   },
+  "walletWaitingForSync": "Waiting for sync",
+  "@walletWaitingForSync": {
+    "description": "Send screen status while a transfer waits for wallet sync"
+  },
+  "walletWaitingForSyncHelp": "You can leave this screen. As long as the app stays open, the transaction will be attempted after sync and should go through if your balance is enough.",
+  "@walletWaitingForSyncHelp": {
+    "description": "Send screen helper text while a transfer waits for wallet sync"
+  },
   "walletFieldRequired": "Please enter a {fieldName}",
   "@walletFieldRequired": {
     "description": "Validation error for required field",

--- a/lib/core/config/l10n/app_localizations.dart
+++ b/lib/core/config/l10n/app_localizations.dart
@@ -2830,6 +2830,18 @@ abstract class AppLocalizations {
   /// **'Sending...'**
   String get walletSending;
 
+  /// Send screen status while a transfer waits for wallet sync
+  ///
+  /// In en, this message translates to:
+  /// **'Waiting for sync'**
+  String get walletWaitingForSync;
+
+  /// Send screen helper text while a transfer waits for wallet sync
+  ///
+  /// In en, this message translates to:
+  /// **'You can leave this screen. As long as the app stays open, the transaction will be attempted after sync and should go through if your balance is enough.'**
+  String get walletWaitingForSyncHelp;
+
   /// Validation error for required field
   ///
   /// In en, this message translates to:

--- a/lib/core/config/l10n/app_localizations_en.dart
+++ b/lib/core/config/l10n/app_localizations_en.dart
@@ -1575,6 +1575,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get walletSending => 'Sending...';
 
   @override
+  String get walletWaitingForSync => 'Waiting for sync';
+
+  @override
+  String get walletWaitingForSyncHelp =>
+      'You can leave this screen. As long as the app stays open, the transaction will be attempted after sync and should go through if your balance is enough.';
+
+  @override
   String walletFieldRequired(String fieldName) {
     return 'Please enter a $fieldName';
   }

--- a/lib/features/dapps/dapp_webview_screen.dart
+++ b/lib/features/dapps/dapp_webview_screen.dart
@@ -698,7 +698,7 @@ class _DappWebViewScreenState extends ConsumerState<DappWebViewScreen> {
       return;
     }
 
-    final resp = await rpc.wallet().txSend(
+    final resp = await rpc.wallet().txSendResult(
           fromPkHash: fromPkHash,
           amount: amount,
           toPkHash: toPkHash,
@@ -706,7 +706,7 @@ class _DappWebViewScreenState extends ConsumerState<DappWebViewScreen> {
         );
 
     final rpcError = resp?.error;
-    final isQueued = rpcError == null || rpcError.isEmpty;
+    final isQueued = resp?.queued ?? false;
     final recordId =
         resp?.txId ?? 'local_${DateTime.now().millisecondsSinceEpoch}';
     _addRecord(_TxRecord(
@@ -727,7 +727,7 @@ class _DappWebViewScreenState extends ConsumerState<DappWebViewScreen> {
     await _resolveJsPromise(
       id: id,
       value: <String, dynamic>{
-        'queued': resp?.queued ?? false,
+        'queued': isQueued,
         'error': rpcError,
       },
       error: null,

--- a/lib/features/node/node_service.dart
+++ b/lib/features/node/node_service.dart
@@ -14,6 +14,7 @@ import 'package:crypto_mobile_app/src/rust/rpc.dart';
 import 'package:crypto_mobile_app/core/providers/accounts_provider.dart';
 import 'package:crypto_mobile_app/core/utils/logger.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/wallet_tx.dart';
+import 'package:crypto_mobile_app/src/rust/frb_types.dart' show Memo;
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:crypto_mobile_app/src/rust/frb_generated.dart';
 import 'package:crypto_mobile_app/src/rust/lib.dart' show enableLogging;
@@ -395,7 +396,6 @@ class RustBackendService {
       if (!AppConfig.viewOnly) {
         builder.mempoolAutoinsertInterval(secs: BigInt.from(1));
       }
-
       // Configure persistent node storage path so wallet cache state survives restarts.
       // Use network-specific paths to avoid conflicts when switching networks.
       final appSupportDir = await getApplicationSupportDirectory();
@@ -1283,6 +1283,7 @@ class RustBackendService {
     if (AppConfig.viewOnly) {
       _log.info('Skipping transferFunds in view-only mode');
       return const RpcWalletTxSendResp(
+        state: RpcWalletTxSendState.ready,
         queued: false,
         error: _viewOnlyTransactionError,
       );
@@ -1302,12 +1303,7 @@ class RustBackendService {
         amount: amount,
         toPkHash: toPkHash,
       );
-      if (rpcResponse != null) {
-        response = RpcWalletTxSendResp(
-          queued: rpcResponse.queued,
-          error: rpcResponse.error,
-        );
-      }
+      response = rpcResponse;
     } on PanicException catch (e, st) {
       // FRB surfaced a Rust-side panic.
       _log.error('FRB panic during transferFunds', error: e, stackTrace: st);
@@ -1348,6 +1344,91 @@ class RustBackendService {
     }
 
     return response;
+  }
+
+  /// Transfer funds and surface ordered wallet-send progress events.
+  Stream<WalletTxSendEvent> transferFundsEvents({
+    required PublicKeyHash fromPkHash,
+    required BigInt amount,
+    required PublicKeyHash toPkHash,
+  }) async* {
+    if (AppConfig.viewOnly) {
+      _log.info('Skipping transferFundsEvents in view-only mode');
+      yield const WalletTxSendEvent.rejected(
+        error: _viewOnlyTransactionError,
+        state: RpcWalletTxSendState.ready,
+      );
+      return;
+    }
+
+    _log.trace(
+      'transferFundsEvents called with params: fromPkHash=[PublicKeyHash], amount=$amount, toPkHash=[PublicKeyHash]',
+    );
+    final r = _rpc;
+    if (r == null) {
+      yield const WalletTxSendEvent.rejected(
+        error: 'Node RPC unavailable',
+        state: RpcWalletTxSendState.ready,
+      );
+      return;
+    }
+
+    var emitted = false;
+    var terminalEmitted = false;
+    try {
+      final events = r.wallet().txSend(
+            fromPkHash: fromPkHash,
+            amount: amount,
+            toPkHash: toPkHash,
+            memo: Memo.fromUtf8Str(s: ''),
+          );
+      await for (final event in events) {
+        emitted = true;
+        event.when(
+          syncing: () {},
+          queued: (_) {
+            terminalEmitted = true;
+          },
+          rejected: (_, __) {
+            terminalEmitted = true;
+          },
+        );
+        yield event;
+      }
+    } on PanicException catch (e, st) {
+      _log.error('FRB panic during transferFundsEvents',
+          error: e, stackTrace: st);
+      _nodeRunning = false;
+      _rpc = null;
+      _control = null;
+      await SentryUtil.captureError(e, st,
+          tag: 'frb_panic_transferFundsEvents');
+      yield const WalletTxSendEvent.rejected(
+        error: 'Node RPC unavailable',
+        state: RpcWalletTxSendState.ready,
+      );
+      return;
+    } catch (e, st) {
+      _log.warn('RPC transferFundsEvents failed: $e\$st');
+      await SentryUtil.captureError(e, st, tag: 'rpc_transferFundsEvents');
+      yield WalletTxSendEvent.rejected(
+        error: e.toString(),
+        state: RpcWalletTxSendState.ready,
+      );
+      return;
+    }
+
+    if (!emitted) {
+      yield const WalletTxSendEvent.rejected(
+        error: 'Transfer stream closed without a result',
+        state: RpcWalletTxSendState.ready,
+      );
+    } else if (!terminalEmitted) {
+      yield const WalletTxSendEvent.rejected(
+        error: 'Transfer stream closed before a final result',
+        state: RpcWalletTxSendState.syncing,
+      );
+    }
   }
 
   /// Query backend for epoch information with VRF status awareness

--- a/lib/features/wallet/screens/scan_screen.dart
+++ b/lib/features/wallet/screens/scan_screen.dart
@@ -166,7 +166,7 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
       final toPkHash = frb_types.publicKeyHashFromString(s: payload.to);
       final memo = frb_types.Memo.fromUtf8Str(s: payload.memo);
 
-      final resp = await rpc.wallet().txSend(
+      final resp = await rpc.wallet().txSendResult(
             fromPkHash: fromPkHash,
             amount: payload.amount,
             toPkHash: toPkHash,
@@ -176,7 +176,7 @@ class _ScanScreenState extends ConsumerState<ScanScreen> {
       if (!mounted) return;
 
       final rpcError = resp?.error;
-      final isQueued = rpcError == null || rpcError.isEmpty;
+      final isQueued = resp?.queued ?? false;
 
       if (isQueued) {
         context.go(AppRoutes.walletSendSuccess, extra: {

--- a/lib/features/wallet/screens/send_screen.dart
+++ b/lib/features/wallet/screens/send_screen.dart
@@ -25,10 +25,11 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   final _formKey = GlobalKey<FormState>();
   final _addressController = TextEditingController();
   final _amountController = TextEditingController();
-  final _feeController = TextEditingController(text: '1');
+  final _feeController = TextEditingController(text: '0');
   final _memoController = TextEditingController();
 
   bool _isSending = false;
+  bool _isSyncing = false;
 
   @override
   void dispose() {
@@ -45,6 +46,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
     setState(() {
       _isSending = true;
+      _isSyncing = false;
     });
 
     try {
@@ -68,15 +70,38 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       final amountStr = _amountController.text.trim();
       final amount = BigInt.from(double.parse(amountStr).round());
 
-      // Call the transfer funds RPC
-      final response = await RustBackendService.instance.transferFunds(
+      bool? queued;
+      String? errorMessage;
+      final events = RustBackendService.instance.transferFundsEvents(
         fromPkHash: fromPkHash,
         amount: amount,
         toPkHash: toPkHash,
       );
+      await for (final event in events) {
+        final isTerminal = event.when(
+          syncing: () {
+            if (mounted) {
+              setState(() {
+                _isSyncing = true;
+              });
+            }
+            return false;
+          },
+          queued: (_) {
+            queued = true;
+            return true;
+          },
+          rejected: (error, _) {
+            queued = false;
+            errorMessage = error;
+            return true;
+          },
+        );
+        if (isTerminal) break;
+      }
 
       if (mounted) {
-        if (response != null && response.queued) {
+        if (queued == true) {
           await ref
               .read(recipientHistoryProvider.notifier)
               .addRecipient(recipientAddress);
@@ -89,9 +114,8 @@ class _SendScreenState extends ConsumerState<SendScreen> {
           });
         } else {
           // Transaction failed
-          final errorMessage = response?.error ?? 'Unknown error occurred';
           context.push(AppRoutes.walletSendFailed, extra: {
-            'errorMessage': errorMessage,
+            'errorMessage': errorMessage ?? 'Unknown error occurred',
           });
         }
       }
@@ -106,6 +130,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       if (mounted) {
         setState(() {
           _isSending = false;
+          _isSyncing = false;
         });
       }
     }
@@ -187,6 +212,10 @@ class _SendScreenState extends ConsumerState<SendScreen> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
+                    if (_isSyncing) ...[
+                      _buildSyncingStatus(theme),
+                      SizedBox(height: spacing.space12),
+                    ],
                     _buildSendButton(theme),
                     SizedBox(height: spacing.space32),
                   ],
@@ -235,6 +264,51 @@ class _SendScreenState extends ConsumerState<SendScreen> {
         isLoading: _isSending,
         onTap: _onSend,
       ),
+    );
+  }
+
+  Widget _buildSyncingStatus(ThemeData theme) {
+    final spacing = theme.extension<AppSpacing>()!;
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+            SizedBox(width: spacing.space8),
+            Flexible(
+              child: Text(
+                l10n.walletWaitingForSync,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: spacing.space8),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: spacing.space8),
+          child: Text(
+            l10n.walletWaitingForSyncHelp,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/test/frb/frb_contract_test.dart
+++ b/test/frb/frb_contract_test.dart
@@ -8,6 +8,8 @@
 // code generator or Rust API changes in a way that alters these Dart signatures,
 // these tests will fail to compile or at assignment time.
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 
 // Our façade over FRB
@@ -23,6 +25,7 @@ import 'package:crypto_mobile_app/src/rust/frb_types.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/list_utxos_by_owner.dart';
 import 'package:crypto_mobile_app/src/rust/rpc/rpcs_generated/wallet.dart';
 import 'package:crypto_mobile_app/src/rust/rpc.dart';
+import 'package:crypto_mobile_app/src/rust/rpc/wallet.dart';
 
 typedef ListBlockchainFn = Future<RpcListBlockchainResp?> Function(
     {int? limit, bool? fromTip});
@@ -38,6 +41,20 @@ typedef TransferFundsFn = Future<RpcWalletTxSendResp?> Function(
     {required PublicKeyHash fromPkHash,
     required BigInt amount,
     required PublicKeyHash toPkHash});
+typedef TransferFundsEventsFn = Stream<WalletTxSendEvent> Function(
+    {required PublicKeyHash fromPkHash,
+    required BigInt amount,
+    required PublicKeyHash toPkHash});
+typedef WalletTxSendFn = Stream<WalletTxSendEvent> Function(
+    {required PublicKeyHash fromPkHash,
+    required BigInt amount,
+    required PublicKeyHash toPkHash,
+    required Memo memo});
+typedef WalletTxSendResultFn = Future<RpcWalletTxSendResp?> Function(
+    {required PublicKeyHash fromPkHash,
+    required BigInt amount,
+    required PublicKeyHash toPkHash,
+    required Memo memo});
 
 void main() {
   group('RustBackendService API signatures (no-load)', () {
@@ -76,6 +93,32 @@ void main() {
         () {
       final TransferFundsFn f = RustBackendService.instance.transferFunds;
       expect(f, isNotNull);
+    });
+
+    test(
+        'transferFundsEvents({required PublicKeyHash fromPkHash, required BigInt amount, required PublicKeyHash toPkHash})',
+        () {
+      final TransferFundsEventsFn f =
+          RustBackendService.instance.transferFundsEvents;
+      expect(f, isNotNull);
+    });
+
+    test('wallet.txSend(...) returns stream events', () {
+      void check(NodeRpcClientWallet wallet) {
+        final WalletTxSendFn f = wallet.txSend;
+        expect(f, isNotNull);
+      }
+
+      expect(check, isNotNull);
+    });
+
+    test('wallet.txSendResult(...) returns final response', () {
+      void check(NodeRpcClientWallet wallet) {
+        final WalletTxSendResultFn f = wallet.txSendResult;
+        expect(f, isNotNull);
+      }
+
+      expect(check, isNotNull);
     });
   });
 
@@ -203,9 +246,24 @@ void main() {
 
     test('RpcWalletTxSendResp members', () {
       void check(RpcWalletTxSendResp r) {
+        final state = r.state; // RpcWalletTxSendState
         final queued = r.queued; // bool
         final error = r.error; // String?
-        expect([queued, error].length, greaterThan(0));
+        final txId = r.txId; // String?
+        expect([state, queued, error, txId].length, greaterThan(0));
+      }
+
+      expect(check, isNotNull);
+    });
+
+    test('WalletTxSendEvent variants', () {
+      void check(WalletTxSendEvent e) {
+        final label = e.when(
+          syncing: () => 'syncing',
+          queued: (txId) => txId,
+          rejected: (error, state) => '$error:$state',
+        );
+        expect(label, isNotEmpty);
       }
 
       expect(check, isNotNull);


### PR DESCRIPTION
Before transfer would fail if node hasn't yet rehydrated user utxos.
Now it will wait instead, show the waiting screen, once rehydrated transfer will be attempted like usual.

Depends on: https://github.com/Usernode-Labs/usernode/pull/853