### PR TITLE
fix: return home after onboarding

### DIFF
--- a/lib/features/onboarding/screens/battery_permission2_screen.dart
+++ b/lib/features/onboarding/screens/battery_permission2_screen.dart
@@ -61,13 +61,13 @@ class _BatteryPermission2ScreenState
     if (!mounted) return;
 
     // If battery optimizations are already disabled when this screen is first
-    // shown, skip the remaining battery onboarding and go straight to the
-    // produced blocks screen after marking onboarding complete.
+    // shown, skip the remaining battery onboarding and enter the home shell
+    // after marking onboarding complete.
     if (disabled) {
       await markOnboardingComplete();
       ref.invalidate(hasCompletedOnboardingProvider);
       if (!mounted) return;
-      context.go(AppRoutes.mainNode);
+      context.go(AppRoutes.home);
     }
   }
 

--- a/lib/features/onboarding/screens/notification_permission3_screen.dart
+++ b/lib/features/onboarding/screens/notification_permission3_screen.dart
@@ -22,11 +22,11 @@ class _NotificationPermission3ScreenState
   bool? _granted;
   bool _requesting = false;
 
-  Future<void> _completeOnboardingAndGoToProducedBlocks() async {
+  Future<void> _completeOnboardingAndGoHome() async {
     await markOnboardingComplete();
     ref.invalidate(hasCompletedOnboardingProvider);
     if (!mounted) return;
-    context.go(AppRoutes.mainNode);
+    context.go(AppRoutes.home);
   }
 
   @override
@@ -44,7 +44,7 @@ class _NotificationPermission3ScreenState
     // If notifications are already enabled, advance automatically.
     if (status.isGranted && mounted) {
       if (Platform.isIOS) {
-        await _completeOnboardingAndGoToProducedBlocks();
+        await _completeOnboardingAndGoHome();
       } else {
         context.go(AppRoutes.onboardingBatteryPermission2);
       }
@@ -76,7 +76,7 @@ class _NotificationPermission3ScreenState
       // If the user just enabled notifications, advance automatically.
       if (isGranted && mounted) {
         if (Platform.isIOS) {
-          await _completeOnboardingAndGoToProducedBlocks();
+          await _completeOnboardingAndGoHome();
         } else {
           context.go(AppRoutes.onboardingBatteryPermission2);
         }
@@ -142,7 +142,7 @@ class _NotificationPermission3ScreenState
                   size: ButtonSize.large,
                   onTap: () async {
                     if (Platform.isIOS) {
-                      await _completeOnboardingAndGoToProducedBlocks();
+                      await _completeOnboardingAndGoHome();
                     } else {
                       if (!mounted) return;
                       context.go(AppRoutes.onboardingBatteryPermission2);

--- a/lib/features/onboarding/screens/onboarding_battery_complete_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_battery_complete_screen.dart
@@ -29,11 +29,11 @@ class _OnboardingBatteryCompleteScreenState
     _checkBatteryStatus();
   }
 
-  Future<void> _completeAndGoToProducedBlocks() async {
+  Future<void> _completeAndGoHome() async {
     await markOnboardingComplete();
     ref.invalidate(hasCompletedOnboardingProvider);
     if (!mounted) return;
-    context.go(AppRoutes.mainNode);
+    context.go(AppRoutes.home);
   }
 
   Future<void> _checkBatteryStatus() async {
@@ -57,7 +57,7 @@ class _OnboardingBatteryCompleteScreenState
   }
 
   Future<void> _onContinue() async {
-    await _completeAndGoToProducedBlocks();
+    await _completeAndGoHome();
   }
 
   @override


### PR DESCRIPTION
## Summary
- Route completed onboarding into `/home` instead of standalone `/main/node`.
- Rename the affected helper methods/comments so the code matches the new destination.

## Why
After initial setup, onboarding used `context.go(AppRoutes.mainNode)`. Because `/main/node` renders `NodeStatusScreen` outside the `HomeScreen` shell, users landed on Node Status without bottom navigation or a back stack. Sending users to `/home` keeps them inside the main shell after setup.

## Validation
- `flutter analyze`
- `flutter test test/features/home/home_screen_test.dart test/features/onboarding/data/registration_repository_test.dart`
- `cd packages/ds_lints && dart pub get && dart run bin/lint.dart ../..`