### PR TITLE
Document ScriptAgent challenge workflows

### DIFF
--- a/docs/CHALLENGE_PROGRESS_OPERATING_GUIDE.md
+++ b/docs/CHALLENGE_PROGRESS_OPERATING_GUIDE.md
@@ -62,7 +62,16 @@ Expressions are deterministic and sandboxed:
 - use `~` for string concatenation, not `+`.
 
 Useful expression helpers include `trim`, `lower`, `upper`, `len`, `values`,
-`keys`, `min`, `max`, `floor`, `ceil`, `round`, `sum`, and `avg`.
+`keys`, `min`, `max`, `floor`, `ceil`, `round`, `sum`, `avg`, and `lookup`.
+`lookup(collection, key_field, key_value, return_field)` is the safe keyed-join
+primitive for small script datasets, for example:
+
+```text
+lookup(steps.accounts.rows, "address", trim(row.wallet_address), "participant_id")
+```
+
+`lookup()` landed in Topochain PR #153. If a live ScriptAgent run reports it as
+an unknown function, the deployed backend is behind that merge.
 
 ## What Makes The App Update
 
@@ -72,6 +81,22 @@ Useful expression helpers include `trim`, `lower`, `upper`, `len`, `values`,
 - `wallet_address`, resolved against `onchain_accounts.address` or
   `onchain_accounts.public_key`;
 - `discord_handle`, resolved against `participants.discord`.
+
+Prefer the most canonical identifier already present in the source. For
+external dApps, forms, and user-submitted activity, `wallet_address` is the
+preferred identity because it is user-owned and can be resolved against
+current-phase accounts. In practice, use:
+
+1. `participant_id` if the source already knows Topochain participants;
+2. `wallet_address` joined to current-phase `onchain_accounts`;
+3. `discord_handle` only when the source has no wallet address and the username
+   is known to match `participants.discord`.
+
+Avoid treating arrays as maps. A JSON response such as `{ "items": [...] }` is
+still an array; expressions like `steps.identity_source.json.items[row.username]`
+will fail unless the source is already keyed by username. When a wallet source
+must be joined to current-phase accounts, use `lookup(...)` over
+`steps.accounts.rows` rather than dynamic object indexing.
 
 For challenge UI:
 
@@ -233,7 +258,7 @@ still the submitted wallet column, not all phase accounts:
     "depends_on": ["fetch_responses"],
     "op": "map",
     "from": "steps.fetch_responses.json",
