### PR TITLE
fix(ci): restore iOS Xcode 26.5 pin + bump version to 0.3.3

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,7 +21,7 @@ env:
   FLUTTER_VERSION: "3.41.4"
   JAVA_VERSION: "17"
   NDK_VERSION: "29.0.14206865"
-  XCODE_VERSION: "26.0"
+  XCODE_VERSION: "26.5"
 
 jobs:
   build-android:
@@ -431,7 +431,7 @@ jobs:
 
   build-ios:
     name: Build iOS App
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: [determine-frb-rev, setup-rust-tools]
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -445,7 +445,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Select Xcode ${{ env.XCODE_VERSION }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          xcodebuild -version
+          xcodebuild -showsdks
 
       - name: Checkout usernode repository
         uses: actions/checkout@v4

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -20,7 +20,7 @@ env:
   FLUTTER_VERSION: "3.41.4"
   JAVA_VERSION: "17"
   NDK_VERSION: "29.0.14206865"
-  XCODE_VERSION: "26.0"
+  XCODE_VERSION: "26.5"
 
 jobs:
   check-tag:
@@ -437,7 +437,7 @@ jobs:
 
   build-ios:
     name: Build iOS App
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: [check-tag, determine-frb-rev, setup-rust-tools]
     outputs:
       version: ${{ github.event.inputs.version }}
@@ -451,7 +451,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Select Xcode ${{ env.XCODE_VERSION }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+          xcodebuild -version
+          xcodebuild -showsdks
 
       - name: Checkout usernode repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problems

Both regressions trace to the same commit `d1bb731` ("feat: align app chrome and challenge UI verification"), which was based on a stale copy of the workflow/pubspec and silently reverted two earlier fixes:

1. **iOS builds fail** with `Error (Xcode): iOS 26.0 Platform Not Installed.` — `d1bb731` reset the iOS CI pin (`a8de79e`) from Xcode `26.5` / `macos-26` back to `26.0` / `macos-latest`, whose Xcode 26.0 has no iOS platform on the current runner image.
2. **Version mismatch across stores** — `d1bb731` reverted the `0.3.2` bump (`e0b0e20`) back to `0.3.1`. Android had already shipped `0.3.2` (run #205, before the revert); iOS never did because its `0.3.2` builds all failed on the Xcode bug. Result: Android store shows `0.3.2`, iOS `0.3.1`.

## Fix

- Restore the iOS CI pin in **both** `build-and-deploy.yml` and `manual-build.yml`:
  - `XCODE_VERSION` `26.0` → `26.5`
  - `build-ios` `runs-on: macos-latest` → `macos-26`
  - re-add `xcodebuild -version` / `-showsdks` diagnostics
- Bump `pubspec.yaml` to `0.3.3+1210` so both platforms build the same, higher version and realign. (The `+N` build suffix is overwritten by CI: `1000 + run number`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)