### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 ---
 name: crypto_mobile_app
 description: A New Layer 1 Operated & Secured by users from their phones.
-version: 0.3.1+1200
+version: 0.3.3+1210
 publish_to: none
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
## Why

The iOS CI fix (PR #473) is now on `develop`, but the version bump that shared that branch did **not** land in the merge — `develop` is still at `0.3.1+1200`.

The store versions are currently mismatched: Android shipped `0.3.2` (run #205, before `d1bb731` reverted the bump) while iOS only started succeeding again at `0.3.1` (run #209). Bumping to `0.3.3` moves both platforms past the mismatch to a common, higher version on the next build.

## Change

- `pubspec.yaml`: `0.3.1+1200` → `0.3.3+1210` (the `+N` build suffix is overwritten by CI: `1000 + run number`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)