-    "expr": "{ \"wallet\": trim(values(row)[14]) }"
+    "expr": "{ \"wallet\": lower(trim(values(row)[14])) }"
   },
   {
     "id": "valid_wallets",
@@ -244,21 +269,30 @@ still the submitted wallet column, not all phase accounts:
     "expr": "row.wallet != \"\""
   },
   {
-    "id": "wallet_values",
+    "id": "wallet_counts",
     "type": "transform",
     "depends_on": ["valid_wallets"],
-    "op": "map",
+    "op": "aggregate",
     "from": "steps.valid_wallets",
-    "expr": "row.wallet"
+    "fn": "count",
+    "group_by": "row.wallet"
   },
   {
-    "id": "accounts",
+    "id": "wallet_values",
+    "type": "transform",
+    "depends_on": ["wallet_counts"],
+    "op": "map",
+    "from": "keys(steps.wallet_counts)",
+    "expr": "row"
+  },
+  {
+    "id": "accounts_current_phase",
     "type": "tool",
     "depends_on": ["wallet_values"],
     "tool": "query_db_table",
     "args": {
       "table": "onchain_accounts",
-      "columns": ["participant_id", "address", "phase_id"],
+      "columns": ["participant_id", "address", "phase_id", "is_used"],
       "where": [
         {
           "column": "phase_id",
@@ -266,21 +300,51 @@ still the submitted wallet column, not all phase accounts:
           "value": { "expr": "agent.phase_id" }
         },
         {
+          "column": "is_used",
+          "op": "=",
+          "value": true
+        },
+        {
           "column": "address",
           "op": "in",
-          "value": { "expr": "steps.wallet_values" }
+          "value": { "expr": "len(steps.wallet_values) > 0 ? steps.wallet_values : [\"\"]" }
         }
       ],
       "limit": 200
     }
   },
   {
+    "id": "eligible_accounts",
+    "type": "transform",
+    "depends_on": ["accounts_current_phase"],
+    "op": "filter",
+    "from": "steps.accounts_current_phase.rows",
+    "expr": "row.participant_id != null and row.participant_id > 0"
+  },
+  {
+    "id": "matched_participants",
+    "type": "transform",
+    "depends_on": ["eligible_accounts"],
+    "op": "aggregate",
+    "from": "steps.eligible_accounts",
+    "fn": "count",
+    "group_by": "row.participant_id"
+  },
+  {
+    "id": "participant_ids",
+    "type": "transform",
+    "depends_on": ["matched_participants"],
+    "op": "map",
+    "from": "keys(steps.matched_participants)",
+    "expr": "row"
+  },
+  {
     "id": "entries",
     "type": "transform",
-    "depends_on": ["accounts"],
+    "depends_on": ["participant_ids"],
     "op": "map",
-    "from": "steps.accounts.rows",
-    "expr": "{ \"participant_id\": row.participant_id, \"points\": 500, \"reasoning\": \"You submitted the feedback form.\" }"
+    "from": "steps.participant_ids",
+    "expr": "{ \"participant_id\": row, \"points\": 500, \"metric_current\": 1, \"reasoning\": \"You submitted the Season 1 feedback form.\" }"
   },
   {
     "id": "award",
@@ -300,6 +364,243 @@ fetches OpenSheet for parsed rows, read that correctly: the direct CSV fetch is
 a proof that Google export access works; the award path is still powered by
 OpenSheet JSON parsing. That hybrid is useful for learning, but it is not a
 native CSV-scoring script.
+
+## Recipe: dApp Voting Leaderboard To Pending Points
+
+Use this for a dApp voting challenge where the source leaderboard returns
+`wallet_address` and vote counts. This is wallet-first: fetch one source, filter
+completed voters, join each wallet to a current-phase account with `lookup()`,
+and submit entries by `participant_id`.
+
+Example source:
+
+```text
+https://appraise-6945af.social-vibecoding.usernodelabs.org/api/leaderboard?round=dapp-hackathon-1-vote-for-your-favorite--m3or6&limit=200&offset=0
+```
+
+Expected source shape:
+
+```json
+{
+  "voters": [
+    {
+      "username": "cyrcle_0",
+      "wallet_address": "ut1...",
+      "votes_cast": 3
+    }
+  ]
+}
+```
+
+Known-good wallet script for a 3-vote, 500-point challenge:
+
+```json
+[
+  {
+    "id": "vote_leaderboard",
+    "type": "tool",
+    "depends_on": [],
+    "tool": "fetch_url",
+    "args": {
+      "url": "https://appraise-6945af.social-vibecoding.usernodelabs.org/api/leaderboard?round=dapp-hackathon-1-vote-for-your-favorite--m3or6&limit=200&offset=0",
+      "parse": "json"
+    }
+  },
+  {
+    "id": "complete_voters",
+    "type": "transform",
+    "depends_on": ["vote_leaderboard"],
+    "op": "filter",
+    "from": "steps.vote_leaderboard.json.voters",
+    "expr": "row.votes_cast >= 3 and row.wallet_address != null and trim(row.wallet_address) != \"\""
+  },
+  {
+    "id": "wallet_values",
+    "type": "transform",
+    "depends_on": ["complete_voters"],
+    "op": "map",
+    "from": "steps.complete_voters",
+    "expr": "trim(row.wallet_address)"
+  },
+  {
+    "id": "accounts",
+    "type": "tool",
+    "depends_on": ["wallet_values"],
+    "tool": "query_db_table",
+    "args": {
+      "table": "onchain_accounts",
+      "columns": ["participant_id", "address", "phase_id", "is_used"],
+      "where": [
+        {
+          "column": "phase_id",
+          "op": "=",
+          "value": { "expr": "agent.phase_id" }
+        },
+        {
+          "column": "is_used",
+          "op": "=",
+          "value": true
+        },
+        {
+          "column": "address",
+          "op": "in",
+          "value": { "expr": "len(steps.wallet_values) > 0 ? steps.wallet_values : [\"\"]" }
+        }
+      ],
+      "limit": 200
+    }
+  },
+  {
+    "id": "entries",
+    "type": "transform",
+    "depends_on": ["complete_voters", "accounts"],
+    "op": "map",
+    "from": "steps.complete_voters",
+    "expr": "{ \"participant_id\": lookup(steps.accounts.rows, \"address\", trim(row.wallet_address), \"participant_id\"), \"points\": 500, \"metric_current\": 3, \"reasoning\": \"You cast all 3 hackathon votes.\" }"
+  },
+  {
+    "id": "entries_matched",
+    "type": "transform",
+    "depends_on": ["entries"],
+    "op": "filter",
+    "from": "steps.entries",
+    "expr": "row.participant_id != null"
+  },
+  {
+    "id": "award",
+    "type": "tool",
+    "depends_on": ["entries_matched"],
+    "when": "len(steps.entries_matched) > 0",
+    "tool": "generate_points_matrix",
+    "args": {
+      "entries": { "expr": "steps.entries_matched" }
+    }
+  }
+]
+```
+
+If the source does not include `wallet_address`, use `discord_handle` only as a
+fallback and document that dependency on username matching.
+
+This minimal version is appropriate for manual runs and first proof. If it will
+run repeatedly, add the idempotency guard described below so the same completed
+vote does not create duplicate pending matrices.
+
+## Recipe: dApp Usage Leaderboard To Pending Points
+
+Use this for a dApp testing challenge where the source leaderboard returns
+`wallet_address`, `apps_tested`, and `apps_total` for each voter. This is the
+case that originally exposed the need for `lookup()`: after querying current
+phase accounts, the script still needs each original API row's `apps_tested`
+value to calculate points and `metric_current`.
+
+Example scoring:
+
+- 200 points for each hackathon app tested;
+- 500 point completion bonus when all apps are tested;
+- 2,100 point cap for 8 apps plus the completion bonus.
+
+Known-good wallet script:
+
+```json
+[
+  {
+    "id": "usage_leaderboard",
+    "type": "tool",
+    "depends_on": [],
+    "tool": "fetch_url",
+    "args": {
+      "url": "https://appraise-6945af.social-vibecoding.usernodelabs.org/api/leaderboard?round=dapp-hackathon-1-vote-for-your-favorite--m3or6&limit=200&offset=0",
+      "parse": "json"
+    }
+  },
+  {
+    "id": "app_testers",
+    "type": "transform",
+    "depends_on": ["usage_leaderboard"],
+    "op": "filter",
+    "from": "steps.usage_leaderboard.json.voters",
+    "expr": "row.wallet_address != null and trim(row.wallet_address) != \"\" and row.apps_tested > 0 and row.apps_total > 0"
+  },
+  {
+    "id": "wallet_values",
+    "type": "transform",
+    "depends_on": ["app_testers"],
+    "op": "map",
+    "from": "steps.app_testers",
+    "expr": "trim(row.wallet_address)"
+  },
+  {
+    "id": "accounts",
+    "type": "tool",
+    "depends_on": ["wallet_values"],
+    "tool": "query_db_table",
+    "args": {
+      "table": "onchain_accounts",
+      "columns": ["participant_id", "address", "phase_id", "is_used"],
+      "where": [
+        {
+          "column": "phase_id",
+          "op": "=",
+          "value": { "expr": "agent.phase_id" }
+        },
+        {
+          "column": "is_used",
+          "op": "=",
+          "value": true
+        },
+        {
+          "column": "address",
+          "op": "in",
+          "value": { "expr": "len(steps.wallet_values) > 0 ? steps.wallet_values : [\"\"]" }
+        }
+      ],
+      "limit": 200
+    }
+  },
+  {
+    "id": "entries",
+    "type": "transform",
+    "depends_on": ["app_testers", "accounts"],
+    "op": "map",
+    "from": "steps.app_testers",
+    "expr": "{ \"participant_id\": lookup(steps.accounts.rows, \"address\", trim(row.wallet_address), \"participant_id\"), \"points\": min(min(row.apps_tested, row.apps_total) * 200 + floor(min(row.apps_tested, row.apps_total) / row.apps_total) * 500, 2100), \"metric_current\": min(row.apps_tested, row.apps_total), \"reasoning\": \"You tested \" ~ min(row.apps_tested, row.apps_total) ~ \" of \" ~ row.apps_total ~ \" hackathon apps. Completion bonus is included once all apps are tested.\" }"
+  },
+  {
+    "id": "entries_matched",
+    "type": "transform",
+    "depends_on": ["entries"],
+    "op": "filter",
+    "from": "steps.entries",
+    "expr": "row.participant_id != null"
+  },
+  {
+    "id": "award",
+    "type": "tool",
+    "depends_on": ["entries_matched"],
+    "when": "len(steps.entries_matched) > 0",
+    "tool": "generate_points_matrix",
+    "args": {
+      "entries": { "expr": "steps.entries_matched" }
+    }
+  }
+]
+```
+
+The bonus formula is intentionally expression-only:
+
+```text
+floor(min(apps_tested, apps_total) / apps_total) * 500
+```
+
+For normal valid rows this gives no bonus below completion and one 500 point
+bonus at completion. The surrounding `min(..., 2100)` keeps the challenge cap
+stable if the source later reports more than 8 tested apps.
+
+If a run fails with `Unknown function "lookup"` or similar, the deployed
+Topochain backend is behind PR #153. Do not fall back to lossy wallet scripts
+that hardcode points for every matched account. Either wait for the deploy or
+use a temporary `discord_handle` script with the identity risk documented.
 
 ## Recipe: Sheet Wallet To Pending Points
 
@@ -427,20 +728,40 @@ dynamic key access.
 
 ## Idempotency For Recurring Agents
 
-Manual one-shot challenges can be simple. Scheduled agents need a guard so they
-do not create the same pending points every run.
+Topochain now handles the main recurring-agent idempotency case for
+challenge-bound `ScriptAgent` instances. PR #150 added snapshot-period behavior
+and PR #151 pins ScriptAgent matrices to the challenge's effective schedule
+window. Because the matrix identity key uses the agent instance plus
+`period_start` / `period_end`, repeated runs for the same challenge update the
+same pending matrix instead of stacking duplicate pending matrices.
 
-Recommended guard:
+That means recurring ScriptAgents should usually submit the **current cumulative
+snapshot** from the source:
 
-- query existing `points_attribution_matrices` for the bound challenge;
-- keep pending, approved, and locked matrices;
-- query their `points_attribution_entries`;
-- skip participants that already have a pending/approved/adjusted entry for
-  this one-submission challenge;
-- also query `offchain_activities` for committed participants and skip them.
+- `metric_current` is the current total, not this run's delta;
+- `points` is the current suggested total for the challenge, not this run's
+  delta;
+- rerunning the same snapshot should leave one pending matrix for the same
+  challenge window.
 
-If the source is cumulative, submit cumulative `metric_current` and only
-propose the delta not already represented by pending or committed progress.
+After a matrix is approved and locked, reruns are intentionally protected:
+
+- with `allow_locked_refresh` off, reruns refuse to overwrite the locked matrix;
+- with `allow_locked_refresh` on, reruns can replace the locked matrix and its
+  ledger rows, so use it only for cumulative sources where the latest external
+  state should remain authoritative.
+
+You still need script-level dedupe when the source itself can emit duplicate
+rows in one snapshot. Examples:
+
+- feedback forms: group by normalized wallet so duplicate submissions produce
+  one entry;
+- event streams: dedupe by transaction id or stable action id before scoring;
+- APIs with pagination: avoid scoring the same item from overlapping pages.
+
+Do not add a pending/committed matrix guard to every scheduled script by
+default. That old pattern can accidentally hide legitimate progress updates now
+that Topochain owns snapshot replacement.
 
 ## Debugging Checklist
 


### PR DESCRIPTION
## Summary
- Update the challenge progress operating guide around ScriptAgent-first challenge workflows.
- Document `wallet_address` as the preferred identity for external dApps, forms, and user-submitted activity.
- Add `lookup()` guidance for joining external rows to current-phase `onchain_accounts`.
- Refresh recurring-agent idempotency guidance based on Topochain snapshot-period and stable challenge-window behavior.

## Why
This keeps the mobile-side operating guide aligned with the current Topochain ScriptAgent model, especially for repeatable challenge agents where scheduled runs should submit cumulative snapshots instead of stacking duplicate pending points.

## Validation
- `git diff --check`
